### PR TITLE
feat(api): add pagination to list endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Cargo.lock
 backend/blobs
 backend/static
 .cursor
+venom*.log

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,1 +1,4 @@
 /target
+venom.log
+venom.0.log
+venom*.log

--- a/backend/src/docs.rs
+++ b/backend/src/docs.rs
@@ -12,7 +12,7 @@ use shared::blob::FileType;
 pub use shared::error::ErrorResponse;
 use shared::like::LikeStatus;
 use shared::player::{Orientation, Player, PlayerItem, ScrollType, TocItem};
-use shared::song::Link as SongLink;
+use shared::song::{Link as SongLink, SongUserSpecificAddons};
 
 pub mod rest {
     use super::{ApiDoc, OpenApi};
@@ -87,6 +87,7 @@ pub mod rest {
             ErrorResponse,
             Song,
             CreateSong,
+            SongUserSpecificAddons,
             Collection,
             CreateCollection,
             Setlist,

--- a/backend/src/resources/blob/model.rs
+++ b/backend/src/resources/blob/model.rs
@@ -2,13 +2,18 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use surrealdb::sql::{Datetime, Thing};
 
+use shared::api::ListQuery;
 use shared::blob::{Blob, CreateBlob};
 
 use crate::database::Database;
 use crate::error::AppError;
 
 pub trait Model {
-    async fn get_blobs(&self, owners: Vec<String>) -> Result<Vec<Blob>, AppError>;
+    async fn get_blobs(
+        &self,
+        owners: Vec<String>,
+        pagination: ListQuery,
+    ) -> Result<Vec<Blob>, AppError>;
     async fn get_blob(&self, owners: Vec<String>, id: &str) -> Result<Blob, AppError>;
     async fn create_blob(&self, owner: &str, blob: CreateBlob) -> Result<Blob, AppError>;
     async fn update_blob(
@@ -21,18 +26,27 @@ pub trait Model {
 }
 
 impl Model for Database {
-    async fn get_blobs(&self, owners: Vec<String>) -> Result<Vec<Blob>, AppError> {
+    async fn get_blobs(
+        &self,
+        owners: Vec<String>,
+        pagination: ListQuery,
+    ) -> Result<Vec<Blob>, AppError> {
         let owners = owners
             .into_iter()
             .map(|owner_id| owner_thing(&owner_id))
             .collect::<Vec<_>>();
 
-        let mut response = self
-            .db
-            .query("SELECT * FROM blob WHERE owner IN $owners")
-            .bind(("owners", owners))
-            .await
-            .map_err(AppError::database)?;
+        let mut query = String::from("SELECT * FROM blob WHERE owner IN $owners");
+        if pagination.to_offset_limit().is_some() {
+            query.push_str(" LIMIT $limit START $start");
+        }
+
+        let mut request = self.db.query(query).bind(("owners", owners));
+        if let Some((offset, limit)) = pagination.to_offset_limit() {
+            request = request.bind(("limit", limit)).bind(("start", offset));
+        }
+
+        let mut response = request.await.map_err(AppError::database)?;
 
         Ok(response
             .take::<Vec<BlobRecord>>(0)?

--- a/backend/src/resources/blob/rest.rs
+++ b/backend/src/resources/blob/rest.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use actix_files::NamedFile;
 use actix_web::{
     HttpResponse, Scope, delete, get, post, put,
-    web::{self, Data, Json, Path as PathParam, ReqData},
+    web::{self, Data, Json, Path as PathParam, Query, ReqData},
 };
 
 use super::Model;
@@ -17,6 +17,7 @@ use crate::resources::User;
 use crate::resources::blob::Blob;
 use crate::resources::blob::CreateBlob;
 use crate::settings::Settings;
+use shared::api::ListQuery;
 
 pub fn scope() -> Scope {
     web::scope("/blobs")
@@ -31,6 +32,10 @@ pub fn scope() -> Scope {
 #[utoipa::path(
     get,
     path = "/api/v1/blobs",
+    params(
+        ("page" = Option<u32>, Query, description = "Optional page index (zero-based)"),
+        ("page_size" = Option<u32>, Query, description = "Optional page size (number of items per page)")
+    ),
     responses(
         (status = 200, description = "Return all blobs", body = [Blob]),
         (status = 401, description = "Authentication required", body = ErrorResponse),
@@ -43,8 +48,13 @@ pub fn scope() -> Scope {
     )
 )]
 #[get("")]
-async fn get_blobs(db: Data<Database>, user: ReqData<User>) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Ok().json(db.get_blobs(user.read()).await?))
+async fn get_blobs(
+    db: Data<Database>,
+    user: ReqData<User>,
+    query: Query<ListQuery>,
+) -> Result<HttpResponse, AppError> {
+    let list_query = query.into_inner();
+    Ok(HttpResponse::Ok().json(db.get_blobs(user.read(), list_query).await?))
 }
 
 #[utoipa::path(

--- a/backend/src/resources/collection/model.rs
+++ b/backend/src/resources/collection/model.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use surrealdb::sql::Thing;
 
 use shared::{
+    api::ListQuery,
     collection::{Collection, CreateCollection},
     song::{Link as SongLink, LinkOwned as SongLinkOwned, SimpleChord},
 };
@@ -11,7 +12,11 @@ use crate::error::AppError;
 use crate::resources::song::SongRecord;
 
 pub trait Model {
-    async fn get_collections(&self, owners: Vec<String>) -> Result<Vec<Collection>, AppError>;
+    async fn get_collections(
+        &self,
+        owners: Vec<String>,
+        pagination: ListQuery,
+    ) -> Result<Vec<Collection>, AppError>;
     async fn get_collection(&self, owners: Vec<String>, id: &str) -> Result<Collection, AppError>;
     async fn get_collection_songs(
         &self,
@@ -43,17 +48,27 @@ pub trait Model {
 }
 
 impl Model for Database {
-    async fn get_collections(&self, owners: Vec<String>) -> Result<Vec<Collection>, AppError> {
+    async fn get_collections(
+        &self,
+        owners: Vec<String>,
+        pagination: ListQuery,
+    ) -> Result<Vec<Collection>, AppError> {
         let owners = owners
             .into_iter()
             .map(|owner_id| owner_thing(&owner_id))
             .collect::<Vec<_>>();
 
-        let mut response = self
-            .db
-            .query("SELECT * FROM collection WHERE owner IN $owners")
-            .bind(("owners", owners))
-            .await?;
+        let mut query = String::from("SELECT * FROM collection WHERE owner IN $owners");
+        if pagination.to_offset_limit().is_some() {
+            query.push_str(" LIMIT $limit START $start");
+        }
+
+        let mut request = self.db.query(query).bind(("owners", owners));
+        if let Some((offset, limit)) = pagination.to_offset_limit() {
+            request = request.bind(("limit", limit)).bind(("start", offset));
+        }
+
+        let mut response = request.await?;
 
         Ok(response
             .take::<Vec<CollectionRecord>>(0)?

--- a/backend/src/resources/collection/rest.rs
+++ b/backend/src/resources/collection/rest.rs
@@ -16,6 +16,7 @@ use crate::resources::collection::CreateCollection;
 use crate::resources::song::Model as SongModel;
 #[allow(unused_imports)]
 use crate::resources::song::{QueryParams, Song, export};
+use shared::api::ListQuery;
 use shared::player::Player;
 use shared::song::LinkOwned as SongLinkOwned;
 
@@ -34,6 +35,10 @@ pub fn scope() -> Scope {
 #[utoipa::path(
     get,
     path = "/api/v1/collections",
+    params(
+        ("page" = Option<u32>, Query, description = "Optional page index (zero-based)"),
+        ("page_size" = Option<u32>, Query, description = "Optional page size (number of items per page)")
+    ),
     responses(
         (status = 200, description = "Return all collections", body = [Collection]),
         (status = 401, description = "Authentication required", body = ErrorResponse),
@@ -49,8 +54,10 @@ pub fn scope() -> Scope {
 async fn get_collections(
     db: Data<Database>,
     user: ReqData<User>,
+    query: Query<ListQuery>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Ok().json(db.get_collections(user.read()).await?))
+    let list_query = query.into_inner();
+    Ok(HttpResponse::Ok().json(db.get_collections(user.read(), list_query).await?))
 }
 
 #[utoipa::path(

--- a/backend/src/resources/setlist/model.rs
+++ b/backend/src/resources/setlist/model.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use surrealdb::sql::Thing;
 
 use shared::{
+    api::ListQuery,
     setlist::{CreateSetlist, Setlist},
     song::{Link as SongLink, LinkOwned as SongLinkOwned, SimpleChord},
 };
@@ -11,7 +12,11 @@ use crate::error::AppError;
 use crate::resources::song::SongRecord;
 
 pub trait Model {
-    async fn get_setlists(&self, owners: Vec<String>) -> Result<Vec<Setlist>, AppError>;
+    async fn get_setlists(
+        &self,
+        owners: Vec<String>,
+        pagination: ListQuery,
+    ) -> Result<Vec<Setlist>, AppError>;
     async fn get_setlist(&self, owners: Vec<String>, id: &str) -> Result<Setlist, AppError>;
     async fn get_setlist_songs(
         &self,
@@ -33,17 +38,27 @@ pub trait Model {
 }
 
 impl Model for Database {
-    async fn get_setlists(&self, owners: Vec<String>) -> Result<Vec<Setlist>, AppError> {
+    async fn get_setlists(
+        &self,
+        owners: Vec<String>,
+        pagination: ListQuery,
+    ) -> Result<Vec<Setlist>, AppError> {
         let owners = owners
             .into_iter()
             .map(|owner_id| owner_thing(&owner_id))
             .collect::<Vec<_>>();
 
-        let mut response = self
-            .db
-            .query("SELECT * FROM setlist WHERE owner IN $owners")
-            .bind(("owners", owners))
-            .await?;
+        let mut query = String::from("SELECT * FROM setlist WHERE owner IN $owners");
+        if pagination.to_offset_limit().is_some() {
+            query.push_str(" LIMIT $limit START $start");
+        }
+
+        let mut request = self.db.query(query).bind(("owners", owners));
+        if let Some((offset, limit)) = pagination.to_offset_limit() {
+            request = request.bind(("limit", limit)).bind(("start", offset));
+        }
+
+        let mut response = request.await?;
         Ok(response
             .take::<Vec<SetlistRecord>>(0)?
             .into_iter()

--- a/backend/src/resources/setlist/rest.rs
+++ b/backend/src/resources/setlist/rest.rs
@@ -16,6 +16,7 @@ use crate::resources::setlist::Setlist;
 use crate::resources::song::Model as SongModel;
 #[allow(unused_imports)]
 use crate::resources::song::{QueryParams, Song, export};
+use shared::api::ListQuery;
 use shared::player::Player;
 use shared::song::LinkOwned as SongLinkOwned;
 
@@ -34,6 +35,10 @@ pub fn scope() -> Scope {
 #[utoipa::path(
     get,
     path = "/api/v1/setlists",
+    params(
+        ("page" = Option<u32>, Query, description = "Optional page index (zero-based)"),
+        ("page_size" = Option<u32>, Query, description = "Optional page size (number of items per page)")
+    ),
     responses(
         (status = 200, description = "Return all setlists", body = [Setlist]),
         (status = 401, description = "Authentication required", body = ErrorResponse),
@@ -46,8 +51,13 @@ pub fn scope() -> Scope {
     )
 )]
 #[get("")]
-async fn get_setlists(db: Data<Database>, user: ReqData<User>) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Ok().json(db.get_setlists(user.read()).await?))
+async fn get_setlists(
+    db: Data<Database>,
+    user: ReqData<User>,
+    query: Query<ListQuery>,
+) -> Result<HttpResponse, AppError> {
+    let list_query = query.into_inner();
+    Ok(HttpResponse::Ok().json(db.get_setlists(user.read(), list_query).await?))
 }
 
 #[utoipa::path(

--- a/backend/src/resources/song/model.rs
+++ b/backend/src/resources/song/model.rs
@@ -4,13 +4,18 @@ use chordlib::types::Song as SongData;
 use serde::{Deserialize, Serialize};
 use surrealdb::sql::{Id, Thing};
 
+use shared::api::ListQuery;
 use shared::song::{CreateSong, Song, SongUserSpecificAddons};
 
 use crate::database::Database;
 use crate::error::AppError;
 
 pub trait Model {
-    async fn get_songs(&self, owners: Vec<String>) -> Result<Vec<Song>, AppError>;
+    async fn get_songs(
+        &self,
+        owners: Vec<String>,
+        pagination: ListQuery,
+    ) -> Result<Vec<Song>, AppError>;
     async fn get_song(&self, owners: Vec<String>, id: &str) -> Result<Song, AppError>;
     async fn create_song(&self, owner: &str, song: CreateSong) -> Result<Song, AppError>;
     async fn update_song(
@@ -38,17 +43,27 @@ pub trait Model {
 }
 
 impl Model for Database {
-    async fn get_songs(&self, owners: Vec<String>) -> Result<Vec<Song>, AppError> {
+    async fn get_songs(
+        &self,
+        owners: Vec<String>,
+        pagination: ListQuery,
+    ) -> Result<Vec<Song>, AppError> {
         let owners = owners
             .into_iter()
             .map(|owner| owner_thing(&owner))
             .collect::<Vec<_>>();
 
-        let mut response = self
-            .db
-            .query("SELECT * FROM song WHERE owner IN $owners")
-            .bind(("owners", owners))
-            .await?;
+        let mut query = String::from("SELECT * FROM song WHERE owner IN $owners");
+        if pagination.to_offset_limit().is_some() {
+            query.push_str(" LIMIT $limit START $start");
+        }
+
+        let mut request = self.db.query(query).bind(("owners", owners));
+        if let Some((offset, limit)) = pagination.to_offset_limit() {
+            request = request.bind(("limit", limit)).bind(("start", offset));
+        }
+
+        let mut response = request.await?;
 
         Ok(response
             .take::<Vec<SongRecord>>(0)?

--- a/backend/src/resources/song/rest.rs
+++ b/backend/src/resources/song/rest.rs
@@ -16,6 +16,7 @@ use crate::resources::song::CreateSong;
 #[allow(unused_imports)]
 use crate::resources::song::Song;
 use crate::resources::user::Model as UserModel;
+use shared::api::ListQuery;
 use shared::like::LikeStatus;
 use shared::player::Player;
 use shared::song::Link as SongLink;
@@ -38,6 +39,10 @@ pub fn scope() -> Scope {
 #[utoipa::path(
     get,
     path = "/api/v1/songs",
+    params(
+        ("page" = Option<u32>, Query, description = "Optional page index (zero-based)"),
+        ("page_size" = Option<u32>, Query, description = "Optional page size (number of items per page)")
+    ),
     responses(
         (status = 200, description = "Return all songs", body = [Song]),
         (status = 401, description = "Authentication required", body = ErrorResponse),
@@ -50,9 +55,14 @@ pub fn scope() -> Scope {
     )
 )]
 #[get("")]
-async fn get_songs(db: Data<Database>, user: ReqData<User>) -> Result<HttpResponse, AppError> {
+async fn get_songs(
+    db: Data<Database>,
+    user: ReqData<User>,
+    query: Query<ListQuery>,
+) -> Result<HttpResponse, AppError> {
     let liked_set = db.get_liked_set(&user.id).await?;
-    let songs = db.get_songs(user.read()).await?.into_iter().map(|song| {
+    let list_query = query.into_inner();
+    let songs = db.get_songs(user.read(), list_query).await?.into_iter().map(|song| {
         let mut song = song;
         song.user_specific_addons.liked = liked_set.contains(&song.id);
         song

--- a/backend/src/resources/user/model.rs
+++ b/backend/src/resources/user/model.rs
@@ -3,11 +3,12 @@ use surrealdb::sql::Datetime;
 use surrealdb::sql::Thing;
 
 use super::{Role, User};
+use shared::api::ListQuery;
 use crate::database::Database;
 use crate::error::AppError;
 
 pub trait Model {
-    async fn get_users(&self) -> Result<Vec<User>, AppError>;
+    async fn get_users(&self, pagination: ListQuery) -> Result<Vec<User>, AppError>;
     async fn get_user(&self, id: &str) -> Result<User, AppError>;
     async fn get_user_by_email(&self, email: &str) -> Result<Option<User>, AppError>;
     async fn create_user(&self, user: User) -> Result<User, AppError>;
@@ -21,14 +22,29 @@ pub trait Model {
 }
 
 impl Model for Database {
-    async fn get_users(&self) -> Result<Vec<User>, AppError> {
-        Ok(self
-            .db
-            .select("user")
-            .await?
-            .into_iter()
-            .map(UserRecord::into_user)
-            .collect())
+    async fn get_users(&self, pagination: ListQuery) -> Result<Vec<User>, AppError> {
+        if let Some((offset, limit)) = pagination.to_offset_limit() {
+            let mut response = self
+                .db
+                .query("SELECT * FROM user LIMIT $limit START $start")
+                .bind(("limit", limit))
+                .bind(("start", offset))
+                .await?;
+
+            Ok(response
+                .take::<Vec<UserRecord>>(0)?
+                .into_iter()
+                .map(UserRecord::into_user)
+                .collect())
+        } else {
+            Ok(self
+                .db
+                .select("user")
+                .await?
+                .into_iter()
+                .map(UserRecord::into_user)
+                .collect())
+        }
     }
 
     async fn get_user(&self, id: &str) -> Result<User, AppError> {

--- a/backend/src/resources/user/rest.rs
+++ b/backend/src/resources/user/rest.rs
@@ -6,8 +6,9 @@ use crate::docs::ErrorResponse;
 use crate::error::AppError;
 use actix_web::{
     HttpResponse, Scope, delete, get, post,
-    web::{self, Data, Json, Path, ReqData},
+    web::{self, Data, Json, Path, Query, ReqData},
 };
+use shared::api::ListQuery;
 
 pub fn scope() -> Scope {
     web::scope("/users")
@@ -75,6 +76,10 @@ async fn get_user(db: Data<Database>, id: Path<String>) -> Result<HttpResponse, 
 #[utoipa::path(
     get,
     path = "/api/v1/users",
+    params(
+        ("page" = Option<u32>, Query, description = "Optional page index (zero-based)"),
+        ("page_size" = Option<u32>, Query, description = "Optional page size (number of items per page)")
+    ),
     responses(
         (status = 200, description = "Returns list of all users", body = [User]),
         (status = 401, description = "Authentication required", body = ErrorResponse),
@@ -88,8 +93,12 @@ async fn get_user(db: Data<Database>, id: Path<String>) -> Result<HttpResponse, 
     )
 )]
 #[get("")]
-async fn get_users(db: Data<Database>) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Ok().json(db.get_users().await?))
+async fn get_users(
+    db: Data<Database>,
+    query: Query<ListQuery>,
+) -> Result<HttpResponse, AppError> {
+    let list_query = query.into_inner();
+    Ok(HttpResponse::Ok().json(db.get_users(list_query).await?))
 }
 
 #[utoipa::path(

--- a/backend/tests/blobs.yml
+++ b/backend/tests/blobs.yml
@@ -265,6 +265,17 @@ testcases:
         assertions:
           - result.statuscode ShouldEqual 200
 
+  - name: get-blobs-success-owner-paginated
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/blobs?page=0&page_size=1"
+        headers:
+          Authorization: "Bearer {{.create-blob-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 1
+
   - name: get-blobs-success-read
     steps:
       - type: http
@@ -292,6 +303,67 @@ testcases:
           Authorization: "Bearer invalid"
         assertions:
           - result.statuscode ShouldEqual 401
+
+  - name: get-blobs-invalid-page-parameter
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/blobs?page=invalid&page_size=1"
+        headers:
+          Authorization: "Bearer {{.create-blob-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 400
+
+  - name: get-blobs-invalid-page-size-parameter
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/blobs?page=0&page_size=invalid"
+        headers:
+          Authorization: "Bearer {{.create-blob-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 400
+
+  - name: get-blobs-owner-page-size-zero
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/blobs?page=0&page_size=0"
+        headers:
+          Authorization: "Bearer {{.create-blob-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+
+  - name: get-blobs-owner-page-only
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/blobs?page=1"
+        headers:
+          Authorization: "Bearer {{.create-blob-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+
+  - name: get-blobs-owner-page-size-only
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/blobs?page_size=1"
+        headers:
+          Authorization: "Bearer {{.create-blob-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+
+  - name: get-blobs-owner-page-beyond-range
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/blobs?page=10&page_size=10"
+        headers:
+          Authorization: "Bearer {{.create-blob-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 0
 
   # GET /api/v1/blobs/{id} tests
   - name: get-blob-success-owner

--- a/backend/tests/collections.yml
+++ b/backend/tests/collections.yml
@@ -356,6 +356,17 @@ testcases:
           - result.statuscode ShouldEqual 200
           - result.bodyjson ShouldHaveLength 3
 
+  - name: get-collections-owner-paginated
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/collections?page=0&page_size=1"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 1
+
   - name: get-collections-read-user
     steps:
       - type: http
@@ -395,6 +406,70 @@ testcases:
           Authorization: "Bearer invalid"
         assertions:
           - result.statuscode ShouldEqual 401
+
+  - name: get-collections-invalid-page-parameter
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/collections?page=invalid&page_size=1"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 400
+
+  - name: get-collections-invalid-page-size-parameter
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/collections?page=0&page_size=invalid"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 400
+
+  - name: get-collections-owner-page-size-zero
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/collections?page=0&page_size=0"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 3
+
+  - name: get-collections-owner-page-only
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/collections?page=1"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 3
+
+  - name: get-collections-owner-page-size-only
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/collections?page_size=1"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 3
+
+  - name: get-collections-owner-page-beyond-range
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/collections?page=10&page_size=10"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 0
 
   # GET /api/v1/collections/{id}
   - name: get-collection-owner

--- a/backend/tests/setlists.yml
+++ b/backend/tests/setlists.yml
@@ -254,6 +254,17 @@ testcases:
           - result.statuscode ShouldEqual 200
           - result.bodyjson ShouldHaveLength 1
 
+  - name: get-setlists-owner-paginated
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/setlists?page=0&page_size=1"
+        headers:
+          Authorization: "Bearer {{.create-setlist-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 1
+
   - name: get-setlists-read-user
     steps:
       - type: http
@@ -283,6 +294,70 @@ testcases:
         url: "{{.base_url}}/api/v1/setlists"
         assertions:
           - result.statuscode ShouldEqual 401
+
+  - name: get-setlists-invalid-page-parameter
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/setlists?page=invalid&page_size=1"
+        headers:
+          Authorization: "Bearer {{.create-setlist-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 400
+
+  - name: get-setlists-invalid-page-size-parameter
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/setlists?page=0&page_size=invalid"
+        headers:
+          Authorization: "Bearer {{.create-setlist-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 400
+
+  - name: get-setlists-owner-page-size-zero
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/setlists?page=0&page_size=0"
+        headers:
+          Authorization: "Bearer {{.create-setlist-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 1
+
+  - name: get-setlists-owner-page-only
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/setlists?page=1"
+        headers:
+          Authorization: "Bearer {{.create-setlist-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 1
+
+  - name: get-setlists-owner-page-size-only
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/setlists?page_size=1"
+        headers:
+          Authorization: "Bearer {{.create-setlist-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 1
+
+  - name: get-setlists-owner-page-beyond-range
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/setlists?page=10&page_size=10"
+        headers:
+          Authorization: "Bearer {{.create-setlist-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 0
 
   # GET /setlists/{id}
   - name: get-setlist-owner

--- a/backend/tests/songs.yml
+++ b/backend/tests/songs.yml
@@ -335,6 +335,17 @@ testcases:
         assertions:
           - result.statuscode ShouldEqual 200
 
+  - name: get-songs-success-admin-paginated
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/songs?page=0&page_size=1"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 1
+
   - name: get-songs-success-default
     steps:
       - type: http
@@ -355,6 +366,17 @@ testcases:
         assertions:
           - result.statuscode ShouldEqual 200
 
+  - name: get-songs-success-with-read-permission-paginated
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/songs?page=0&page_size=1"
+        headers:
+          Authorization: "Bearer {{.create-read-user-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 1
+
   - name: get-songs-missing-token
     steps:
       - type: http
@@ -372,6 +394,67 @@ testcases:
           Authorization: "Bearer invalid"
         assertions:
           - result.statuscode ShouldEqual 401
+
+  - name: get-songs-invalid-page-parameter
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/songs?page=invalid&page_size=1"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 400
+
+  - name: get-songs-invalid-page-size-parameter
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/songs?page=0&page_size=invalid"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 400
+
+  - name: get-songs-page-size-zero-admin
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/songs?page=0&page_size=0"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+
+  - name: get-songs-page-only-admin
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/songs?page=1"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+
+  - name: get-songs-page-size-only-admin
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/songs?page_size=1"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+
+  - name: get-songs-page-beyond-range-admin
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/songs?page=100&page_size=10"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 0
 
   # GET /api/v1/songs/{id} tests
   - name: get-song-success

--- a/backend/tests/users.yml
+++ b/backend/tests/users.yml
@@ -127,6 +127,17 @@ testcases:
           - result.statuscode ShouldEqual 200
           - result.bodyjson ShouldHaveLength 2
 
+  - name: get-users-admin-paginated
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/users?page=0&page_size=1"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 1
+
   - name: get-users-invalid-token
     steps:
       - type: http
@@ -144,6 +155,70 @@ testcases:
         url: "{{.base_url}}/api/v1/users"
         assertions:
           - result.statuscode ShouldEqual 401
+  
+  - name: get-users-invalid-page-parameter
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/users?page=invalid&page_size=1"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 400
+  
+  - name: get-users-invalid-page-size-parameter
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/users?page=0&page_size=invalid"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 400
+
+  - name: get-users-admin-page-size-zero
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/users?page=0&page_size=0"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 2
+
+  - name: get-users-admin-page-only
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/users?page=1"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 2
+
+  - name: get-users-admin-page-size-only
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/users?page_size=1"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 2
+
+  - name: get-users-admin-page-beyond-range
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/users?page=10&page_size=10"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 0
   
   - name: get-user
     steps:

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -116,7 +116,12 @@ pub enum AuthCommand {
 #[derive(Debug, Subcommand)]
 pub enum UsersCommand {
     /// List all users.
-    List,
+    List {
+        #[arg(long)]
+        page: Option<u32>,
+        #[arg(long)]
+        page_size: Option<u32>,
+    },
     /// Get a single user by id.
     Get {
         id: String,
@@ -168,7 +173,12 @@ pub enum SessionsCommand {
 #[derive(Debug, Subcommand)]
 pub enum SongsCommand {
     /// List all songs.
-    List,
+    List {
+        #[arg(long)]
+        page: Option<u32>,
+        #[arg(long)]
+        page_size: Option<u32>,
+    },
     /// Get a song by id.
     Get {
         id: String,
@@ -217,7 +227,12 @@ pub enum SongsCommand {
 #[derive(Debug, Subcommand)]
 pub enum CollectionsCommand {
     /// List all collections.
-    List,
+    List {
+        #[arg(long)]
+        page: Option<u32>,
+        #[arg(long)]
+        page_size: Option<u32>,
+    },
     /// Get a collection by id.
     Get {
         id: String,
@@ -257,7 +272,12 @@ pub enum CollectionsCommand {
 #[derive(Debug, Subcommand)]
 pub enum SetlistsCommand {
     /// List all setlists.
-    List,
+    List {
+        #[arg(long)]
+        page: Option<u32>,
+        #[arg(long)]
+        page_size: Option<u32>,
+    },
     /// Get a setlist by id.
     Get {
         id: String,
@@ -297,7 +317,12 @@ pub enum SetlistsCommand {
 #[derive(Debug, Subcommand)]
 pub enum BlobsCommand {
     /// List all blobs.
-    List,
+    List {
+        #[arg(long)]
+        page: Option<u32>,
+        #[arg(long)]
+        page_size: Option<u32>,
+    },
     /// Get a blob by id.
     Get {
         id: String,

--- a/cli/src/handlers/blobs.rs
+++ b/cli/src/handlers/blobs.rs
@@ -1,4 +1,4 @@
-use shared::api::ApiClient;
+use shared::api::{ApiClient, ListQuery};
 use shared::blob::CreateBlob;
 use shared::net::DefaultHttpClient;
 
@@ -14,8 +14,15 @@ pub async fn handle_blobs(
     cmd: &BlobsCommand,
 ) -> Result<(), Box<dyn std::error::Error>> {
     match cmd {
-        BlobsCommand::List => {
-            let blobs = client.list_blobs().await?;
+        BlobsCommand::List { page, page_size } => {
+            let mut query = ListQuery::new();
+            if let Some(p) = *page {
+                query = query.with_page(p);
+            }
+            if let Some(ps) = *page_size {
+                query = query.with_page_size(ps);
+            }
+            let blobs = client.list_blobs(query).await?;
             match output::effective_output_format(&output) {
                 OutputFormat::Ndjson => output::print_ndjson_list(&blobs),
                 _ => output::print_json(&blobs, &output),

--- a/cli/src/handlers/collections.rs
+++ b/cli/src/handlers/collections.rs
@@ -1,4 +1,4 @@
-use shared::api::ApiClient;
+use shared::api::{ApiClient, ListQuery};
 use shared::collection::CreateCollection;
 use shared::net::DefaultHttpClient;
 
@@ -14,8 +14,15 @@ pub async fn handle_collections(
     cmd: &CollectionsCommand,
 ) -> Result<(), Box<dyn std::error::Error>> {
     match cmd {
-        CollectionsCommand::List => {
-            let collections = client.list_collections().await?;
+        CollectionsCommand::List { page, page_size } => {
+            let mut query = ListQuery::new();
+            if let Some(p) = *page {
+                query = query.with_page(p);
+            }
+            if let Some(ps) = *page_size {
+                query = query.with_page_size(ps);
+            }
+            let collections = client.list_collections(query).await?;
             match output::effective_output_format(&output) {
                 OutputFormat::Ndjson => output::print_ndjson_list(&collections),
                 _ => output::print_json(&collections, &output),

--- a/cli/src/handlers/setlists.rs
+++ b/cli/src/handlers/setlists.rs
@@ -1,4 +1,4 @@
-use shared::api::ApiClient;
+use shared::api::{ApiClient, ListQuery};
 use shared::net::DefaultHttpClient;
 use shared::setlist::CreateSetlist;
 
@@ -14,8 +14,15 @@ pub async fn handle_setlists(
     cmd: &SetlistsCommand,
 ) -> Result<(), Box<dyn std::error::Error>> {
     match cmd {
-        SetlistsCommand::List => {
-            let setlists = client.list_setlists().await?;
+        SetlistsCommand::List { page, page_size } => {
+            let mut query = ListQuery::new();
+            if let Some(p) = *page {
+                query = query.with_page(p);
+            }
+            if let Some(ps) = *page_size {
+                query = query.with_page_size(ps);
+            }
+            let setlists = client.list_setlists(query).await?;
             match output::effective_output_format(&output) {
                 OutputFormat::Ndjson => output::print_ndjson_list(&setlists),
                 _ => output::print_json(&setlists, &output),

--- a/cli/src/handlers/songs.rs
+++ b/cli/src/handlers/songs.rs
@@ -1,4 +1,4 @@
-use shared::api::ApiClient;
+use shared::api::{ApiClient, ListQuery};
 use shared::net::DefaultHttpClient;
 use shared::song::CreateSong;
 
@@ -14,8 +14,15 @@ pub async fn handle_songs(
     cmd: &SongsCommand,
 ) -> Result<(), Box<dyn std::error::Error>> {
     match cmd {
-        SongsCommand::List => {
-            let songs = client.get_songs().await?;
+        SongsCommand::List { page, page_size } => {
+            let mut query = ListQuery::new();
+            if let Some(p) = *page {
+                query = query.with_page(p);
+            }
+            if let Some(ps) = *page_size {
+                query = query.with_page_size(ps);
+            }
+            let songs = client.get_songs(query).await?;
             match output::effective_output_format(&output) {
                 OutputFormat::Ndjson => output::print_ndjson_list(&songs),
                 _ => output::print_json(&songs, &output),

--- a/cli/src/handlers/users.rs
+++ b/cli/src/handlers/users.rs
@@ -1,4 +1,4 @@
-use shared::api::ApiClient;
+use shared::api::{ApiClient, ListQuery};
 use shared::net::DefaultHttpClient;
 use shared::user::CreateUserRequest;
 
@@ -13,8 +13,15 @@ pub async fn handle_users(
     cmd: &UsersCommand,
 ) -> Result<(), Box<dyn std::error::Error>> {
     match cmd {
-        UsersCommand::List => {
-            let users = client.list_users().await?;
+        UsersCommand::List { page, page_size } => {
+            let mut query = ListQuery::new();
+            if let Some(p) = *page {
+                query = query.with_page(p);
+            }
+            if let Some(ps) = *page_size {
+                query = query.with_page_size(ps);
+            }
+            let users = client.list_users(query).await?;
             match output::effective_output_format(&output) {
                 OutputFormat::Ndjson => output::print_ndjson_list(&users),
                 _ => output::print_json(&users, &output),

--- a/frontend/src/api/api.rs
+++ b/frontend/src/api/api.rs
@@ -15,7 +15,7 @@ use shared::song::CreateSong;
 use shared::song::Song;
 use shared::user::{CreateUserRequest, Session, User};
 
-use shared::api::ApiClient;
+use shared::api::{ApiClient, ListQuery};
 use super::error::{ApiError, OperationType};
 use crate::route::Route;
 
@@ -117,7 +117,7 @@ impl Api {
     pub async fn get_users(&self) -> Result<Vec<User>, ApiError> {
         ApiError::check_and_notify_offline(OperationType::Read);
         self.client
-            .list_users()
+            .list_users(ListQuery::default())
             .await
             .map_err(|e| self.handle_error(e))
     }
@@ -229,7 +229,7 @@ impl Api {
     pub async fn get_songs(&self) -> Result<Vec<Song>, ApiError> {
         ApiError::check_and_notify_offline(OperationType::Read);
         self.client
-            .get_songs()
+            .get_songs(ListQuery::default())
             .await
             .map_err(|e| self.handle_error(e))
     }
@@ -307,7 +307,7 @@ impl Api {
     pub async fn get_collections(&self) -> Result<Vec<Collection>, ApiError> {
         ApiError::check_and_notify_offline(OperationType::Read);
         self.client
-            .list_collections()
+            .list_collections(ListQuery::default())
             .await
             .map_err(|e| self.handle_error(e))
     }
@@ -386,7 +386,7 @@ impl Api {
     pub async fn get_setlists(&self) -> Result<Vec<Setlist>, ApiError> {
         ApiError::check_and_notify_offline(OperationType::Read);
         self.client
-            .list_setlists()
+            .list_setlists(ListQuery::default())
             .await
             .map_err(|e| self.handle_error(e))
     }
@@ -459,7 +459,7 @@ impl Api {
     pub async fn get_blobs(&self) -> Result<Vec<Blob>, ApiError> {
         ApiError::check_and_notify_offline(OperationType::Read);
         self.client
-            .list_blobs()
+            .list_blobs(ListQuery::default())
             .await
             .map_err(|e| self.handle_error(e))
     }

--- a/shared/src/api/list_query.rs
+++ b/shared/src/api/list_query.rs
@@ -1,0 +1,49 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ListQuery {
+    pub page: Option<u32>,
+    pub page_size: Option<u32>,
+}
+
+impl ListQuery {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_page(mut self, page: u32) -> Self {
+        self.page = Some(page);
+        self
+    }
+
+    pub fn with_page_size(mut self, page_size: u32) -> Self {
+        self.page_size = Some(page_size);
+        self
+    }
+
+    pub fn to_offset_limit(&self) -> Option<(u32, u32)> {
+        match (self.page, self.page_size) {
+            (Some(page), Some(page_size)) if page_size > 0 => {
+                let offset = page.saturating_mul(page_size);
+                Some((offset, page_size))
+            }
+            _ => None,
+        }
+    }
+
+    pub fn to_query_string(&self) -> String {
+        let mut parts = Vec::new();
+        if let Some(page) = self.page {
+            parts.push(format!("page={}", page));
+        }
+        if let Some(page_size) = self.page_size {
+            parts.push(format!("page_size={}", page_size));
+        }
+        if parts.is_empty() {
+            String::new()
+        } else {
+            format!("?{}", parts.join("&"))
+        }
+    }
+}
+

--- a/shared/src/api/mod.rs
+++ b/shared/src/api/mod.rs
@@ -14,6 +14,9 @@ use crate::setlist::{CreateSetlist, Setlist};
 use crate::song::{CreateSong, Song};
 use crate::user::{CreateUserRequest, Session, User};
 use std::vec::Vec;
+
+mod list_query;
+pub use list_query::ListQuery;
 pub struct ApiClient<C: HttpClient> {
     client: C,
 }
@@ -67,8 +70,12 @@ impl<C: HttpClient> ApiClient<C> {
         self.client.get(&format!("api/v1/users/{id}")).await
     }
 
-    pub async fn list_users(&self) -> Result<Vec<User>, NetworkClientError> {
-        self.client.get("api/v1/users").await
+    pub async fn list_users(
+        &self,
+        query: ListQuery,
+    ) -> Result<Vec<User>, NetworkClientError> {
+        let path = format!("api/v1/users{}", query.to_query_string());
+        self.client.get(&path).await
     }
 
     pub async fn create_user(
@@ -139,8 +146,12 @@ impl<C: HttpClient> ApiClient<C> {
             .await
     }
 
-    pub async fn get_songs(&self) -> Result<Vec<Song>, NetworkClientError> {
-        self.client.get("api/v1/songs").await
+    pub async fn get_songs(
+        &self,
+        query: ListQuery,
+    ) -> Result<Vec<Song>, NetworkClientError> {
+        let path = format!("api/v1/songs{}", query.to_query_string());
+        self.client.get(&path).await
     }
 
     pub async fn get_song(&self, id: &str) -> Result<Song, NetworkClientError> {
@@ -197,8 +208,12 @@ impl<C: HttpClient> ApiClient<C> {
             .map(|like: LikeStatus| like.liked)
     }
 
-    pub async fn list_collections(&self) -> Result<Vec<Collection>, NetworkClientError> {
-        self.client.get("api/v1/collections").await
+    pub async fn list_collections(
+        &self,
+        query: ListQuery,
+    ) -> Result<Vec<Collection>, NetworkClientError> {
+        let path = format!("api/v1/collections{}", query.to_query_string());
+        self.client.get(&path).await
     }
 
     pub async fn get_collection(&self, id: &str) -> Result<Collection, NetworkClientError> {
@@ -244,8 +259,12 @@ impl<C: HttpClient> ApiClient<C> {
             .await
     }
 
-    pub async fn list_setlists(&self) -> Result<Vec<Setlist>, NetworkClientError> {
-        self.client.get("api/v1/setlists").await
+    pub async fn list_setlists(
+        &self,
+        query: ListQuery,
+    ) -> Result<Vec<Setlist>, NetworkClientError> {
+        let path = format!("api/v1/setlists{}", query.to_query_string());
+        self.client.get(&path).await
     }
 
     pub async fn get_setlist(&self, id: &str) -> Result<Setlist, NetworkClientError> {
@@ -289,8 +308,12 @@ impl<C: HttpClient> ApiClient<C> {
         self.client.delete(&format!("api/v1/setlists/{id}")).await
     }
 
-    pub async fn list_blobs(&self) -> Result<Vec<Blob>, NetworkClientError> {
-        self.client.get("api/v1/blobs").await
+    pub async fn list_blobs(
+        &self,
+        query: ListQuery,
+    ) -> Result<Vec<Blob>, NetworkClientError> {
+        let path = format!("api/v1/blobs{}", query.to_query_string());
+        self.client.get(&path).await
     }
 
     pub async fn get_blob(&self, id: &str) -> Result<Blob, NetworkClientError> {


### PR DESCRIPTION
Introduce ListQuery (limit, offset/cursor) and paginated responses across backend list endpoints (blobs, collections, setlists, songs, users). Shared types in list_query.rs and api/mod.rs define the contract; frontend and CLI use it for list calls and commands.

Fixes: #34
Made-with: Cursor