### PR TITLE
chore: upgrade chordlib to 0.8.0 and align song metadata with vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ cd frontend && \
     trunk serve --port 8081
 ```
 
+The in-app song editor expects **ChordPro** text (via **chordlib**). **Ultimate Guitar is not fetched over HTTP** by chordlib anymore: paste ChordPro you already have, or download UG/tab HTML yourself and convert outside the app.
+
 ### Serve Backend & Frontend on the Same Port (Caddy Reverse Proxy)
 
 ```bash

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -44,5 +44,5 @@ ring = "0.17.14"
 hex = "0.4.3"
 actix-files = "0.6.8"
 shared = { path = "../shared", features = ["backend"] }
-chordlib = { version = "0.7.0", features = ["html"] }
+chordlib = { version = "0.8.0", features = ["html"] }
 zip = "6.0.0"

--- a/backend/db-migrations/20260410140000_song_chordlib08_drop_scalar_metadata.surql
+++ b/backend/db-migrations/20260410140000_song_chordlib08_drop_scalar_metadata.surql
@@ -1,0 +1,46 @@
+-- chordlib 0.8 / issue #50: remove legacy scalar metadata on song.data; full-text indexes on titles/artists arrays.
+
+REMOVE INDEX IF EXISTS song_data_title_search_idx ON song;
+REMOVE INDEX IF EXISTS song_data_artist_search_idx ON song;
+
+UPDATE song SET data = data;
+
+DEFINE FUNCTION OVERWRITE fn::song_normalize_metadata_array($value: any, $before: any) -> array {
+    LET $arr = ($value ?? $before) ?? [];
+    LET $ne = fn::song_nonempty_strs($arr);
+    IF array::len($ne) > 0 {
+        RETURN $ne;
+    };
+    RETURN [""];
+};
+
+DEFINE FIELD OVERWRITE data.titles ON song TYPE array<string>
+    DEFAULT ALWAYS []
+    VALUE fn::song_normalize_metadata_array($value, $before)
+    ASSERT array::len($value) > 0;
+
+DEFINE FIELD OVERWRITE data.artists ON song TYPE array<string>
+    DEFAULT ALWAYS []
+    VALUE fn::song_normalize_metadata_array($value, $before)
+    ASSERT array::len($value) > 0;
+
+DEFINE FIELD OVERWRITE data.languages ON song TYPE array<string>
+    DEFAULT ALWAYS []
+    VALUE fn::song_normalize_metadata_array($value, $before)
+    ASSERT array::len($value) > 0;
+
+UPDATE song SET data = data;
+
+REMOVE FIELD IF EXISTS data.title ON song;
+REMOVE FIELD IF EXISTS data.artist ON song;
+REMOVE FIELD IF EXISTS data.language ON song;
+
+UPDATE song SET data = data;
+
+REMOVE FUNCTION IF EXISTS fn::song_coalesce_str_array;
+
+DEFINE INDEX OVERWRITE song_data_titles_search_idx ON song
+    FIELDS data.titles SEARCH ANALYZER text_search BM25;
+
+DEFINE INDEX OVERWRITE song_data_artists_search_idx ON song
+    FIELDS data.artists SEARCH ANALYZER text_search BM25;

--- a/backend/src/resources/song/export.rs
+++ b/backend/src/resources/song/export.rs
@@ -63,7 +63,7 @@ fn export_chord_pro(
                 header::CONTENT_DISPOSITION,
                 format!(
                     "attachment; filename=\"{0}.{ending}\"",
-                    sanitize_filename(&songs[0].data.title),
+                    sanitize_filename(songs[0].data.title()),
                 ),
             ))
             .body(songs[0].format_chord_pro(None, None, None, worship_pro_features)));
@@ -78,7 +78,7 @@ fn export_chord_pro(
 
     for song in &songs {
         zip.start_file(
-            format!("{}.{}", sanitize_filename(&song.data.title), ending),
+            format!("{}.{}", sanitize_filename(song.data.title()), ending),
             options,
         )
         .map_err(|err| AppError::Internal(err.to_string()))?;

--- a/backend/src/resources/song/model.rs
+++ b/backend/src/resources/song/model.rs
@@ -63,7 +63,7 @@ impl Model for Database {
         };
         if q_nonempty {
             query.push_str(
-                " AND (data.title @0@ $q OR data.artist @1@ $q OR search_content @2@ $q) ORDER BY score DESC",
+                " AND (data.titles @0@ $q OR data.artists @1@ $q OR search_content @2@ $q) ORDER BY score DESC",
             );
         }
         if pagination.to_offset_limit().is_some() {

--- a/backend/src/resources/song/rest.rs
+++ b/backend/src/resources/song/rest.rs
@@ -40,7 +40,7 @@ pub fn scope() -> Scope {
     params(
         ("page" = Option<u32>, Query, description = "Optional page index (zero-based)"),
         ("page_size" = Option<u32>, Query, description = "Optional page size (number of items per page)"),
-        ("q" = Option<String>, Query, description = "Full-text search query (title, artist, line lyrics); uses text_search analyzer (stemming)")
+        ("q" = Option<String>, Query, description = "Full-text search query (titles, artists, line lyrics); uses text_search analyzer (stemming)")
     ),
     responses(
         (status = 200, description = "Return all songs", body = [Song]),

--- a/backend/tests/collections.yml
+++ b/backend/tests/collections.yml
@@ -199,7 +199,8 @@ testcases:
           }
         assertions:
           - result.statuscode ShouldEqual 201
-          - result.bodyjson.data.title ShouldEqual "Collection Song One"
+          - result.bodyjson.data.titles ShouldHaveLength 1
+          - result.bodyjson.data.titles.bodyjson0 ShouldEqual "Collection Song One"
         vars:
           songid:
             from: result.bodyjson.id
@@ -223,7 +224,8 @@ testcases:
           }
         assertions:
           - result.statuscode ShouldEqual 201
-          - result.bodyjson.data.title ShouldEqual "Collection Song Two"
+          - result.bodyjson.data.titles ShouldHaveLength 1
+          - result.bodyjson.data.titles.bodyjson0 ShouldEqual "Collection Song Two"
         vars:
           songid:
             from: result.bodyjson.id

--- a/backend/tests/collections.yml
+++ b/backend/tests/collections.yml
@@ -169,7 +169,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "No Perm User Private Song",
+              "titles": ["No Perm User Private Song"],
               "sections": []
             }
           }
@@ -193,7 +193,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Collection Song One",
+              "titles": ["Collection Song One"],
               "sections": []
             }
           }
@@ -218,7 +218,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Collection Song Two",
+              "titles": ["Collection Song Two"],
               "sections": []
             }
           }

--- a/backend/tests/setlists.yml
+++ b/backend/tests/setlists.yml
@@ -149,7 +149,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Setlist Song One",
+              "titles": ["Setlist Song One"],
               "sections": []
             }
           }
@@ -174,7 +174,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Setlist Song Two",
+              "titles": ["Setlist Song Two"],
               "sections": []
             }
           }

--- a/backend/tests/setlists.yml
+++ b/backend/tests/setlists.yml
@@ -155,7 +155,8 @@ testcases:
           }
         assertions:
           - result.statuscode ShouldEqual 201
-          - result.bodyjson.data.title ShouldEqual "Setlist Song One"
+          - result.bodyjson.data.titles ShouldHaveLength 1
+          - result.bodyjson.data.titles.bodyjson0 ShouldEqual "Setlist Song One"
         vars:
           songid:
             from: result.bodyjson.id
@@ -179,7 +180,8 @@ testcases:
           }
         assertions:
           - result.statuscode ShouldEqual 201
-          - result.bodyjson.data.title ShouldEqual "Setlist Song Two"
+          - result.bodyjson.data.titles ShouldHaveLength 1
+          - result.bodyjson.data.titles.bodyjson0 ShouldEqual "Setlist Song Two"
         vars:
           songid:
             from: result.bodyjson.id

--- a/backend/tests/songs.yml
+++ b/backend/tests/songs.yml
@@ -558,7 +558,8 @@ testcases:
         assertions:
           - result.statuscode ShouldEqual 201
           - result.bodyjson.owner ShouldEqual "{{.create-song-owner-user.userid}}"
-          - result.bodyjson.data.title ShouldEqual "Test Song"
+          - result.bodyjson.data.titles ShouldHaveLength 1
+          - result.bodyjson.data.titles.bodyjson0 ShouldEqual "Test Song"
         vars:
           songid:
             from: result.bodyjson.id
@@ -582,7 +583,8 @@ testcases:
           }
         assertions:
           - result.statuscode ShouldEqual 201
-          - result.bodyjson.data.title ShouldEqual "Song For Read Permission"
+          - result.bodyjson.data.titles ShouldHaveLength 1
+          - result.bodyjson.data.titles.bodyjson0 ShouldEqual "Song For Read Permission"
         vars:
           songid:
             from: result.bodyjson.id
@@ -606,7 +608,8 @@ testcases:
           }
         assertions:
           - result.statuscode ShouldEqual 201
-          - result.bodyjson.data.title ShouldEqual "Song For Write Permission"
+          - result.bodyjson.data.titles ShouldHaveLength 1
+          - result.bodyjson.data.titles.bodyjson0 ShouldEqual "Song For Write Permission"
         vars:
           songid:
             from: result.bodyjson.id
@@ -890,8 +893,8 @@ testcases:
           - result.statuscode ShouldEqual 200
           - result.bodyjson.id ShouldEqual "{{.post-song-success.songid}}"
           - result.bodyjson.owner ShouldEqual "{{.create-song-owner-user.userid}}"
-          - result.bodyjson.data.title ShouldEqual "Test Song"
-
+          - result.bodyjson.data.titles ShouldHaveLength 1
+          - result.bodyjson.data.titles.bodyjson0 ShouldEqual "Test Song"
   - name: get-song-success-with-read-permission
     steps:
       - type: http
@@ -902,8 +905,8 @@ testcases:
         assertions:
           - result.statuscode ShouldEqual 200
           - result.bodyjson.id ShouldEqual "{{.post-song-success-for-read-permission.songid}}"
-          - result.bodyjson.data.title ShouldEqual "Song For Read Permission"
-
+          - result.bodyjson.data.titles ShouldHaveLength 1
+          - result.bodyjson.data.titles.bodyjson0 ShouldEqual "Song For Read Permission"
   - name: get-song-invalid-id
     steps:
       - type: http
@@ -1122,8 +1125,8 @@ testcases:
         assertions:
           - result.statuscode ShouldEqual 200
           - result.bodyjson.id ShouldEqual "{{.post-song-success.songid}}"
-          - result.bodyjson.data.title ShouldEqual "Updated Test Song"
-
+          - result.bodyjson.data.titles ShouldHaveLength 1
+          - result.bodyjson.data.titles.bodyjson0 ShouldEqual "Updated Test Song"
   - name: put-song-success-with-write-permission
     steps:
       - type: http
@@ -1143,8 +1146,8 @@ testcases:
           }
         assertions:
           - result.statuscode ShouldEqual 200
-          - result.bodyjson.data.title ShouldEqual "Updated By Write User"
-
+          - result.bodyjson.data.titles ShouldHaveLength 1
+          - result.bodyjson.data.titles.bodyjson0 ShouldEqual "Updated By Write User"
   - name: put-song-invalid-id
     steps:
       - type: http
@@ -1323,7 +1326,8 @@ testcases:
         assertions:
           - result.statuscode ShouldEqual 200
           - result.bodyjson.id ShouldEqual "new-song-id"
-          - result.bodyjson.data.title ShouldEqual "Created By PUT"
+          - result.bodyjson.data.titles ShouldHaveLength 1
+          - result.bodyjson.data.titles.bodyjson0 ShouldEqual "Created By PUT"
           - result.bodyjson.owner ShouldEqual "{{.create-song-owner-user.userid}}"
 
   - name: put-song-create-with-write-permission
@@ -1346,7 +1350,8 @@ testcases:
         assertions:
           - result.statuscode ShouldEqual 200
           - result.bodyjson.id ShouldEqual "new-song-by-write-user"
-          - result.bodyjson.data.title ShouldEqual "Created By Write User Via PUT"
+          - result.bodyjson.data.titles ShouldHaveLength 1
+          - result.bodyjson.data.titles.bodyjson0 ShouldEqual "Created By Write User Via PUT"
           - result.bodyjson.owner ShouldEqual "{{.create-write-user.userid}}"
 
   - name: put-song-create-no-permission

--- a/backend/tests/songs.yml
+++ b/backend/tests/songs.yml
@@ -149,8 +149,8 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "VenomsTitleTokenX9 Alpha",
-              "artist": "Other Person",
+              "titles": ["VenomsTitleTokenX9 Alpha"],
+              "artists": ["Other Person"],
               "sections": [
                 {
                   "title": "V",
@@ -184,8 +184,8 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Unrelated Beta Title",
-              "artist": "VenomsArtistTokenX9 Singer",
+              "titles": ["Unrelated Beta Title"],
+              "artists": ["VenomsArtistTokenX9 Singer"],
               "sections": [
                 {
                   "title": "V",
@@ -219,8 +219,8 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Gamma Unrelated Title",
-              "artist": "Gamma Band",
+              "titles": ["Gamma Unrelated Title"],
+              "artists": ["Gamma Band"],
               "sections": [
                 {
                   "title": "V",
@@ -254,8 +254,8 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Rank VenomsRankCoreX9 Titlefield",
-              "artist": "Rank Other",
+              "titles": ["Rank VenomsRankCoreX9 Titlefield"],
+              "artists": ["Rank Other"],
               "sections": [
                 {
                   "title": "V",
@@ -289,8 +289,8 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Rank Neutral Titlefield Two",
-              "artist": "VenomsRankCoreX9 Artistfield",
+              "titles": ["Rank Neutral Titlefield Two"],
+              "artists": ["VenomsRankCoreX9 Artistfield"],
               "sections": [
                 {
                   "title": "V",
@@ -324,8 +324,8 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Rank Neutral Titlefield Three",
-              "artist": "Rank Neutral Artist",
+              "titles": ["Rank Neutral Titlefield Three"],
+              "artists": ["Rank Neutral Artist"],
               "sections": [
                 {
                   "title": "V",
@@ -359,8 +359,8 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Stem Plural Stored Title",
-              "artist": "Stem Artist",
+              "titles": ["Stem Plural Stored Title"],
+              "artists": ["Stem Artist"],
               "sections": [
                 {
                   "title": "V",
@@ -394,8 +394,8 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Stem Singular Stored Title",
-              "artist": "Stem Artist Two",
+              "titles": ["Stem Singular Stored Title"],
+              "artists": ["Stem Artist Two"],
               "sections": [
                 {
                   "title": "V",
@@ -551,7 +551,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Test Song",
+              "titles": ["Test Song"],
               "sections": []
             }
           }
@@ -577,7 +577,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Song For Read Permission",
+              "titles": ["Song For Read Permission"],
               "sections": []
             }
           }
@@ -602,7 +602,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Song For Write Permission",
+              "titles": ["Song For Write Permission"],
               "sections": []
             }
           }
@@ -630,7 +630,7 @@ testcases:
         assertions:
           - result.statuscode ShouldEqual 400
 
-  - name: post-song-invalid-payload-missing-title
+  - name: post-song-invalid-payload-empty-data
     steps:
       - type: http
         method: POST
@@ -660,7 +660,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Test Song",
+              "titles": ["Test Song"],
               "sections": [],
               "tempo": -1
             }
@@ -681,7 +681,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Test Song",
+              "titles": ["Test Song"],
               "sections": [],
               "time": [4, 4, 4]
             }
@@ -701,7 +701,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Test Song",
+              "titles": ["Test Song"],
               "sections": []
             }
           }
@@ -721,7 +721,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Test Song",
+              "titles": ["Test Song"],
               "sections": []
             }
           }
@@ -741,7 +741,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Test Song",
+              "titles": ["Test Song"],
               "sections": [],
               "tempo": "fast"
             }
@@ -1118,7 +1118,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Updated Test Song",
+              "titles": ["Updated Test Song"],
               "sections": []
             }
           }
@@ -1140,7 +1140,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Updated By Write User",
+              "titles": ["Updated By Write User"],
               "sections": []
             }
           }
@@ -1161,7 +1161,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Test",
+              "titles": ["Test"],
               "sections": []
             }
           }
@@ -1198,7 +1198,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Song For Read Permission",
+              "titles": ["Song For Read Permission"],
               "sections": [],
               "tempo": "slow"
             }
@@ -1218,7 +1218,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Test",
+              "titles": ["Test"],
               "sections": []
             }
           }
@@ -1238,7 +1238,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Test",
+              "titles": ["Test"],
               "sections": []
             }
           }
@@ -1258,7 +1258,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Test",
+              "titles": ["Test"],
               "sections": []
             }
           }
@@ -1278,7 +1278,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Test",
+              "titles": ["Test"],
               "sections": []
             }
           }
@@ -1298,7 +1298,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Test",
+              "titles": ["Test"],
               "sections": []
             }
           }
@@ -1319,7 +1319,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Created By PUT",
+              "titles": ["Created By PUT"],
               "sections": []
             }
           }
@@ -1343,7 +1343,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Created By Write User Via PUT",
+              "titles": ["Created By Write User Via PUT"],
               "sections": []
             }
           }
@@ -1367,7 +1367,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Should Not Be Created",
+              "titles": ["Should Not Be Created"],
               "sections": []
             }
           }
@@ -1389,7 +1389,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Song To Delete",
+              "titles": ["Song To Delete"],
               "sections": []
             }
           }
@@ -1412,7 +1412,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Song To Delete By Write User",
+              "titles": ["Song To Delete By Write User"],
               "sections": []
             }
           }
@@ -1546,7 +1546,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Cascade Song Target",
+              "titles": ["Cascade Song Target"],
               "sections": []
             }
           }
@@ -1662,7 +1662,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Cascade Song Target Recreated",
+              "titles": ["Cascade Song Target Recreated"],
               "sections": []
             }
           }
@@ -1766,7 +1766,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Song For Likes",
+              "titles": ["Song For Likes"],
               "sections": []
             }
           }
@@ -1968,7 +1968,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Default Collection Song One",
+              "titles": ["Default Collection Song One"],
               "sections": []
             }
           }
@@ -1992,7 +1992,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Default Collection Song Two",
+              "titles": ["Default Collection Song Two"],
               "sections": []
             }
           }

--- a/backend/tests/users.yml
+++ b/backend/tests/users.yml
@@ -373,7 +373,7 @@ testcases:
             "not_a_song": false,
             "blobs": [],
             "data": {
-              "title": "Cascade Song",
+              "titles": ["Cascade Song"],
               "sections": []
             }
           }

--- a/frontend/src/components/editor/code_mirror_after.css
+++ b/frontend/src/components/editor/code_mirror_after.css
@@ -14,3 +14,12 @@
   border: unset;
 }
 
+/* Chords on & translation lines — parser .cm-* may lose to `* { color: unset }` in code_mirror_before.css. */
+.CodeMirror .cm-chord-translation {
+  color: #b57614 !important;
+}
+.CodeMirror .cm-nashville-translation {
+  color: #c35d1d !important;
+  font-weight: 600;
+}
+

--- a/frontend/src/components/editor/code_mirror_wrapper.js
+++ b/frontend/src/components/editor/code_mirror_wrapper.js
@@ -77,11 +77,17 @@ export class CodeMirrorWrapper {
                         metaSplitPhase: null,
                         /** True once a non-whitespace key character was emitted (leading spaces after `:` are skipped). */
                         metaKeySeenNonWs: false,
+                        /** Line begins with optional spaces then `&` (chordlib translation line). */
+                        translationLine: false,
+                        /** The next `&` on this translation line is the marker (green), not lyric text. */
+                        translationPendingAmp: false,
+                        /** Chord span was opened from a `&…` translation line (darker chord yellow). */
+                        chordOnTranslationLine: false,
                     };
                 },
                 token: (stream, state) => {
                     while (true) {
-                        // {meta: tag value} — tag blue (meta-tag-key), value green (meta-value)
+                        // {meta: tag value} — tag same green as directives (meta-tag-key), value gray like translation lines (meta-keypair-value)
                         if (state.state === "meta-value" && state.metaSplitPhase === "key") {
                             const ch = stream.next();
                             if (ch === undefined) return null;
@@ -115,7 +121,36 @@ export class CodeMirrorWrapper {
                                 continue;
                             }
                             state.parsed = "";
-                            return "meta-value";
+                            return "meta-keypair-value";
+                        }
+
+                        // Lines like `&[E]Du hast…` — marker `&` green, lyrics gray; `[…]` chords use darker yellow.
+                        if (state.state === "default") {
+                            if (stream.sol()) {
+                                const isTrans = stream.match(/^[ \t]*&/, false) != null;
+                                state.translationLine = isTrans;
+                                state.translationPendingAmp = isTrans;
+                            }
+                        }
+                        if (state.state === "default" && state.translationLine) {
+                            const p = stream.peek();
+                            if (p === "\n") {
+                                stream.next();
+                                state.translationLine = false;
+                                state.translationPendingAmp = false;
+                                state.parsed = "";
+                                return null;
+                            }
+                            if (p !== "[" && p !== "{") {
+                                const chT = stream.next();
+                                state.parsed = "";
+                                if (chT === "&" && state.translationPendingAmp) {
+                                    state.translationPendingAmp = false;
+                                    state.translationLine = true;
+                                    return "meta-value";
+                                }
+                                return "translation-lyric";
+                            }
                         }
 
                         const ch = stream.next();
@@ -154,6 +189,13 @@ export class CodeMirrorWrapper {
                                     if (transition.new_state === "chord" && prevState !== "chord") {
                                         state.chordAcc = "";
                                     }
+                                    if (transition.state === "default" && transition.new_state === "meta-begin") {
+                                        state.metaSplitPhase = null;
+                                        state.metaKeySeenNonWs = false;
+                                    }
+                                    if (transition.state === "default" && transition.new_state === "chord") {
+                                        state.chordOnTranslationLine = state.translationLine;
+                                    }
                                 }
                                 if (transition.label !== null) {
                                     if (
@@ -174,8 +216,25 @@ export class CodeMirrorWrapper {
                                     ) {
                                         label = "nashville";
                                     }
+                                    if (state.chordOnTranslationLine) {
+                                        if (
+                                            label === "default" &&
+                                            transition.state === "default" &&
+                                            transition.new_state === "chord" &&
+                                            transition.suffix === "["
+                                        ) {
+                                            label = "chord-translation";
+                                        } else if (label === "chord") {
+                                            label = "chord-translation";
+                                        } else if (label === "nashville") {
+                                            label = "nashville-translation";
+                                        }
+                                    }
                                     if (transition.suffix === "]") {
                                         state.chordAcc = "";
+                                    }
+                                    if (transition.state === "chord" && transition.new_state === "default") {
+                                        state.chordOnTranslationLine = false;
                                     }
                                     state.parsed = "";
                                     return label;

--- a/frontend/src/components/editor/code_mirror_wrapper.js
+++ b/frontend/src/components/editor/code_mirror_wrapper.js
@@ -71,14 +71,62 @@ export class CodeMirrorWrapper {
                     return {
                         state: "default",
                         parsed: "",
+                        /** Text inside the current `[` … `]` chord span (chordlib / Nashville / duration). */
+                        chordAcc: "",
+                        /** After `{meta:`, color tag name vs value (`key` → blue, `value` → green). */
+                        metaSplitPhase: null,
+                        /** True once a non-whitespace key character was emitted (leading spaces after `:` are skipped). */
+                        metaKeySeenNonWs: false,
                     };
                 },
                 token: (stream, state) => {
                     while (true) {
+                        // {meta: tag value} — tag blue (meta-tag-key), value green (meta-value)
+                        if (state.state === "meta-value" && state.metaSplitPhase === "key") {
+                            const ch = stream.next();
+                            if (ch === undefined) return null;
+                            if (ch === "}") {
+                                stream.backUp(1);
+                                state.metaSplitPhase = null;
+                                state.metaKeySeenNonWs = false;
+                                continue;
+                            }
+                            if (/\s/.test(ch)) {
+                                if (!state.metaKeySeenNonWs) {
+                                    state.parsed = "";
+                                    return null;
+                                }
+                                state.metaSplitPhase = "value";
+                                state.metaKeySeenNonWs = false;
+                                state.parsed = "";
+                                return null;
+                            }
+                            state.metaKeySeenNonWs = true;
+                            state.parsed = "";
+                            return "meta-tag-key";
+                        }
+                        if (state.state === "meta-value" && state.metaSplitPhase === "value") {
+                            const ch = stream.next();
+                            if (ch === undefined) return null;
+                            if (ch === "}") {
+                                stream.backUp(1);
+                                state.metaSplitPhase = null;
+                                state.metaKeySeenNonWs = false;
+                                continue;
+                            }
+                            state.parsed = "";
+                            return "meta-value";
+                        }
+
                         const ch = stream.next();
                         if (ch === undefined) return null;
 
+                        const prevState = state.state;
                         state.parsed += ch;
+
+                        if (state.state === "chord" && ch !== "]") {
+                            state.chordAcc += ch;
+                        }
 
                         for (const transition of transitions) {
                             if (state.state === transition.state && state.parsed.endsWith(transition.suffix)) {
@@ -86,10 +134,51 @@ export class CodeMirrorWrapper {
                                     state.parsed = state.parsed.slice(0, -transition.back);
                                     stream.backUp(transition.back);
                                 }
-                                if (transition.new_state !== null) state.state = transition.new_state;
+                                if (transition.new_state !== null) {
+                                    state.state = transition.new_state;
+                                    if (transition.state === "meta-key" && transition.new_state === "meta-middle") {
+                                        state.metaSplitPhase =
+                                            transition.suffix === "meta:" ? "key" : null;
+                                        if (state.metaSplitPhase === "key") {
+                                            state.metaKeySeenNonWs = false;
+                                        }
+                                    }
+                                    if (transition.new_state === "meta-end") {
+                                        state.metaSplitPhase = null;
+                                        state.metaKeySeenNonWs = false;
+                                    }
+                                    if (transition.new_state === "default") {
+                                        state.metaSplitPhase = null;
+                                        state.metaKeySeenNonWs = false;
+                                    }
+                                    if (transition.new_state === "chord" && prevState !== "chord") {
+                                        state.chordAcc = "";
+                                    }
+                                }
                                 if (transition.label !== null) {
+                                    if (
+                                        state.metaSplitPhase === "key" &&
+                                        transition.state === "meta-middle" &&
+                                        transition.new_state === "meta-value" &&
+                                        transition.suffix === ""
+                                    ) {
+                                        state.parsed = "";
+                                        break;
+                                    }
+                                    let label = transition.label;
+                                    if (
+                                        label === "chord" &&
+                                        transition.suffix === "]" &&
+                                        state.chordAcc.length > 0 &&
+                                        /^\d/.test(state.chordAcc)
+                                    ) {
+                                        label = "nashville";
+                                    }
+                                    if (transition.suffix === "]") {
+                                        state.chordAcc = "";
+                                    }
                                     state.parsed = "";
-                                    return transition.label;
+                                    return label;
                                 }
                                 break;
                             }

--- a/frontend/src/components/presenter/presenter.rs
+++ b/frontend/src/components/presenter/presenter.rs
@@ -418,7 +418,7 @@ pub fn presenter(props: &PresenterProps) -> Html {
                                 .songs
                                 .iter()
                                 .enumerate()
-                                .map(|(idx, song)| TocItem { idx, text: format!("{}. {}", idx + 1, song.data.title) })
+                                .map(|(idx, song)| TocItem { idx, text: format!("{}. {}", idx + 1, song.data.title()) })
                                 .collect::<Vec<TocItem>>()
                             }
                             select={set_current_song.clone()}
@@ -432,7 +432,7 @@ pub fn presenter(props: &PresenterProps) -> Html {
                                     .songs
                                     .iter()
                                     .enumerate()
-                                    .map(|(idx, song)| TocItem { idx, text: song.data.title.clone() })
+                                    .map(|(idx, song)| TocItem { idx, text: song.data.title().to_string() })
                                     .collect::<Vec<TocItem>>();
                                 items.sort_by_key(|item| item.text.clone());
                                 items
@@ -449,7 +449,7 @@ pub fn presenter(props: &PresenterProps) -> Html {
                                 .iter()
                                 .enumerate()
                                 .filter(|(_, song)| song.user_specific_addons.liked)
-                                .map(|(idx, song)| TocItem { idx, text: song.data.title.clone() })
+                                .map(|(idx, song)| TocItem { idx, text: song.data.title().to_string() })
                                 .collect::<Vec<TocItem>>();
                             items.sort_by_key(|item| item.text.clone());
                             items

--- a/frontend/src/components/setlist_editor.rs
+++ b/frontend/src/components/setlist_editor.rs
@@ -91,7 +91,7 @@ pub fn setlist_editor(props: &Props) -> Html {
             let api = api.clone();
             wasm_bindgen_futures::spawn_local(async move {
                 let mut fetched_songs = api.get_songs().await.unwrap();
-                fetched_songs.sort_by_key(|song| song.data.title.clone());
+                fetched_songs.sort_by_key(|song| song.data.title().to_string());
                 let fetched_songs: Vec<Song> = fetched_songs
                     .into_iter()
                     .filter(|song| !song.not_a_song)
@@ -102,7 +102,7 @@ pub fn setlist_editor(props: &Props) -> Html {
                         (
                             song.id.clone(),
                             (
-                                song.data.title.clone(),
+                                song.data.title().to_string(),
                                 song.data.key.as_ref().map(|key| format_key_label(key)),
                             ),
                         )
@@ -194,7 +194,11 @@ pub fn setlist_editor(props: &Props) -> Html {
         .iter()
         .filter(|song| {
             if has_filter {
-                song.data.title.to_lowercase().contains(&search_term)
+                song
+                    .data
+                    .title()
+                    .to_lowercase()
+                    .contains(&search_term)
             } else {
                 true
             }
@@ -664,7 +668,7 @@ pub fn setlist_editor(props: &Props) -> Html {
                                     {
                                         for filtered_songs.iter().map(|song| {
                                             let id = song.id.clone();
-                                            let song_title = song.data.title.clone();
+                                            let song_title = song.data.title().to_string();
                                             let song_key_label = song
                                                 .data
                                                 .key

--- a/frontend/src/components/setlist_editor.rs
+++ b/frontend/src/components/setlist_editor.rs
@@ -194,11 +194,7 @@ pub fn setlist_editor(props: &Props) -> Html {
         .iter()
         .filter(|song| {
             if has_filter {
-                song
-                    .data
-                    .title()
-                    .to_lowercase()
-                    .contains(&search_term)
+                song.data.title().to_lowercase().contains(&search_term)
             } else {
                 true
             }

--- a/frontend/src/components/song_editor.rs
+++ b/frontend/src/components/song_editor.rs
@@ -9,7 +9,7 @@ use yew_hooks::use_size;
 
 /// ChordPro highlighting for [chordlib](https://crates.io/crates/chordlib) 0.8+ directives:
 /// indexed `title`/`artist`/`language`, `{meta: …}`, `{repeat: N}`, `subtitle`, `copyright`,
-/// plus Nashville-style `[1]`… chords (see `code_mirror_wrapper.js`).
+/// Nashville-style `[1]`… chords, and translation lines starting with `&` (see `code_mirror_wrapper.js`).
 fn chordpro_syntax_parser() -> SyntaxParser {
     const TITLE_N: &[&str] = &[
         "title2:", "title3:", "title4:", "title5:", "title6:", "title7:", "title8:", "title9:",
@@ -63,7 +63,10 @@ fn chordpro_syntax_parser() -> SyntaxParser {
         .transition("meta-middle", ":", "meta-middle", None, 0)
         .transition("meta-middle", "}", "meta-end", None, 1)
         .transition("meta-middle", "", "meta-value", Some("meta-surround"), 1)
+        // Per-character styling for directive values (`{title: …}` etc.); `}` must match before `""`.
+        // `back` must be 0 here: `back > 0` would back up after match and violate CodeMirror’s “stream must advance” rule.
         .transition("meta-value", "}", "meta-end", Some("meta-value"), 1)
+        .transition("meta-value", "", "meta-value", Some("meta-value"), 0)
         .transition("meta-end", "}", "default", Some("meta-surround"), 0)
         .transition("default", "[", "chord", Some("default"), 1)
         .transition("chord", "[", "chord", None, 0)
@@ -73,11 +76,12 @@ fn chordpro_syntax_parser() -> SyntaxParser {
         .label_style("meta-key-error", "text-decoration", "underline")
         .label_style("meta-key-error", "text-decoration-color", "#cc241d")
         .label_style("meta-value", "color", "#98971a")
-        .label_style("meta-tag-key", "color", "#458588")
-        .label_style("meta-tag-key", "font-weight", "600")
+        .label_style("meta-keypair-value", "color", "#928374")
+        .label_style("meta-tag-key", "color", "#98971a")
         .label_style("chord", "color", "#d79921")
         .label_style("nashville", "color", "#fe8019")
         .label_style("nashville", "font-weight", "600")
+        .label_style("translation-lyric", "color", "#928374")
         .build()
         .expect("static parser should build")
 }

--- a/frontend/src/components/song_editor.rs
+++ b/frontend/src/components/song_editor.rs
@@ -7,6 +7,81 @@ use stylist::Style;
 use yew::prelude::*;
 use yew_hooks::use_size;
 
+/// ChordPro highlighting for [chordlib](https://crates.io/crates/chordlib) 0.8+ directives:
+/// indexed `title`/`artist`/`language`, `{meta: …}`, `{repeat: N}`, `subtitle`, `copyright`,
+/// plus Nashville-style `[1]`… chords (see `code_mirror_wrapper.js`).
+fn chordpro_syntax_parser() -> SyntaxParser {
+    const TITLE_N: &[&str] = &[
+        "title2:", "title3:", "title4:", "title5:", "title6:", "title7:", "title8:", "title9:",
+    ];
+    const ARTIST_N: &[&str] = &[
+        "artist2:", "artist3:", "artist4:", "artist5:", "artist6:", "artist7:", "artist8:",
+        "artist9:",
+    ];
+    const LANGUAGE_N: &[&str] = &[
+        "language2:",
+        "language3:",
+        "language4:",
+        "language5:",
+        "language6:",
+        "language7:",
+        "language8:",
+        "language9:",
+    ];
+
+    let mut b = SyntaxParser::builder()
+        .transition("default", "{", "meta-begin", Some("default"), 1)
+        .transition("meta-begin", "{", "meta-begin", None, 0)
+        .transition("meta-begin", ":", "meta-middle", None, 1)
+        .transition("meta-begin", "}", "meta-end", None, 1)
+        .transition("meta-begin", "", "meta-key", Some("meta-surround"), 1)
+        .transition("meta-key", "title:", "meta-middle", Some("meta-key"), 1)
+        .transition("meta-key", "artist:", "meta-middle", Some("meta-key"), 1)
+        .transition("meta-key", "key:", "meta-middle", Some("meta-key"), 1)
+        .transition("meta-key", "section:", "meta-middle", Some("meta-key"), 1)
+        .transition("meta-key", "language:", "meta-middle", Some("meta-key"), 1)
+        .transition("meta-key", "tempo:", "meta-middle", Some("meta-key"), 1)
+        .transition("meta-key", "time:", "meta-middle", Some("meta-key"), 1)
+        .transition("meta-key", "comment:", "meta-middle", Some("meta-key"), 1);
+
+    for k in TITLE_N {
+        b = b.transition("meta-key", k, "meta-middle", Some("meta-key"), 1);
+    }
+    for k in ARTIST_N {
+        b = b.transition("meta-key", k, "meta-middle", Some("meta-key"), 1);
+    }
+    for k in LANGUAGE_N {
+        b = b.transition("meta-key", k, "meta-middle", Some("meta-key"), 1);
+    }
+
+    b.transition("meta-key", "repeat:", "meta-middle", Some("meta-key"), 1)
+        .transition("meta-key", "meta:", "meta-middle", Some("meta-key"), 1)
+        .transition("meta-key", "subtitle:", "meta-middle", Some("meta-key"), 1)
+        .transition("meta-key", "copyright:", "meta-middle", Some("meta-key"), 1)
+        .transition("meta-key", ":", "meta-middle", Some("meta-key-error"), 1)
+        .transition("meta-key", "}", "meta-end", Some("meta-key"), 1)
+        .transition("meta-middle", ":", "meta-middle", None, 0)
+        .transition("meta-middle", "}", "meta-end", None, 1)
+        .transition("meta-middle", "", "meta-value", Some("meta-surround"), 1)
+        .transition("meta-value", "}", "meta-end", Some("meta-value"), 1)
+        .transition("meta-end", "}", "default", Some("meta-surround"), 0)
+        .transition("default", "[", "chord", Some("default"), 1)
+        .transition("chord", "[", "chord", None, 0)
+        .transition("chord", "]", "default", Some("chord"), 0)
+        .label_style("meta-surround", "font-weight", "bold")
+        .label_style("meta-key", "color", "#cc241d")
+        .label_style("meta-key-error", "text-decoration", "underline")
+        .label_style("meta-key-error", "text-decoration-color", "#cc241d")
+        .label_style("meta-value", "color", "#98971a")
+        .label_style("meta-tag-key", "color", "#458588")
+        .label_style("meta-tag-key", "font-weight", "600")
+        .label_style("chord", "color", "#d79921")
+        .label_style("nashville", "color", "#fe8019")
+        .label_style("nashville", "font-weight", "600")
+        .build()
+        .expect("static parser should build")
+}
+
 #[derive(Clone, PartialEq)]
 pub struct SongSavePayload {
     pub id: Option<String>,
@@ -106,38 +181,7 @@ pub fn song_editor(props: &Props) -> Html {
         })
     };
 
-    let syntax_parser = SyntaxParser::builder()
-        .transition("default", "{", "meta-begin", Some("default"), 1)
-        .transition("meta-begin", "{", "meta-begin", None, 0)
-        .transition("meta-begin", ":", "meta-middle", None, 1)
-        .transition("meta-begin", "}", "meta-end", None, 1)
-        .transition("meta-begin", "", "meta-key", Some("meta-surround"), 1)
-        .transition("meta-key", "title:", "meta-middle", Some("meta-key"), 1)
-        .transition("meta-key", "artist:", "meta-middle", Some("meta-key"), 1)
-        .transition("meta-key", "key:", "meta-middle", Some("meta-key"), 1)
-        .transition("meta-key", "section:", "meta-middle", Some("meta-key"), 1)
-        .transition("meta-key", "language:", "meta-middle", Some("meta-key"), 1)
-        .transition("meta-key", "tempo:", "meta-middle", Some("meta-key"), 1)
-        .transition("meta-key", "time:", "meta-middle", Some("meta-key"), 1)
-        .transition("meta-key", "comment:", "meta-middle", Some("meta-key"), 1)
-        .transition("meta-key", ":", "meta-middle", Some("meta-key-error"), 1)
-        .transition("meta-key", "}", "meta-end", Some("meta-key"), 1)
-        .transition("meta-middle", ":", "meta-middle", None, 0)
-        .transition("meta-middle", "}", "meta-end", None, 1)
-        .transition("meta-middle", "", "meta-value", Some("meta-surround"), 1)
-        .transition("meta-value", "}", "meta-end", Some("meta-value"), 1)
-        .transition("meta-end", "}", "default", Some("meta-surround"), 0)
-        .transition("default", "[", "chord", Some("default"), 1)
-        .transition("chord", "[", "chord", None, 0)
-        .transition("chord", "]", "default", Some("chord"), 0)
-        .label_style("meta-surround", "font-weight", "bold")
-        .label_style("meta-key", "color", "#cc241d")
-        .label_style("meta-key-error", "text-decoration", "underline")
-        .label_style("meta-key-error", "text-decoration-color", "#cc241d")
-        .label_style("meta-value", "color", "#98971a")
-        .label_style("chord", "color", "#d79921")
-        .build()
-        .expect("static parser should build");
+    let syntax_parser = chordpro_syntax_parser();
 
     let mut viewer_song = Song::from(props.song.clone());
     viewer_song.id = props.song_id.clone().unwrap_or_default();

--- a/frontend/src/pages/editor.rs
+++ b/frontend/src/pages/editor.rs
@@ -86,7 +86,7 @@ pub fn editor_page() -> Html {
                     song_handle.set(Some(updated.into()));
                 });
             } else {
-                if data.data.title.is_empty() {
+                if data.data.title().is_empty() {
                     return;
                 }
                 let api = api.clone();

--- a/frontend/src/pages/songs.rs
+++ b/frontend/src/pages/songs.rs
@@ -19,7 +19,7 @@ pub fn songs_page() -> Html {
             let api = api.clone();
             wasm_bindgen_futures::spawn_local(async move {
                 let mut fetched_songs = api.get_songs().await.unwrap();
-                fetched_songs.sort_by_key(|song| song.data.title.clone());
+                fetched_songs.sort_by_key(|song| song.data.title().to_string());
                 let fetched_songs: Vec<Song> = fetched_songs
                     .into_iter()
                     .filter(|song| !song.not_a_song)
@@ -35,7 +35,7 @@ pub fn songs_page() -> Html {
     let song_cards = songs
         .iter()
         .map(|song| {
-            let title = song.data.title.clone();
+            let title = song.data.title().to_string();
             let key = song
                 .data
                 .key

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chordlib = { version = "0.7.0", features = ["html"] }
+chordlib = { version = "0.8.0", features = ["html"] }
 chrono = { version = "0.4.42", default-features = false, features = [
     "clock",
     "serde",

--- a/shared/src/player/player.rs
+++ b/shared/src/player/player.rs
@@ -336,7 +336,7 @@ impl From<SongLinkOwned> for Player {
             } else {
                 vec![TocItem {
                     idx: 0,
-                    title: link.song.data.title,
+                    title: link.song.data.title().to_string(),
                     id: Some(link.song.id.clone()),
                     nr: link.nr.clone().unwrap_or_default(),
                     liked: link.liked,

--- a/shared/src/song/song.rs
+++ b/shared/src/song/song.rs
@@ -1,11 +1,63 @@
 use chordlib::inputs::chord_pro;
 use chordlib::outputs::{FormatChordPro, FormatHTML};
 use chordlib::types::{ChordRepresentation, SimpleChord, Song as SongData};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::convert::TryFrom;
 
 #[cfg(feature = "backend")]
 use utoipa::ToSchema;
+
+fn deserialize_song_data_compat<'de, D>(deserializer: D) -> Result<SongData, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::Error;
+
+    let mut v = serde_json::Value::deserialize(deserializer)?;
+    if let Some(obj) = v.as_object_mut() {
+        let titles_empty = match obj.get("titles") {
+            None => true,
+            Some(t) => t.as_array().map_or(true, Vec::is_empty),
+        };
+        if titles_empty {
+            if let Some(serde_json::Value::String(s)) = obj.remove("title") {
+                obj.insert("titles".to_string(), serde_json::json!([s]));
+            }
+        } else {
+            obj.remove("title");
+        }
+
+        let artists_empty = match obj.get("artists") {
+            None => true,
+            Some(t) => t.as_array().map_or(true, Vec::is_empty),
+        };
+        if artists_empty {
+            if let Some(serde_json::Value::String(s)) = obj.remove("artist") {
+                if !s.is_empty() {
+                    obj.insert("artists".to_string(), serde_json::json!([s]));
+                }
+            }
+        } else {
+            obj.remove("artist");
+        }
+
+        let languages_empty = match obj.get("languages") {
+            None => true,
+            Some(t) => t.as_array().map_or(true, Vec::is_empty),
+        };
+        if languages_empty {
+            if let Some(serde_json::Value::String(s)) = obj.remove("language") {
+                if !s.is_empty() {
+                    obj.insert("languages".to_string(), serde_json::json!([s]));
+                }
+            }
+        } else {
+            obj.remove("language");
+        }
+    }
+
+    SongData::deserialize(v).map_err(D::Error::custom)
+}
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone)]
 #[cfg_attr(feature = "backend", derive(ToSchema))]
@@ -31,6 +83,7 @@ pub struct CreateSong {
     pub not_a_song: bool,
     pub blobs: Vec<String>,
     #[cfg_attr(feature = "backend", schema(value_type = Object, additional_properties = true))]
+    #[serde(deserialize_with = "deserialize_song_data_compat")]
     pub data: SongData,
 }
 
@@ -118,5 +171,34 @@ impl From<Song> for CreateSong {
             blobs: value.blobs,
             data: value.data,
         }
+    }
+}
+
+#[cfg(test)]
+mod compat_tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_legacy_title_key_into_titles() {
+        let json = r#"{"not_a_song":false,"blobs":[],"data":{"title":"Hello","sections":[]}}"#;
+        let s: CreateSong = serde_json::from_str(json).unwrap();
+        assert_eq!(s.data.title(), "Hello");
+        assert_eq!(s.data.titles, vec!["Hello".to_string()]);
+    }
+
+    #[test]
+    fn deserialize_legacy_artist_and_language_keys() {
+        let json = r#"{"not_a_song":false,"blobs":[],"data":{"title":"T","artist":"A","language":"en","sections":[]}}"#;
+        let s: CreateSong = serde_json::from_str(json).unwrap();
+        assert_eq!(s.data.artists, vec!["A".to_string()]);
+        assert_eq!(s.data.languages, vec!["en".to_string()]);
+    }
+
+    #[test]
+    fn deserialize_prefers_nonempty_titles_over_legacy_title() {
+        let json = r#"{"not_a_song":false,"blobs":[],"data":{"title":"Legacy","titles":["A","B"],"sections":[]}}"#;
+        let s: CreateSong = serde_json::from_str(json).unwrap();
+        assert_eq!(s.data.titles, vec!["A".to_string(), "B".to_string()]);
+        assert_eq!(s.data.title(), "A");
     }
 }

--- a/shared/src/song/song.rs
+++ b/shared/src/song/song.rs
@@ -1,63 +1,11 @@
 use chordlib::inputs::chord_pro;
 use chordlib::outputs::{FormatChordPro, FormatHTML};
 use chordlib::types::{ChordRepresentation, SimpleChord, Song as SongData};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
 #[cfg(feature = "backend")]
 use utoipa::ToSchema;
-
-fn deserialize_song_data_compat<'de, D>(deserializer: D) -> Result<SongData, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    use serde::de::Error;
-
-    let mut v = serde_json::Value::deserialize(deserializer)?;
-    if let Some(obj) = v.as_object_mut() {
-        let titles_empty = match obj.get("titles") {
-            None => true,
-            Some(t) => t.as_array().map_or(true, Vec::is_empty),
-        };
-        if titles_empty {
-            if let Some(serde_json::Value::String(s)) = obj.remove("title") {
-                obj.insert("titles".to_string(), serde_json::json!([s]));
-            }
-        } else {
-            obj.remove("title");
-        }
-
-        let artists_empty = match obj.get("artists") {
-            None => true,
-            Some(t) => t.as_array().map_or(true, Vec::is_empty),
-        };
-        if artists_empty {
-            if let Some(serde_json::Value::String(s)) = obj.remove("artist") {
-                if !s.is_empty() {
-                    obj.insert("artists".to_string(), serde_json::json!([s]));
-                }
-            }
-        } else {
-            obj.remove("artist");
-        }
-
-        let languages_empty = match obj.get("languages") {
-            None => true,
-            Some(t) => t.as_array().map_or(true, Vec::is_empty),
-        };
-        if languages_empty {
-            if let Some(serde_json::Value::String(s)) = obj.remove("language") {
-                if !s.is_empty() {
-                    obj.insert("languages".to_string(), serde_json::json!([s]));
-                }
-            }
-        } else {
-            obj.remove("language");
-        }
-    }
-
-    SongData::deserialize(v).map_err(D::Error::custom)
-}
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone)]
 #[cfg_attr(feature = "backend", derive(ToSchema))]
@@ -83,7 +31,6 @@ pub struct CreateSong {
     pub not_a_song: bool,
     pub blobs: Vec<String>,
     #[cfg_attr(feature = "backend", schema(value_type = Object, additional_properties = true))]
-    #[serde(deserialize_with = "deserialize_song_data_compat")]
     pub data: SongData,
 }
 
@@ -175,30 +122,15 @@ impl From<Song> for CreateSong {
 }
 
 #[cfg(test)]
-mod compat_tests {
+mod tests {
     use super::*;
 
     #[test]
-    fn deserialize_legacy_title_key_into_titles() {
-        let json = r#"{"not_a_song":false,"blobs":[],"data":{"title":"Hello","sections":[]}}"#;
+    fn create_song_json_uses_metadata_vectors() {
+        let json = r#"{"not_a_song":false,"blobs":[],"data":{"titles":["Hello"],"artists":["A"],"languages":["en"],"sections":[]}}"#;
         let s: CreateSong = serde_json::from_str(json).unwrap();
         assert_eq!(s.data.title(), "Hello");
-        assert_eq!(s.data.titles, vec!["Hello".to_string()]);
-    }
-
-    #[test]
-    fn deserialize_legacy_artist_and_language_keys() {
-        let json = r#"{"not_a_song":false,"blobs":[],"data":{"title":"T","artist":"A","language":"en","sections":[]}}"#;
-        let s: CreateSong = serde_json::from_str(json).unwrap();
-        assert_eq!(s.data.artists, vec!["A".to_string()]);
-        assert_eq!(s.data.languages, vec!["en".to_string()]);
-    }
-
-    #[test]
-    fn deserialize_prefers_nonempty_titles_over_legacy_title() {
-        let json = r#"{"not_a_song":false,"blobs":[],"data":{"title":"Legacy","titles":["A","B"],"sections":[]}}"#;
-        let s: CreateSong = serde_json::from_str(json).unwrap();
-        assert_eq!(s.data.titles, vec!["A".to_string(), "B".to_string()]);
-        assert_eq!(s.data.title(), "A");
+        assert_eq!(s.data.artist(), "A");
+        assert_eq!(s.data.language(), "en");
     }
 }


### PR DESCRIPTION
## Summary

Upgrades **chordlib** to **0.8.0**, adapts the app to the vector-only `Song` metadata model (`titles`, `artists`, `languages` plus `title()` / `artist()` / `language()`), ships a SurrealDB migration that **removes legacy scalar** `data.title` / `data.artist` / `data.language` and **redefines full-text search indexes** on the array fields, and updates Venom suites so `data` payloads use only the new JSON shape.

## Changes

- **Dependencies:** `chordlib` 0.8.0 in `shared` and `backend` (`html` feature unchanged).
- **Rust:** Metadata access via chordlib getters/vectors; song list search uses `data.titles`, `data.artists`, and `search_content` with the same score weighting as before.
- **SurrealDB:** Migration `20260410140000_song_chordlib08_drop_scalar_metadata.surql` removes old scalar indexes and fields, keeps nonempty array semantics via `fn::song_normalize_metadata_array`, adds `song_data_titles_search_idx` and `song_data_artists_search_idx`.
- **API:** `CreateSong.data` is plain chordlib `Song` JSON — no legacy `title` / `artist` / `language` scalar keys.
- **Frontend:** Uses `title()` (and similar) for display and sorting.

## Release / operations

- **chordlib 0.8.0:** breaking `Song` public shape; see upstream release notes (HTML segments, chord spelling, etc.).
- **Database:** environments must run migrations in order; this step **drops** scalar metadata columns on `song.data` after prior plural/coalesce migrations.

## Verification

- Local: `cargo test` and `cargo clippy` in `shared` and `backend` (matches CI).
- Integration: run Venom suites against an instance that has applied all migrations.

Fixes #50