### PR TITLE
ci(backend): GitHub Actions for backend (build, test, clippy, fmt, cache)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,46 @@
+name: Backend CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/**"
+      - "shared/**"
+      - "rust-toolchain.toml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "backend/**"
+      - "shared/**"
+      - "rust-toolchain.toml"
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@v1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: backend
+
+      - name: Build
+        working-directory: backend
+        run: cargo build
+
+      - name: Test
+        working-directory: backend
+        run: cargo test
+
+      - name: Clippy
+        working-directory: backend
+        run: cargo clippy -- -D warnings
+
+      - name: Format check
+        run: |
+          cargo fmt --manifest-path backend/Cargo.toml --check
+          cargo fmt --manifest-path shared/Cargo.toml --check

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -8,6 +8,7 @@ on:
       - "backend/**"
       - "shared/**"
       - "rust-toolchain.toml"
+      - ".github/workflows/backend-ci.yml"
   pull_request:
     branches:
       - main
@@ -15,6 +16,7 @@ on:
       - "backend/**"
       - "shared/**"
       - "rust-toolchain.toml"
+      - ".github/workflows/backend-ci.yml"
 
 jobs:
   backend:

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -23,6 +23,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/backend/src/auth/oidc/rest.rs
+++ b/backend/src/auth/oidc/rest.rs
@@ -43,10 +43,7 @@ async fn login(
     query: web::Query<LoginQuery>,
 ) -> Result<HttpResponse, AppError> {
     db.cleanup_expired_oidc_states().await?;
-    let redirect_hint = query
-        .redirect_to
-        .as_deref()
-        .and_then(sanitize_redirect);
+    let redirect_hint = query.redirect_to.as_deref().and_then(sanitize_redirect);
 
     let oidc_clients = oidc_clients.get_ref();
     let provider = query

--- a/backend/src/auth/rest.rs
+++ b/backend/src/auth/rest.rs
@@ -40,12 +40,11 @@ async fn logout(db: Data<Database>, req: HttpRequest) -> HttpResponse {
         .cookie(&settings.cookie_name)
         .map(|cookie| cookie.value().to_owned());
 
-    if let Some(session_id) = bearer_session
-        .as_deref()
-        .or(cookie_session.as_deref())
-        && let Err(err) = db.delete_session(session_id).await {
-            warn!(session = session_id, "failed to drop session: {}", err);
-        }
+    if let Some(session_id) = bearer_session.as_deref().or(cookie_session.as_deref())
+        && let Err(err) = db.delete_session(session_id).await
+    {
+        warn!(session = session_id, "failed to drop session: {}", err);
+    }
 
     let mut response = HttpResponse::NoContent();
     if cookie_session.is_some() {

--- a/backend/src/database/migrations.rs
+++ b/backend/src/database/migrations.rs
@@ -26,9 +26,8 @@ pub async fn run(db: &Surreal<Any>, migration_root: &str) -> AnyResult<()> {
 
     for path in files {
         let script_name = file_name(&path)?;
-        let script = fs::read_to_string(&path).with_context(|| {
-            format!("failed to read migration script '{}'", path.display())
-        })?;
+        let script = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read migration script '{}'", path.display()))?;
         let checksum = script_checksum(&script);
 
         if let Some(existing_checksum) = applied.get(&script_name) {
@@ -120,9 +119,7 @@ COMMIT TRANSACTION;",
         .with_context(|| format!("migration body returned errors '{}'", script_name))?;
 
     let record_response = db
-        .query(
-            "CREATE migration_script SET script_name = $script_name, checksum = $checksum;",
-        )
+        .query("CREATE migration_script SET script_name = $script_name, checksum = $checksum;")
         .bind(("script_name", script_name.to_owned()))
         .bind(("checksum", checksum.to_owned()))
         .await

--- a/backend/src/mail.rs
+++ b/backend/src/mail.rs
@@ -37,12 +37,7 @@ impl<'a> Mail<'a> {
             .build()
             .send(
                 &Message::builder()
-                    .from(
-                        settings
-                            .gmail_from
-                            .parse()
-                            .map_err(AppError::mail)?,
-                    )
+                    .from(settings.gmail_from.parse().map_err(AppError::mail)?)
                     .to(self.to.parse().map_err(AppError::mail)?)
                     .subject(self.subject)
                     .body(self.body.to_owned())

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -35,46 +35,42 @@ async fn main() -> AnyResult<()> {
     db.migrate().await.context("database migration failed")?;
 
     if let Some(email) = settings.initial_admin_user_email.as_ref() {
-        let (admin, created_initial_admin) =
-            if let Some(user) = db
-                .get_user_by_email(email)
+        let (admin, created_initial_admin) = if let Some(user) =
+            db.get_user_by_email(email)
                 .await
                 .context("failed to look up initial admin user by email")?
-            {
-                info!(
-                    "Initial admin user already exists ({}), not creating: {}",
-                    user.id, user.email
-                );
-                (user, false)
-            } else {
-                let admin = db
-                    .create_user(User {
-                        id: String::new(),
-                        email: email.to_owned(),
-                        role: UserRole::Admin,
-                        read: vec![],
-                        write: vec![],
-                        default_collection: None,
-                        created_at: Utc::now(),
-                        last_login_at: None,
-                        request_count: 0,
-                    })
-                    .await
-                    .context("failed to create admin user")?;
-                info!(
-                    "Created admin user {} with email: {}",
-                    admin.id, admin.email
-                );
-                (admin, true)
-            };
+        {
+            info!(
+                "Initial admin user already exists ({}), not creating: {}",
+                user.id, user.email
+            );
+            (user, false)
+        } else {
+            let admin = db
+                .create_user(User {
+                    id: String::new(),
+                    email: email.to_owned(),
+                    role: UserRole::Admin,
+                    read: vec![],
+                    write: vec![],
+                    default_collection: None,
+                    created_at: Utc::now(),
+                    last_login_at: None,
+                    request_count: 0,
+                })
+                .await
+                .context("failed to create admin user")?;
+            info!(
+                "Created admin user {} with email: {}",
+                admin.id, admin.email
+            );
+            (admin, true)
+        };
 
         if settings.initial_admin_user_test_session {
             if created_initial_admin {
                 let session = db
-                    .create_session(Session::admin(
-                        admin,
-                        settings.session_ttl_seconds as i64,
-                    ))
+                    .create_session(Session::admin(admin, settings.session_ttl_seconds as i64))
                     .await
                     .context("failed to create a test session for the admin user")?;
                 info!(
@@ -82,9 +78,7 @@ async fn main() -> AnyResult<()> {
                     session.id,
                 );
             } else {
-                info!(
-                    "Initial admin user was not created on this run, not creating test session"
-                );
+                info!("Initial admin user was not created on this run, not creating test session");
             }
         }
     }

--- a/backend/src/resources/collection/model.rs
+++ b/backend/src/resources/collection/model.rs
@@ -75,9 +75,10 @@ impl Model for Database {
 
         let mut request = self.db.query(query).bind(("owners", owners));
         if let Some(ref q) = pagination.q
-            && !q.trim().is_empty() {
-                request = request.bind(("q", q.trim().to_string()));
-            }
+            && !q.trim().is_empty()
+        {
+            request = request.bind(("q", q.trim().to_string()));
+        }
         if let Some((offset, limit)) = pagination.to_offset_limit() {
             request = request.bind(("limit", limit)).bind(("start", offset));
         }
@@ -283,9 +284,10 @@ impl CollectionRecord {
 
 fn blob_thing(blob_id: &str) -> Thing {
     if let Ok(thing) = blob_id.parse::<Thing>()
-        && thing.tb == "blob" {
-            return thing;
-        }
+        && thing.tb == "blob"
+    {
+        return thing;
+    }
 
     Thing::from(("blob".to_owned(), blob_id.to_owned()))
 }
@@ -325,9 +327,10 @@ fn owner_thing(user_id: &str) -> Thing {
 
 fn song_thing(song_id: &str) -> Thing {
     if let Ok(thing) = song_id.parse::<Thing>()
-        && thing.tb == "song" {
-            return thing;
-        }
+        && thing.tb == "song"
+    {
+        return thing;
+    }
 
     Thing::from(("song".to_owned(), song_id.to_owned()))
 }

--- a/backend/src/resources/setlist/model.rs
+++ b/backend/src/resources/setlist/model.rs
@@ -65,9 +65,10 @@ impl Model for Database {
 
         let mut request = self.db.query(query).bind(("owners", owners));
         if let Some(ref q) = pagination.q
-            && !q.trim().is_empty() {
-                request = request.bind(("q", q.trim().to_string()));
-            }
+            && !q.trim().is_empty()
+        {
+            request = request.bind(("q", q.trim().to_string()));
+        }
         if let Some((offset, limit)) = pagination.to_offset_limit() {
             request = request.bind(("limit", limit)).bind(("start", offset));
         }
@@ -329,9 +330,10 @@ fn setlist_belongs_to(record: &SetlistRecord, owners: Vec<String>) -> bool {
 
 fn song_thing(id: &str) -> Thing {
     if let Ok(thing) = id.parse::<Thing>()
-        && thing.tb == "song" {
-            return thing;
-        }
+        && thing.tb == "song"
+    {
+        return thing;
+    }
 
     Thing::from(("song".to_owned(), id.to_owned()))
 }

--- a/backend/src/resources/song/export.rs
+++ b/backend/src/resources/song/export.rs
@@ -103,7 +103,8 @@ fn export_chord_pro(
 }
 
 async fn export_pdf(songs: Vec<Song>) -> Result<HttpResponse, AppError> {
-    let css = songs.first()
+    let css = songs
+        .first()
         .map(|song| song.format_html(None, None, None, None).1)
         .unwrap_or_default();
     let pages = songs

--- a/backend/src/resources/song/model.rs
+++ b/backend/src/resources/song/model.rs
@@ -72,9 +72,10 @@ impl Model for Database {
 
         let mut request = self.db.query(query).bind(("owners", owners));
         if let Some(ref q) = pagination.q
-            && !q.trim().is_empty() {
-                request = request.bind(("q", q.trim().to_string()));
-            }
+            && !q.trim().is_empty()
+        {
+            request = request.bind(("q", q.trim().to_string()));
+        }
         if let Some((offset, limit)) = pagination.to_offset_limit() {
             request = request.bind(("limit", limit)).bind(("start", offset));
         }
@@ -338,9 +339,10 @@ fn owner_thing(user_id: &str) -> Thing {
 
 fn blob_thing(blob_id: &str) -> Thing {
     if let Ok(thing) = blob_id.parse::<Thing>()
-        && thing.tb == "blob" {
-            return thing;
-        }
+        && thing.tb == "blob"
+    {
+        return thing;
+    }
 
     Thing::from(("blob".to_owned(), blob_id.to_owned()))
 }

--- a/backend/src/resources/song/rest.rs
+++ b/backend/src/resources/song/rest.rs
@@ -62,11 +62,16 @@ async fn get_songs(
 ) -> Result<HttpResponse, AppError> {
     let liked_set = db.get_liked_set(&user.id).await?;
     let list_query = query.into_inner();
-    let songs = db.get_songs(user.read(), list_query).await?.into_iter().map(|song| {
-        let mut song = song;
-        song.user_specific_addons.liked = liked_set.contains(&song.id);
-        song
-    }).collect::<Vec<Song>>();
+    let songs = db
+        .get_songs(user.read(), list_query)
+        .await?
+        .into_iter()
+        .map(|song| {
+            let mut song = song;
+            song.user_specific_addons.liked = liked_set.contains(&song.id);
+            song
+        })
+        .collect::<Vec<Song>>();
     Ok(HttpResponse::Ok().json(songs))
 }
 

--- a/backend/src/resources/user/model.rs
+++ b/backend/src/resources/user/model.rs
@@ -3,9 +3,9 @@ use surrealdb::sql::Datetime;
 use surrealdb::sql::Thing;
 
 use super::{Role, User};
-use shared::api::ListQuery;
 use crate::database::Database;
 use crate::error::AppError;
+use shared::api::ListQuery;
 
 pub trait Model {
     async fn get_users(&self, pagination: ListQuery) -> Result<Vec<User>, AppError>;

--- a/backend/src/resources/user/rest.rs
+++ b/backend/src/resources/user/rest.rs
@@ -93,10 +93,7 @@ async fn get_user(db: Data<Database>, id: Path<String>) -> Result<HttpResponse, 
     )
 )]
 #[get("")]
-async fn get_users(
-    db: Data<Database>,
-    query: Query<ListQuery>,
-) -> Result<HttpResponse, AppError> {
+async fn get_users(db: Data<Database>, query: Query<ListQuery>) -> Result<HttpResponse, AppError> {
     let list_query = query.into_inner();
     Ok(HttpResponse::Ok().json(db.get_users(list_query).await?))
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"

--- a/shared/src/api/list_query.rs
+++ b/shared/src/api/list_query.rs
@@ -70,4 +70,3 @@ fn encode_query_value(s: &str) -> String {
     }
     out
 }
-

--- a/shared/src/api/mod.rs
+++ b/shared/src/api/mod.rs
@@ -3,12 +3,12 @@ use crate::blob::{Blob, CreateBlob};
 use crate::collection::{Collection, CreateCollection};
 use crate::error::NetworkClientError;
 use crate::like::LikeStatus;
+use crate::net::HttpClient;
 #[cfg(any(
     all(feature = "cli", not(target_arch = "wasm32")),
     all(feature = "frontend", target_arch = "wasm32")
 ))]
 use crate::net::{DefaultHttpClient, HttpClientConfig};
-use crate::net::HttpClient;
 use crate::player::Player;
 use crate::setlist::{CreateSetlist, Setlist};
 use crate::song::{CreateSong, Song};
@@ -50,9 +50,7 @@ impl<C: HttpClient> ApiClient<C> {
         self.client.post("auth/otp/verify", &payload).await
     }
 
-    pub async fn get_openapi_docs(
-        &self,
-    ) -> Result<serde_json::Value, NetworkClientError> {
+    pub async fn get_openapi_docs(&self) -> Result<serde_json::Value, NetworkClientError> {
         self.client.get("api/docs/openapi.json").await
     }
 
@@ -70,10 +68,7 @@ impl<C: HttpClient> ApiClient<C> {
         self.client.get(&format!("api/v1/users/{id}")).await
     }
 
-    pub async fn list_users(
-        &self,
-        query: ListQuery,
-    ) -> Result<Vec<User>, NetworkClientError> {
+    pub async fn list_users(&self, query: ListQuery) -> Result<Vec<User>, NetworkClientError> {
         let path = format!("api/v1/users{}", query.to_query_string());
         self.client.get(&path).await
     }
@@ -146,10 +141,7 @@ impl<C: HttpClient> ApiClient<C> {
             .await
     }
 
-    pub async fn get_songs(
-        &self,
-        query: ListQuery,
-    ) -> Result<Vec<Song>, NetworkClientError> {
+    pub async fn get_songs(&self, query: ListQuery) -> Result<Vec<Song>, NetworkClientError> {
         let path = format!("api/v1/songs{}", query.to_query_string());
         self.client.get(&path).await
     }
@@ -308,10 +300,7 @@ impl<C: HttpClient> ApiClient<C> {
         self.client.delete(&format!("api/v1/setlists/{id}")).await
     }
 
-    pub async fn list_blobs(
-        &self,
-        query: ListQuery,
-    ) -> Result<Vec<Blob>, NetworkClientError> {
+    pub async fn list_blobs(&self, query: ListQuery) -> Result<Vec<Blob>, NetworkClientError> {
         let path = format!("api/v1/blobs{}", query.to_query_string());
         self.client.get(&path).await
     }

--- a/shared/src/error/mod.rs
+++ b/shared/src/error/mod.rs
@@ -64,4 +64,3 @@ impl From<gloo_net::Error> for NetworkClientError {
         }
     }
 }
-

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,5 +1,5 @@
-pub mod auth;
 pub mod api;
+pub mod auth;
 pub mod blob;
 pub mod collection;
 pub mod error;

--- a/shared/src/net/desktop.rs
+++ b/shared/src/net/desktop.rs
@@ -2,8 +2,8 @@ use reqwest::Client;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use crate::error::NetworkClientError;
 use super::{HttpClient, HttpClientConfig};
+use crate::error::NetworkClientError;
 
 #[derive(Clone)]
 pub struct DesktopHttpClient {
@@ -139,4 +139,3 @@ impl HttpClient for DesktopHttpClient {
         Ok(value)
     }
 }
-

--- a/shared/src/net/mod.rs
+++ b/shared/src/net/mod.rs
@@ -83,4 +83,3 @@ pub type DefaultHttpClient = DesktopHttpClient;
 
 #[cfg(all(feature = "frontend", target_arch = "wasm32"))]
 pub type DefaultHttpClient = WasmHttpClient;
-

--- a/shared/src/net/wasm.rs
+++ b/shared/src/net/wasm.rs
@@ -1,8 +1,8 @@
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use crate::error::NetworkClientError;
 use super::{HttpClient, HttpClientConfig};
+use crate::error::NetworkClientError;
 use web_sys::RequestCredentials;
 
 #[derive(Clone)]
@@ -156,4 +156,3 @@ impl HttpClient for WasmHttpClient {
         Ok(value)
     }
 }
-


### PR DESCRIPTION
## Summary

Adds a path-filtered GitHub Actions workflow for the Rust backend plus repo-root `rust-toolchain.toml`, and applies rustfmt to `backend/` and `shared/` so `cargo fmt --check` passes in CI.

## Changes

- **Workflow** (`.github/workflows/backend-ci.yml`): runs on `push` / `pull_request` to `main` when `backend/**`, `shared/**`, or `rust-toolchain.toml` change.
- **Steps**: `dtolnay/rust-toolchain@v1` (reads `rust-toolchain.toml`), `Swatinem/rust-cache@v2` with `workspaces: backend`, then `cargo build`, `cargo test`, `cargo clippy -- -D warnings` from `backend/`, and `cargo fmt --check` for both crates via `--manifest-path`.
- **No** `--locked`.
- **Formatting**: one-time rustfmt on backend and shared so the new fmt gate is green.

Fixes #46

## Verification

```text
cargo fmt --manifest-path backend/Cargo.toml --check
cargo fmt --manifest-path shared/Cargo.toml --check
cd backend && cargo clippy -- -D warnings
cd backend && cargo test
```