### PR TITLE
fix(backend): clear default Clippy warnings

### DIFF
--- a/backend/src/auth/middleware.rs
+++ b/backend/src/auth/middleware.rs
@@ -69,7 +69,7 @@ where
                     req.cookie(&cookie_name)
                         .map(|cookie| cookie.value().to_owned())
                 })
-                .ok_or_else(|| AppError::unauthorized())?;
+                .ok_or_else(AppError::unauthorized)?;
 
             let user = match db
                 .get_session_and_update_user_metrics_or_delete_if_exipired(&session_id)

--- a/backend/src/auth/oidc/rest.rs
+++ b/backend/src/auth/oidc/rest.rs
@@ -46,7 +46,7 @@ async fn login(
     let redirect_hint = query
         .redirect_to
         .as_deref()
-        .and_then(|value| sanitize_redirect(value));
+        .and_then(sanitize_redirect);
 
     let oidc_clients = oidc_clients.get_ref();
     let provider = query
@@ -179,9 +179,11 @@ fn session_cookie(session_id: &str) -> Cookie<'static> {
 
 fn sanitize_redirect(path: &str) -> Option<String> {
     let trimmed = path.trim();
-    if trimmed.is_empty() || !trimmed.starts_with('/') || trimmed.starts_with("//") {
-        None
-    } else if trimmed.starts_with("/http") {
+    if trimmed.is_empty()
+        || !trimmed.starts_with('/')
+        || trimmed.starts_with("//")
+        || trimmed.starts_with("/http")
+    {
         None
     } else {
         Some(trimmed.to_string())

--- a/backend/src/auth/rest.rs
+++ b/backend/src/auth/rest.rs
@@ -42,12 +42,10 @@ async fn logout(db: Data<Database>, req: HttpRequest) -> HttpResponse {
 
     if let Some(session_id) = bearer_session
         .as_deref()
-        .or_else(|| cookie_session.as_deref())
-    {
-        if let Err(err) = db.delete_session(session_id).await {
+        .or(cookie_session.as_deref())
+        && let Err(err) = db.delete_session(session_id).await {
             warn!(session = session_id, "failed to drop session: {}", err);
         }
-    }
 
     let mut response = HttpResponse::NoContent();
     if cookie_session.is_some() {

--- a/backend/src/mail.rs
+++ b/backend/src/mail.rs
@@ -29,7 +29,7 @@ impl<'a> Mail<'a> {
         let settings = Settings::global();
 
         let response = SmtpTransport::relay("smtp.gmail.com")
-            .map_err(|err| AppError::mail(err))?
+            .map_err(AppError::mail)?
             .credentials(Credentials::new(
                 settings.gmail_from.to_owned(),
                 settings.gmail_app_password.to_owned(),
@@ -41,14 +41,14 @@ impl<'a> Mail<'a> {
                         settings
                             .gmail_from
                             .parse()
-                            .map_err(|err| AppError::mail(err))?,
+                            .map_err(AppError::mail)?,
                     )
-                    .to(self.to.parse().map_err(|err| AppError::mail(err))?)
+                    .to(self.to.parse().map_err(AppError::mail)?)
                     .subject(self.subject)
                     .body(self.body.to_owned())
-                    .map_err(|err| AppError::mail(err))?,
+                    .map_err(AppError::mail)?,
             )
-            .map_err(|err| AppError::mail(err))?;
+            .map_err(AppError::mail)?;
 
         if !response.is_positive() {
             return Err(AppError::mail("sending the mail was not positive"));

--- a/backend/src/resources/blob/rest.rs
+++ b/backend/src/resources/blob/rest.rs
@@ -9,7 +9,6 @@ use actix_web::{
 use super::Model;
 use crate::database::Database;
 #[allow(unused_imports)]
-#[allow(unused_imports)]
 use crate::docs::ErrorResponse;
 use crate::error::AppError;
 use crate::resources::User;
@@ -196,7 +195,7 @@ async fn download_blob_image(
     user: ReqData<User>,
     id: PathParam<String>,
 ) -> Result<NamedFile, AppError> {
-    Ok(NamedFile::open(
+    NamedFile::open(
         Path::new(&Settings::global().blob_dir).join(PathBuf::from(
             db.get_blob(user.read(), &id.into_inner())
                 .await?
@@ -204,5 +203,5 @@ async fn download_blob_image(
                 .ok_or(AppError::NotFound("blob has no id".into()))?,
         )),
     )
-    .map_err(|err| AppError::Internal(format!("{}", err)))?)
+    .map_err(|err| AppError::Internal(format!("{}", err)))
 }

--- a/backend/src/resources/collection/model.rs
+++ b/backend/src/resources/collection/model.rs
@@ -74,11 +74,10 @@ impl Model for Database {
         }
 
         let mut request = self.db.query(query).bind(("owners", owners));
-        if let Some(ref q) = pagination.q {
-            if !q.trim().is_empty() {
+        if let Some(ref q) = pagination.q
+            && !q.trim().is_empty() {
                 request = request.bind(("q", q.trim().to_string()));
             }
-        }
         if let Some((offset, limit)) = pagination.to_offset_limit() {
             request = request.bind(("limit", limit)).bind(("start", offset));
         }
@@ -274,7 +273,7 @@ impl CollectionRecord {
     fn from_payload(id: Option<Thing>, owner: Option<Thing>, collection: CreateCollection) -> Self {
         Self {
             id,
-            owner: owner,
+            owner,
             title: collection.title,
             cover: Some(blob_thing(&collection.cover)),
             songs: collection.songs.into_iter().map(Into::into).collect(),
@@ -283,11 +282,10 @@ impl CollectionRecord {
 }
 
 fn blob_thing(blob_id: &str) -> Thing {
-    if let Ok(thing) = blob_id.parse::<Thing>() {
-        if thing.tb == "blob" {
+    if let Ok(thing) = blob_id.parse::<Thing>()
+        && thing.tb == "blob" {
             return thing;
         }
-    }
 
     Thing::from(("blob".to_owned(), blob_id.to_owned()))
 }
@@ -326,11 +324,10 @@ fn owner_thing(user_id: &str) -> Thing {
 }
 
 fn song_thing(song_id: &str) -> Thing {
-    if let Ok(thing) = song_id.parse::<Thing>() {
-        if thing.tb == "song" {
+    if let Ok(thing) = song_id.parse::<Thing>()
+        && thing.tb == "song" {
             return thing;
         }
-    }
 
     Thing::from(("song".to_owned(), song_id.to_owned()))
 }

--- a/backend/src/resources/collection/rest.rs
+++ b/backend/src/resources/collection/rest.rs
@@ -6,7 +6,6 @@ use actix_web::{
 use super::Model;
 use crate::database::Database;
 #[allow(unused_imports)]
-#[allow(unused_imports)]
 use crate::docs::ErrorResponse;
 use crate::error::AppError;
 use crate::resources::User;

--- a/backend/src/resources/rest.rs
+++ b/backend/src/resources/rest.rs
@@ -4,7 +4,7 @@ use actix_web::{dev::HttpServiceFactory, web};
 
 pub fn scope() -> impl HttpServiceFactory {
     web::scope("/api/v1")
-        .wrap(RequireUser::default())
+        .wrap(RequireUser)
         .service(blob::rest::scope())
         .service(collection::rest::scope())
         .service(setlist::rest::scope())

--- a/backend/src/resources/setlist/model.rs
+++ b/backend/src/resources/setlist/model.rs
@@ -64,11 +64,10 @@ impl Model for Database {
         }
 
         let mut request = self.db.query(query).bind(("owners", owners));
-        if let Some(ref q) = pagination.q {
-            if !q.trim().is_empty() {
+        if let Some(ref q) = pagination.q
+            && !q.trim().is_empty() {
                 request = request.bind(("q", q.trim().to_string()));
             }
-        }
         if let Some((offset, limit)) = pagination.to_offset_limit() {
             request = request.bind(("limit", limit)).bind(("start", offset));
         }
@@ -233,7 +232,7 @@ impl SetlistRecord {
     fn from_payload(id: Option<Thing>, owner: Option<Thing>, setlist: CreateSetlist) -> Self {
         Self {
             id,
-            owner: owner,
+            owner,
             title: setlist.title,
             songs: setlist.songs.into_iter().map(Into::into).collect(),
         }
@@ -329,11 +328,10 @@ fn setlist_belongs_to(record: &SetlistRecord, owners: Vec<String>) -> bool {
 }
 
 fn song_thing(id: &str) -> Thing {
-    if let Ok(thing) = id.parse::<Thing>() {
-        if thing.tb == "song" {
+    if let Ok(thing) = id.parse::<Thing>()
+        && thing.tb == "song" {
             return thing;
         }
-    }
 
     Thing::from(("song".to_owned(), id.to_owned()))
 }

--- a/backend/src/resources/setlist/rest.rs
+++ b/backend/src/resources/setlist/rest.rs
@@ -6,7 +6,6 @@ use actix_web::{
 use super::Model;
 use crate::database::Database;
 #[allow(unused_imports)]
-#[allow(unused_imports)]
 use crate::docs::ErrorResponse;
 use crate::error::AppError;
 use crate::resources::User;

--- a/backend/src/resources/song/export.rs
+++ b/backend/src/resources/song/export.rs
@@ -78,7 +78,7 @@ fn export_chord_pro(
 
     for song in &songs {
         zip.start_file(
-            &format!("{}.{}", sanitize_filename(&song.data.title), ending),
+            format!("{}.{}", sanitize_filename(&song.data.title), ending),
             options,
         )
         .map_err(|err| AppError::Internal(err.to_string()))?;
@@ -97,14 +97,13 @@ fn export_chord_pro(
         .insert_header((header::CONTENT_TYPE, "application/zip"))
         .insert_header((
             header::CONTENT_DISPOSITION,
-            format!("attachment; filename=\"songs.zip\""),
+            "attachment; filename=\"songs.zip\"".to_string(),
         ))
         .body(bytes))
 }
 
 async fn export_pdf(songs: Vec<Song>) -> Result<HttpResponse, AppError> {
-    let css = songs
-        .get(0)
+    let css = songs.first()
         .map(|song| song.format_html(None, None, None, None).1)
         .unwrap_or_default();
     let pages = songs

--- a/backend/src/resources/song/model.rs
+++ b/backend/src/resources/song/model.rs
@@ -71,11 +71,10 @@ impl Model for Database {
         }
 
         let mut request = self.db.query(query).bind(("owners", owners));
-        if let Some(ref q) = pagination.q {
-            if !q.trim().is_empty() {
+        if let Some(ref q) = pagination.q
+            && !q.trim().is_empty() {
                 request = request.bind(("q", q.trim().to_string()));
             }
-        }
         if let Some((offset, limit)) = pagination.to_offset_limit() {
             request = request.bind(("limit", limit)).bind(("start", offset));
         }
@@ -320,7 +319,7 @@ impl SongRecord {
         let search_content = search_content_from_song_data(&song.data);
         Self {
             id,
-            owner: owner,
+            owner,
             not_a_song: song.not_a_song,
             blobs: song
                 .blobs
@@ -338,11 +337,10 @@ fn owner_thing(user_id: &str) -> Thing {
 }
 
 fn blob_thing(blob_id: &str) -> Thing {
-    if let Ok(thing) = blob_id.parse::<Thing>() {
-        if thing.tb == "blob" {
+    if let Ok(thing) = blob_id.parse::<Thing>()
+        && thing.tb == "blob" {
             return thing;
         }
-    }
 
     Thing::from(("blob".to_owned(), blob_id.to_owned()))
 }

--- a/backend/src/resources/song/rest.rs
+++ b/backend/src/resources/song/rest.rs
@@ -6,7 +6,6 @@ use actix_web::{
 use super::{Model, QueryParams, export};
 use crate::database::Database;
 #[allow(unused_imports)]
-#[allow(unused_imports)]
 use crate::docs::ErrorResponse;
 use crate::error::AppError;
 use crate::resources::User;
@@ -354,8 +353,8 @@ async fn update_song_like_status(
 }
 
 async fn import(identifier: &str) -> Result<Song, AppError> {
-    if identifier.starts_with("tabs/ultimate-guitar/com/tab/") {
-        let url = format!("https://tabs.ultimate-guitar.com/tab/{}", &identifier[29..]);
+    if let Some(suffix) = identifier.strip_prefix("tabs/ultimate-guitar/com/tab/") {
+        let url = format!("https://tabs.ultimate-guitar.com/tab/{}", suffix);
         let html = reqwest::Client::default()
             .get(&url)
             .send()

--- a/backend/src/resources/user/model.rs
+++ b/backend/src/resources/user/model.rs
@@ -156,7 +156,7 @@ impl UserRecord {
 
     pub fn from_user(user: User) -> Self {
         Self {
-            id: if user.id.len() > 0 {
+            id: if !user.id.is_empty() {
                 Some(Thing::from(("user".to_owned(), user.id)))
             } else {
                 None

--- a/backend/src/resources/user/rest.rs
+++ b/backend/src/resources/user/rest.rs
@@ -18,7 +18,7 @@ pub fn scope() -> Scope {
         .service(session::rest::delete_session_for_current_user)
         .service(
             web::scope("")
-                .wrap(RequireAdmin::default())
+                .wrap(RequireAdmin)
                 .service(create_user)
                 .service(delete_user)
                 .service(get_user)


### PR DESCRIPTION
## Summary

Resolves backend Clippy noise from [#44](https://github.com/xilefmusics/worship_viewer/issues/44): default `cargo clippy` in `backend/` completes with zero warnings.

## Changes

- Removed duplicate `#[allow(unused_imports)]` on `ErrorResponse` imports in resource REST modules.
- Applied Clippy fixes: redundant closures (`AppError::mail` / `unauthorized`), `or` vs `or_else`, collapsible `if`/`let`, shorthand struct fields, `RequireUser`/`RequireAdmin` without redundant `default()`, needless `?`/`Ok` around blob download, `strip_prefix` for Ultimate Guitar import URLs, `first()` vs `get(0)`, `!is_empty()` vs `len() > 0`, needless borrows and `format!` in song export.
- **OIDC `sanitize_redirect`:** merged the two branches that both returned `None` (`invalid path` and `starts_with("/http")`) into one predicate so behavior stays the same with no duplicate blocks.

## Rationale for existing allows

No new `#[allow(clippy::…)]` was added. Pre-existing scoped `unused_imports` on `ErrorResponse` (for utoipa macro use) were left as a single attribute per file.

## Verification

- `cd backend && cargo clippy`
- `cd backend && cargo clippy -- -D warnings`
- `cd backend && cargo test`

Fixes #44