### PR TITLE
chore(deps): bump Rust image and dependency pins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.91.1-slim AS builder
+FROM rust:1.94.1-slim AS builder
 
 RUN export CARGO_BUILD_JOBS=$(nproc) && \
     cargo install cargo-binstall && \

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -32,17 +32,17 @@ envy = "0.4.2"
 futures-util = "0.3"
 utoipa = { version = "4", features = ["chrono"] }
 utoipa-swagger-ui = { version = "5", features = ["actix-web"] }
-surrealdb = { version = "2.4.0", default-features = false, features = [
+surrealdb = { version = "2.6.5", default-features = false, features = [
     "kv-mem",
     "protocol-http",
     "protocol-ws",
     "rustls",
 ] }
 async-trait = "0.1.89"
-lettre = "0.11.19"
+lettre = "0.11.21"
 ring = "0.17.14"
 hex = "0.4.3"
-actix-files = "0.6.8"
+actix-files = "0.6.10"
 shared = { path = "../shared", features = ["backend"] }
 chordlib = { version = "0.8.0", features = ["html"] }
 zip = "6.0.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,11 +8,11 @@ name = "worship-viewer"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.5.4", features = ["derive", "env"] }
-tokio = { version = "1.40.0", features = ["rt-multi-thread", "macros"] }
+clap = { version = "4.6.0", features = ["derive", "env"] }
+tokio = { version = "1.51.1", features = ["rt-multi-thread", "macros"] }
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.145"
-toml = "0.8.19"
+serde_json = "1.0.149"
+toml = "0.8.23"
 dirs = "5.0.1"
 shared = { path = "../shared", features = ["cli"] }
 

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -8,12 +8,12 @@ shared = { path = "../shared", features = ["frontend"] }
 yew = { version = "0.21.0", features = ["csr"] }
 yew-router = "0.18"
 stylist = { version = "0.13.0", features = ["yew_integration", "parser"] }
-wasm-bindgen-futures = "0.4.55"
-wasm-bindgen = "0.2.105"
+wasm-bindgen-futures = "0.4.67"
+wasm-bindgen = "0.2.117"
 gloo-net = "0.6.0"
 gloo-console = "0.3.0"
 yew-hooks = "0.3.4"
-web-sys = { version = "0.3.82", features = [
+web-sys = { version = "0.3.94", features = [
     "DragEvent",
     "HtmlInputElement",
     "Location",
@@ -35,13 +35,13 @@ web-sys = { version = "0.3.82", features = [
 ] }
 gloo = "0.11.0"
 serde = { version = "1.0.228", features = ["derive"] }
-url = "2.5.7"
+url = "2.5.8"
 getrandom_0_3 = { package = "getrandom", version = "0.3.4", features = [
     "wasm_js",
 ] }
-js-sys = "0.3.82"
-chrono = { version = "0.4.42", default-features = false, features = [
+js-sys = "0.3.94"
+chrono = { version = "0.4.44", default-features = false, features = [
     "clock",
     "serde",
 ] }
-serde_json = "1.0.145"
+serde_json = "1.0.149"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -5,19 +5,19 @@ edition = "2021"
 
 [dependencies]
 chordlib = { version = "0.8.0", features = ["html"] }
-chrono = { version = "0.4.42", default-features = false, features = [
+chrono = { version = "0.4.44", default-features = false, features = [
     "clock",
     "serde",
 ] }
 serde = { version = "1.0.228", features = ["derive"] }
-uuid = { version = "1.18.1", features = ["v4"], optional = true }
+uuid = { version = "1.23.0", features = ["v4"], optional = true }
 utoipa = { version = "4", optional = true }
 thiserror = "1.0"
 async-trait = "0.1"
 serde_json = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
 gloo-net = { version = "0.6", features = ["http"], optional = true }
-web-sys = { version = "0.3.82", features = ["RequestCredentials"], optional = true }
+web-sys = { version = "0.3.94", features = ["RequestCredentials"], optional = true }
 
 [features]
 backend = ["utoipa", "uuid"]


### PR DESCRIPTION
## Summary
Updates the Docker builder image to Rust 1.94.1 and refreshes pinned crate versions across backend, shared, CLI, and frontend.

## Notable changes
- **chordlib** 0.8 (shared + backend)
- **surrealdb** 2.6.5, **lettre** / **actix-files** patch bumps
- **wasm-bindgen** / **web-sys** / **js-sys** aligned on the frontend WASM stack
- CLI: **clap** 4.6, **tokio** 1.51

## Verification
- `cargo check` on shared, backend, cli
- `cargo check --target wasm32-unknown-unknown` in frontend (native host check is not applicable for this crate)


Made with [Cursor](https://cursor.com)