### PR TITLE
build(deps): bump chordlib to 0.8.1

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -44,5 +44,5 @@ ring = "0.17.14"
 hex = "0.4.3"
 actix-files = "0.6.10"
 shared = { path = "../shared", features = ["backend"] }
-chordlib = { version = "0.8.0", features = ["html"] }
+chordlib = { version = "0.8.1", features = ["html"] }
 zip = "6.0.0"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chordlib = { version = "0.8.0", features = ["html"] }
+chordlib = { version = "0.8.1", features = ["html"] }
 chrono = { version = "0.4.44", default-features = false, features = [
     "clock",
     "serde",


### PR DESCRIPTION
Updates `chordlib` from 0.8.0 to 0.8.1 in `shared` and `backend`.`cargo build` and `cargo test` were run in `backend` successfully.

Made with [Cursor](https://cursor.com)