### PR TITLE
chore(github): refresh bug and feature issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,38 +1,63 @@
 ---
 name: Bug report
-about: Create a report to help us improve
-title: ''
-labels: ''
-assignees: ''
-
+about: Reproducible defect with acceptance criteria for the fix
+labels: bug
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+## Summary
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+One sentence: what breaks and where (screen, flow, or API).
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+## Spec for “fixed”
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+Replace the placeholders below with concrete, testable statements. An implementer or agent should be able to verify each item.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+- [ ] 
+- [ ] 
+- [ ] 
 
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+## Context
 
-**Additional context**
-Add any other context about the problem here.
+Where it happens (check all that apply and fill details):
+
+| | |
+| --- | --- |
+| Deployment | `app.worshipviewer.com` / Docker image tag / `trunk serve` / other: |
+| Account / role | |
+| Song / set / asset | If relevant, name or minimal example (no private data) |
+
+## Steps to reproduce
+
+1. 
+2. 
+3. 
+
+## Actual behavior
+
+## Expected behavior
+
+## Evidence
+
+Paste errors, network failures, or console output inside fenced blocks. Attach screenshots or short screen recordings if UI-related.
+
+```
+```
+
+## Environment
+
+| | |
+| --- | --- |
+| OS | |
+| Browser | |
+| Browser version | |
+| App or image version / commit (if known) | |
+
+Mobile-only issues: device model, OS version, browser.
+
+## Suspected area (optional)
+
+Rust / WASM / Trunk, specific crate, route, or file path if you already know.
+
+## Related
+
+Links to issues, PRs, or internal notes.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,67 @@
 ---
-name: Feature request
-about: Suggest an idea for this project
-title: ''
-labels: ''
-assignees: ''
-
+name: Feature or change
+about: Problem, behavior spec, acceptance criteria, and boundaries for implementers or agents
+labels: enhancement
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+## Summary
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+One sentence: the outcome you want.
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+## Problem
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+What is wrong, missing, or expensive today? Who is affected?
+
+## User story (optional)
+
+As a …, I want …, so that …
+
+## Specification
+
+Numbered, observable behaviors. Prefer “when X then Y” over vague goals.
+
+1. 
+2. 
+3. 
+
+## Acceptance criteria
+
+Checkboxes define done. Keep each item verifiable without guessing intent.
+
+- [ ] 
+- [ ] 
+- [ ] 
+
+## Non-goals
+
+What this issue must not do or solve (prevents scope creep for humans and agents).
+
+- 
+
+## Constraints
+
+Technical, UX, accessibility, performance, compatibility, or data rules that must hold.
+
+- 
+
+## Dependencies
+
+Blocked by or blocks other work. Link issues or PRs.
+
+- 
+
+## Open questions
+
+Decisions still needed. Mark resolved items as you go.
+
+- 
+
+## Verification
+
+How a reviewer or agent should confirm the spec (manual steps, test level, or “N/A for design-only”).
+
+- 
+
+## Related
+
+Design docs, prior discussion, or comparable products (links).


### PR DESCRIPTION
## Summary

Restructures the GitHub bug report and feature issue templates with clearer sections for context, reproduction, evidence, environment, and verifiable acceptance criteria.

## Changes

- **Bug report**: Summary, spec for fixed, context table, steps, actual/expected, evidence, environment, optional suspected area, related links; default `bug` label.
- **Feature / change**: Problem, specification, acceptance criteria, non-goals, constraints, dependencies, open questions, verification; default `enhancement` label.

## Why

Improves triage and gives implementers and agents enough structure to verify work without guessing reporter intent.