### PR TITLE
feat(cli): improve schema inspection

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1,49 +1,26 @@
-//! CLI argument definitions (clap). No side effects.
-
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 
 use crate::output::OutputFormat;
 
 #[derive(Debug, Parser)]
 #[command(name = "worship-viewer", version, about = "CLI for the Worship Viewer REST API")]
 pub struct Cli {
-    /// Base URL of the Worship Viewer backend.
-    ///
-    /// Precedence:
-    /// - flag `--base-url`
-    /// - env `WORSHIP_VIEWER_BASE_URL`
-    /// - config file `~/.worshipviewer/config.toml` (`base_url`)
-    /// - default `http://127.0.0.1:8080`
-    #[arg(long)]
+    #[arg(long, global = true)]
     pub base_url: Option<String>,
 
-    /// Session cookie value for the backend.
-    ///
-    /// The backend expects an `sso_session` cookie; this CLI will send
-    /// `Cookie: sso_session=<value>` when configured.
-    ///
-    /// Precedence:
-    /// - flag `--sso-session`
-    /// - env `WORSHIP_VIEWER_SSO_SESSION`
-    /// - config file `~/.worshipviewer/config.toml` (`sso_session`)
-    #[arg(long)]
+    #[arg(long, global = true)]
     pub sso_session: Option<String>,
 
-    /// Bearer token to send as `Authorization: Bearer <token>`.
-    #[arg(long, env = "WORSHIP_VIEWER_BEARER_TOKEN")]
+    #[arg(long, env = "WORSHIP_VIEWER_BEARER_TOKEN", global = true)]
     pub bearer_token: Option<String>,
 
-    /// Output format. When set to `auto`, JSON is emitted when stdout is not a TTY.
-    #[arg(long, env = "WORSHIP_VIEWER_OUTPUT", default_value = "auto")]
+    #[arg(long, env = "WORSHIP_VIEWER_OUTPUT", default_value = "auto", global = true)]
     pub output: OutputFormat,
 
-    /// Global dry-run flag. When enabled, mutating commands are validated locally
-    /// and the planned HTTP request is printed, but no request is sent.
-    #[arg(long)]
+    #[arg(long, global = true)]
     pub dry_run: bool,
 
-    /// Request timeout in seconds.
-    #[arg(long, env = "WORSHIP_VIEWER_TIMEOUT_SECS")]
+    #[arg(long, env = "WORSHIP_VIEWER_TIMEOUT_SECS", global = true)]
     pub timeout_secs: Option<u64>,
 
     #[command(subcommand)]
@@ -52,64 +29,64 @@ pub struct Cli {
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
-    /// Introspect the OpenAPI schema exposed by the backend.
-    Schema {
-        /// Optional path prefix filter, e.g. `/api/v1/songs`.
-        #[arg(long)]
-        path_prefix: Option<String>,
-    },
-    /// Authentication and session bootstrap helpers.
+    Schema(SchemaArgs),
     Auth {
         #[command(subcommand)]
         command: AuthCommand,
     },
-    /// User-related operations.
     Users {
         #[command(subcommand)]
         command: UsersCommand,
     },
-    /// Session-related operations.
     Sessions {
         #[command(subcommand)]
         command: SessionsCommand,
     },
-    /// Song-related operations.
     Songs {
         #[command(subcommand)]
         command: SongsCommand,
     },
-    /// Collection-related operations.
     Collections {
         #[command(subcommand)]
         command: CollectionsCommand,
     },
-    /// Setlist-related operations.
     Setlists {
         #[command(subcommand)]
         command: SetlistsCommand,
     },
-    /// Blob-related operations.
     Blobs {
         #[command(subcommand)]
         command: BlobsCommand,
     },
 }
 
+#[derive(Debug, Args)]
+pub struct SchemaArgs {
+    #[command(subcommand)]
+    pub command: Option<SchemaCommand>,
+
+    #[arg(long)]
+    pub path_prefix: Option<String>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum SchemaCommand {
+    Inspect {
+        domain: String,
+        action: String,
+    },
+}
+
 #[derive(Debug, Subcommand)]
 pub enum AuthCommand {
-    /// Request a one-time password (OTP) to be sent to the given email.
     OtpRequest {
-        /// Raw JSON payload matching `OtpRequest`.
         #[arg(long)]
         json: String,
     },
-    /// Verify an OTP and establish a session.
     OtpVerify {
-        /// Raw JSON payload matching `OtpVerify`.
         #[arg(long)]
         json: String,
     },
-    /// Log out the current session.
     Logout,
 }
 
@@ -126,13 +103,10 @@ pub enum UsersCommand {
     Get {
         id: String,
     },
-    /// Create a user from a JSON payload.
     Create {
-        /// Raw JSON payload matching `CreateUserRequest`.
         #[arg(long)]
         json: String,
     },
-    /// Delete a user by id.
     Delete {
         id: String,
     },
@@ -140,30 +114,23 @@ pub enum UsersCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum SessionsCommand {
-    /// List sessions for the current user.
     ListMine,
-    /// Get a session for the current user.
     GetMine {
         id: String,
     },
-    /// Delete a session for the current user.
     DeleteMine {
         id: String,
     },
-    /// Create a session for the given user id.
     CreateForUser {
         user_id: String,
     },
-    /// List sessions for a given user id.
     ListForUser {
         user_id: String,
     },
-    /// Get a specific session for a given user id.
     GetForUser {
         user_id: String,
         id: String,
     },
-    /// Delete a specific session for a given user id.
     DeleteForUser {
         user_id: String,
         id: String,
@@ -183,41 +150,31 @@ pub enum SongsCommand {
     Get {
         id: String,
     },
-    /// Get a player description for the given song id.
     Player {
         id: String,
     },
-    /// Get an export URL for a song and format.
     ExportUrl {
         id: String,
         format: String,
     },
-    /// Create a song from a JSON payload.
     Create {
-        /// Raw JSON payload matching `CreateSong`.
         #[arg(long)]
         json: String,
     },
-    /// Update a song with the given id from a JSON payload.
     Update {
         id: String,
-        /// Raw JSON payload matching `CreateSong`.
         #[arg(long)]
         json: String,
     },
-    /// Delete a song by id.
     Delete {
         id: String,
     },
-    /// Import a song from an external identifier.
     Import {
         identifier: String,
     },
-    /// Get like status for a song.
     LikeStatus {
         id: String,
     },
-    /// Update like status for a song.
     UpdateLikeStatus {
         id: String,
         liked: bool,
@@ -237,33 +194,25 @@ pub enum CollectionsCommand {
     Get {
         id: String,
     },
-    /// List songs in a collection.
     Songs {
         id: String,
     },
-    /// Get a player description for the given collection id.
     Player {
         id: String,
     },
-    /// Get an export URL for a collection and format.
     ExportUrl {
         id: String,
         format: String,
     },
-    /// Create a collection from a JSON payload.
     Create {
-        /// Raw JSON payload matching `CreateCollection`.
         #[arg(long)]
         json: String,
     },
-    /// Update a collection with the given id from a JSON payload.
     Update {
         id: String,
-        /// Raw JSON payload matching `CreateCollection`.
         #[arg(long)]
         json: String,
     },
-    /// Delete a collection by id.
     Delete {
         id: String,
     },
@@ -282,33 +231,25 @@ pub enum SetlistsCommand {
     Get {
         id: String,
     },
-    /// List songs in a setlist.
     Songs {
         id: String,
     },
-    /// Get a player description for the given setlist id.
     Player {
         id: String,
     },
-    /// Get an export URL for a setlist and format.
     ExportUrl {
         id: String,
         format: String,
     },
-    /// Create a setlist from a JSON payload.
     Create {
-        /// Raw JSON payload matching `CreateSetlist`.
         #[arg(long)]
         json: String,
     },
-    /// Update a setlist with the given id from a JSON payload.
     Update {
         id: String,
-        /// Raw JSON payload matching `CreateSetlist`.
         #[arg(long)]
         json: String,
     },
-    /// Delete a setlist by id.
     Delete {
         id: String,
     },
@@ -327,24 +268,18 @@ pub enum BlobsCommand {
     Get {
         id: String,
     },
-    /// Create a blob from a JSON payload.
     Create {
-        /// Raw JSON payload matching `CreateBlob`.
         #[arg(long)]
         json: String,
     },
-    /// Update a blob with the given id from a JSON payload.
     Update {
         id: String,
-        /// Raw JSON payload matching `CreateBlob`.
         #[arg(long)]
         json: String,
     },
-    /// Delete a blob by id.
     Delete {
         id: String,
     },
-    /// Get the download URL for a blob's image data.
     DownloadUrl {
         id: String,
     },

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -13,8 +13,6 @@ use shared::net::HttpClientConfig;
 
 const DEFAULT_BASE_URL: &str = "http://127.0.0.1:8080";
 
-/// Options passed from the CLI (or other caller) to build HTTP client config.
-/// Precedence for base_url and sso_session: CLI/arg > env > file > default.
 #[derive(Debug, Clone, Default)]
 pub struct BuildConfigOptions {
     pub base_url: Option<String>,
@@ -24,7 +22,6 @@ pub struct BuildConfigOptions {
 }
 
 impl BuildConfigOptions {
-    /// Build from a Cli instance (avoids config depending on commands at type level in callers).
     pub fn from_cli(cli: &crate::commands::Cli) -> Self {
         Self {
             base_url: cli.base_url.clone(),
@@ -41,7 +38,6 @@ pub struct FileConfig {
     pub sso_session: Option<String>,
 }
 
-/// Load config from `~/.worshipviewer/config.toml`. Returns default if file is missing.
 pub fn load_file_config() -> Result<FileConfig, Box<dyn std::error::Error>> {
     let home: PathBuf = home_dir().ok_or_else(|| {
         io::Error::new(io::ErrorKind::Other, "failed to determine home directory")
@@ -70,7 +66,6 @@ pub fn load_file_config() -> Result<FileConfig, Box<dyn std::error::Error>> {
     Ok(cfg)
 }
 
-/// Resolve effective base URL: cli/arg > env > file > default.
 fn resolve_base_url(cli_base: Option<String>, file_cfg: &FileConfig) -> String {
     let env_base = env::var("WORSHIP_VIEWER_BASE_URL").ok();
     cli_base
@@ -79,14 +74,11 @@ fn resolve_base_url(cli_base: Option<String>, file_cfg: &FileConfig) -> String {
         .unwrap_or_else(|| DEFAULT_BASE_URL.to_string())
 }
 
-/// Resolve effective SSO session: cli/arg > env > file.
 fn resolve_sso_session(cli_sso: Option<String>, file_cfg: &FileConfig) -> Option<String> {
     let env_sso = env::var("WORSHIP_VIEWER_SSO_SESSION").ok();
     cli_sso.or(env_sso).or(file_cfg.sso_session.clone())
 }
 
-/// Build HTTP client config and effective base URL from CLI options and file config.
-/// The returned base URL string should be used for constructing full URLs (e.g. export/download).
 pub fn build_http_client_config(
     options: &BuildConfigOptions,
 ) -> Result<(HttpClientConfig, String), Box<dyn std::error::Error>> {

--- a/cli/src/handlers/mod.rs
+++ b/cli/src/handlers/mod.rs
@@ -1,9 +1,7 @@
-//! Async command handlers. Dispatch by command and delegate to per-domain modules.
-
 use shared::api::ApiClient;
 use shared::net::DefaultHttpClient;
 
-use crate::commands::{Cli, Command};
+use crate::commands::{Cli, Command, SchemaCommand};
 
 mod auth;
 mod blobs;
@@ -14,16 +12,24 @@ mod setlists;
 mod songs;
 mod users;
 
-/// Run the command specified in `cli`, using `client` and `effective_base_url` for API and URL construction.
 pub async fn dispatch(
     client: &ApiClient<DefaultHttpClient>,
     cli: &Cli,
     effective_base_url: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     match &cli.command {
-        Command::Schema { path_prefix } => {
-            schema::handle_schema(client, cli.output.clone(), path_prefix.clone()).await
-        }
+        Command::Schema(args) => match &args.command {
+            Some(SchemaCommand::Inspect { domain, action }) => {
+                schema::handle_schema_inspect(
+                    client,
+                    cli.output.clone(),
+                    domain,
+                    action,
+                )
+                .await
+            }
+            None => schema::handle_schema(client, cli.output.clone(), args.path_prefix.clone()).await,
+        },
         Command::Auth { command } => {
             auth::handle_auth(client, cli.output.clone(), cli.dry_run, command).await
         }

--- a/cli/src/handlers/schema.rs
+++ b/cli/src/handlers/schema.rs
@@ -20,3 +20,207 @@ pub async fn handle_schema(
 
     output::print_json(&schema, &output)
 }
+
+pub async fn handle_schema_inspect(
+    client: &ApiClient<DefaultHttpClient>,
+    output: OutputFormat,
+    domain: &str,
+    action: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let openapi: Value = client.get_openapi_docs().await?;
+
+    let (method, path) = map_cli_command_to_openapi_operation(domain, action)?;
+    let operation = get_operation(&openapi, &path, &method)?;
+
+    let operation_id = operation
+        .get("operationId")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let components = openapi
+        .get("components")
+        .and_then(|v| v.as_object())
+        .and_then(|o| o.get("schemas"))
+        .and_then(|v| v.as_object());
+
+    let request_schema = extract_request_schema(operation)
+        .map(|schema| expand_refs(&schema, components, &mut std::collections::HashSet::new()));
+
+    let response_schema = extract_success_response_schema(operation)
+        .map(|schema| expand_refs(&schema, components, &mut std::collections::HashSet::new()));
+
+    let result = serde_json::json!({
+        "method": method.to_uppercase(),
+        "path": path,
+        "operation_id": operation_id,
+        "request": request_schema,
+        "response": response_schema,
+    });
+
+    output::print_json(&result, &output)
+}
+
+fn map_cli_command_to_openapi_operation(
+    domain: &str,
+    action: &str,
+) -> Result<(String, String), Box<dyn std::error::Error>> {
+    let domain = domain.to_ascii_lowercase();
+    let action = action.to_ascii_lowercase();
+
+    let mapped = match (domain.as_str(), action.as_str()) {
+        ("auth", "otp-request") => ("post", "/auth/otp/request"),
+        ("auth", "otp-verify") => ("post", "/auth/otp/verify"),
+        ("auth", "logout") => ("post", "/auth/logout"),
+        ("users", "list") => ("get", "/api/v1/users"),
+        ("users", "get") => ("get", "/api/v1/users/{id}"),
+        ("users", "create") => ("post", "/api/v1/users"),
+        ("users", "delete") => ("delete", "/api/v1/users/{id}"),
+        ("sessions", "list-mine") => ("get", "/api/v1/users/me/sessions"),
+        ("sessions", "get-mine") => ("get", "/api/v1/users/me/sessions/{id}"),
+        ("sessions", "delete-mine") => ("delete", "/api/v1/users/me/sessions/{id}"),
+        ("sessions", "create-for-user") => ("post", "/api/v1/users/{user_id}/sessions"),
+        ("sessions", "list-for-user") => ("get", "/api/v1/users/{user_id}/sessions"),
+        ("sessions", "get-for-user") => ("get", "/api/v1/users/{user_id}/sessions/{id}"),
+        ("sessions", "delete-for-user") => ("delete", "/api/v1/users/{user_id}/sessions/{id}"),
+        ("songs", "list") => ("get", "/api/v1/songs"),
+        ("songs", "get") => ("get", "/api/v1/songs/{id}"),
+        ("songs", "player") => ("get", "/api/v1/songs/{id}/player"),
+        ("songs", "create") => ("post", "/api/v1/songs"),
+        ("songs", "update") => ("put", "/api/v1/songs/{id}"),
+        ("songs", "delete") => ("delete", "/api/v1/songs/{id}"),
+        ("songs", "import") => ("get", "/api/v1/songs/import/{identifier:.*}"),
+        ("songs", "like-status") => ("get", "/api/v1/songs/{id}/likes"),
+        ("songs", "update-like-status") => ("put", "/api/v1/songs/{id}/likes"),
+        ("collections", "list") => ("get", "/api/v1/collections"),
+        ("collections", "get") => ("get", "/api/v1/collections/{id}"),
+        ("collections", "songs") => ("get", "/api/v1/collections/{id}/songs"),
+        ("collections", "player") => ("get", "/api/v1/collections/{id}/player"),
+        ("collections", "create") => ("post", "/api/v1/collections"),
+        ("collections", "update") => ("put", "/api/v1/collections/{id}"),
+        ("collections", "delete") => ("delete", "/api/v1/collections/{id}"),
+        ("setlists", "list") => ("get", "/api/v1/setlists"),
+        ("setlists", "get") => ("get", "/api/v1/setlists/{id}"),
+        ("setlists", "songs") => ("get", "/api/v1/setlists/{id}/songs"),
+        ("setlists", "player") => ("get", "/api/v1/setlists/{id}/player"),
+        ("setlists", "create") => ("post", "/api/v1/setlists"),
+        ("setlists", "update") => ("put", "/api/v1/setlists/{id}"),
+        ("setlists", "delete") => ("delete", "/api/v1/setlists/{id}"),
+        ("blobs", "list") => ("get", "/api/v1/blobs"),
+        ("blobs", "get") => ("get", "/api/v1/blobs/{id}"),
+        ("blobs", "create") => ("post", "/api/v1/blobs"),
+        ("blobs", "update") => ("put", "/api/v1/blobs/{id}"),
+        ("blobs", "delete") => ("delete", "/api/v1/blobs/{id}"),
+        ("blobs", "download-url") => ("get", "/api/v1/blobs/{id}/data"),
+        _ => return Err(format!("Unknown CLI command: {domain} {action}").into()),
+    };
+
+    Ok((mapped.0.to_string(), mapped.1.to_string()))
+}
+
+fn get_operation<'a>(
+    openapi: &'a Value,
+    path: &str,
+    method: &str,
+) -> Result<&'a Value, Box<dyn std::error::Error>> {
+    let paths = openapi
+        .get("paths")
+        .and_then(|v| v.as_object())
+        .ok_or_else(|| "OpenAPI document missing paths")?;
+
+    let path_item = paths
+        .get(path)
+        .ok_or_else(|| format!("OpenAPI document missing path {path}"))?;
+
+    let operation = path_item
+        .get(method)
+        .ok_or_else(|| format!("OpenAPI document missing operation {method} {path}"))?;
+
+    Ok(operation)
+}
+
+fn extract_request_schema(operation: &Value) -> Option<Value> {
+    let request_body = operation.get("requestBody")?;
+    let content = request_body.get("content")?.as_object()?;
+    let schema = pick_content_schema(content)?;
+    Some(schema.clone())
+}
+
+fn extract_success_response_schema(operation: &Value) -> Option<Value> {
+    let responses = operation.get("responses")?.as_object()?;
+
+    let preferred = ["200", "201", "202", "204"];
+    let mut chosen: Option<&Value> = None;
+    for code in preferred {
+        if let Some(v) = responses.get(code) {
+            chosen = Some(v);
+            break;
+        }
+    }
+
+    if chosen.is_none() {
+        for (code, value) in responses {
+            if code.starts_with('2') {
+                chosen = Some(value);
+                break;
+            }
+        }
+    }
+
+    let chosen = chosen?;
+    let content = chosen.get("content")?.as_object()?;
+    let schema = pick_content_schema(content)?;
+    Some(schema.clone())
+}
+
+fn pick_content_schema(content: &serde_json::Map<String, Value>) -> Option<&Value> {
+    if let Some(app) = content.get("application/json") {
+        return app.get("schema");
+    }
+
+    for (_ct, value) in content {
+        if let Some(schema) = value.get("schema") {
+            return Some(schema);
+        }
+    }
+
+    None
+}
+
+fn expand_refs(
+    schema: &Value,
+    components_schemas: Option<&serde_json::Map<String, Value>>,
+    seen: &mut std::collections::HashSet<String>,
+) -> Value {
+    match schema {
+        Value::Object(obj) => {
+            if let Some(Value::String(reference)) = obj.get("$ref") {
+                if let Some((prefix, name)) = reference.split_once("#/components/schemas/") {
+                    let _ = prefix;
+                    if let Some(components) = components_schemas {
+                        if let Some(resolved) = components.get(name) {
+                            if seen.insert(name.to_string()) {
+                                let expanded = expand_refs(resolved, components_schemas, seen);
+                                seen.remove(name);
+                                return expanded;
+                            }
+                        }
+                    }
+                }
+
+                return schema.clone();
+            }
+
+            let mut out = serde_json::Map::new();
+            for (k, v) in obj {
+                out.insert(k.clone(), expand_refs(v, components_schemas, seen));
+            }
+            Value::Object(out)
+        }
+        Value::Array(arr) => Value::Array(
+            arr.iter()
+                .map(|v| expand_refs(v, components_schemas, seen))
+                .collect(),
+        ),
+        other => other.clone(),
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -22,6 +22,37 @@ async fn main() {
 async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
+    {
+        use std::io::Write;
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open("/Users/xilef/Git/worship_viewer/.cursor/debug-3dd3ca.log")
+        {
+            let _ = writeln!(
+                f,
+                "{}",
+                serde_json::json!({
+                    "sessionId":"3dd3ca",
+                    "runId":"pre-fix",
+                    "hypothesisId":"H1_global_args_not_global",
+                    "location":"cli/src/main.rs:run",
+                    "message":"Parsed CLI args",
+                    "data":{
+                        "output": format!("{:?}", cli.output),
+                        "dry_run": cli.dry_run,
+                        "has_base_url": cli.base_url.is_some(),
+                        "command": format!("{:?}", cli.command),
+                    },
+                    "timestamp": std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_millis() as u64)
+                        .unwrap_or(0)
+                })
+            );
+        }
+    }
+
     let options = config::BuildConfigOptions::from_cli(&cli);
     let (client_config, effective_base_url) = config::build_http_client_config(&options)?;
     let client = ApiClient::<DefaultHttpClient>::with_default(client_config);

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -3,16 +3,11 @@ use std::io::{self, IsTerminal};
 use clap::ValueEnum;
 use serde::Serialize;
 
-/// Output format for JSON printed by the CLI.
 #[derive(Debug, Clone, ValueEnum)]
 pub enum OutputFormat {
-    /// Automatically choose a format based on whether stdout is a TTY.
     Auto,
-    /// Compact JSON, one document per command.
     Json,
-    /// Pretty-printed JSON.
     Pretty,
-    /// Newline-delimited JSON (only meaningful for list commands).
     Ndjson,
 }
 
@@ -20,7 +15,6 @@ pub fn is_stdout_tty() -> bool {
     io::stdout().is_terminal()
 }
 
-/// Resolve Auto to Json or Pretty based on TTY; other variants unchanged.
 pub fn effective_output_format(format: &OutputFormat) -> OutputFormat {
     match format {
         OutputFormat::Auto => {

--- a/cli/src/validate.rs
+++ b/cli/src/validate.rs
@@ -1,6 +1,5 @@
 use std::fmt;
 
-/// Error type for invalid CLI input that fails local validation.
 #[derive(Debug)]
 pub struct ValidationError {
     message: String,
@@ -22,12 +21,6 @@ impl fmt::Display for ValidationError {
 
 impl std::error::Error for ValidationError {}
 
-/// Validate a resource identifier or path segment used in API URLs.
-///
-/// Rules (inspired by AI-first CLI hardening guidelines):
-/// - must not be empty
-/// - must not contain control characters (ASCII < 0x20)
-/// - must not contain '?', '#', or '%' to avoid embedded query params or double-encoding
 pub fn validate_resource_id(id: &str) -> Result<&str, ValidationError> {
     if id.is_empty() {
         return Err(ValidationError::new("id must not be empty"));


### PR DESCRIPTION
Add a schema inspect subcommand that maps CLI domain/action pairs to concrete OpenAPI paths and HTTP methods, then extracts and expands request/response schemas for better inspection. Also promote common HTTP flags to global clap arguments and remove redundant inline documentation now that help text and external docs cover those details.

Fixes: #36
Made-with: Cursor