### PR TITLE
feat(team): team invitations and related API

### DIFF
--- a/backend/db-migrations/20260413170000_team_invitation.surql
+++ b/backend/db-migrations/20260413170000_team_invitation.surql
@@ -1,0 +1,18 @@
+DEFINE TABLE OVERWRITE team_invitation SCHEMAFULL;
+
+DEFINE FIELD OVERWRITE team ON team_invitation TYPE record<team>
+    ASSERT $value != NONE;
+
+DEFINE FIELD OVERWRITE created_by ON team_invitation TYPE record<user>
+    ASSERT $value != NONE;
+
+DEFINE FIELD OVERWRITE created_at ON team_invitation TYPE datetime
+    DEFAULT time::now()
+    VALUE $before ?? $value
+    READONLY;
+
+DEFINE INDEX OVERWRITE team_invitation_team_idx ON team_invitation COLUMNS team;
+
+DEFINE EVENT OVERWRITE team_invitation_team_cascade ON team
+    WHEN $event = "DELETE"
+    THEN DELETE team_invitation WHERE team = $before.id;

--- a/backend/src/docs.rs
+++ b/backend/src/docs.rs
@@ -14,7 +14,8 @@ use shared::like::LikeStatus;
 use shared::player::{Orientation, Player, PlayerItem, ScrollType, TocItem};
 use shared::song::{Link as SongLink, SongUserSpecificAddons};
 use shared::team::{
-    CreateTeam, Team, TeamMember, TeamMemberInput, TeamRole, TeamUser, TeamUserRef, UpdateTeam,
+    CreateTeam, Team, TeamInvitation, TeamMember, TeamMemberInput, TeamRole, TeamUser, TeamUserRef,
+    UpdateTeam,
 };
 
 pub mod rest {
@@ -81,7 +82,12 @@ pub mod rest {
         crate::resources::team::rest::get_team,
         crate::resources::team::rest::create_team,
         crate::resources::team::rest::update_team,
-        crate::resources::team::rest::delete_team
+        crate::resources::team::rest::delete_team,
+        crate::resources::team::rest::create_team_invitation,
+        crate::resources::team::rest::list_team_invitations,
+        crate::resources::team::rest::get_team_invitation,
+        crate::resources::team::rest::delete_team_invitation,
+        crate::resources::team::rest::accept_team_invitation
     ),
     components(
         schemas(
@@ -117,7 +123,8 @@ pub mod rest {
             TeamUserRef,
             CreateTeam,
             UpdateTeam,
-            TeamMemberInput
+            TeamMemberInput,
+            TeamInvitation
         )
     ),
     tags(

--- a/backend/src/resources/rest.rs
+++ b/backend/src/resources/rest.rs
@@ -10,5 +10,6 @@ pub fn scope() -> impl HttpServiceFactory {
         .service(setlist::rest::scope())
         .service(song::rest::scope())
         .service(team::rest::scope())
+        .service(team::invitations_accept_scope())
         .service(user::rest::scope())
 }

--- a/backend/src/resources/team/invitation_model.rs
+++ b/backend/src/resources/team/invitation_model.rs
@@ -1,0 +1,302 @@
+use serde::{Deserialize, Serialize};
+use surrealdb::sql::{Datetime, Thing};
+use uuid::Uuid;
+
+use shared::team::{Team, TeamInvitation, TeamUser};
+
+use crate::database::{Database, record_id_string};
+use crate::error::AppError;
+use crate::resources::user::UserRecord;
+
+use super::model::{
+    DbTeamMember, TeamFetched, effective_admin, is_public_resource, load_team_display,
+    member_or_owner_readable, team_fetched_to_stored, team_resource_or_reject_public,
+    thing_user_id, user_thing,
+};
+
+pub trait TeamInvitationModel {
+    async fn create_team_invitation(
+        &self,
+        user_id: &str,
+        team_id: &str,
+    ) -> Result<TeamInvitation, AppError>;
+
+    async fn list_team_invitations(
+        &self,
+        user_id: &str,
+        team_id: &str,
+    ) -> Result<Vec<TeamInvitation>, AppError>;
+
+    async fn get_team_invitation(
+        &self,
+        user_id: &str,
+        team_id: &str,
+        invitation_id: &str,
+    ) -> Result<TeamInvitation, AppError>;
+
+    async fn delete_team_invitation(
+        &self,
+        user_id: &str,
+        team_id: &str,
+        invitation_id: &str,
+    ) -> Result<(), AppError>;
+
+    async fn accept_team_invitation(
+        &self,
+        user_id: &str,
+        invitation_id: &str,
+    ) -> Result<Team, AppError>;
+}
+
+#[derive(Debug, Deserialize)]
+struct InvitationRow {
+    id: Thing,
+    team: Thing,
+    created_by: UserRecord,
+    created_at: Datetime,
+}
+
+#[derive(Debug, Deserialize)]
+struct InvitationAcceptRow {
+    #[allow(dead_code)]
+    id: Thing,
+    team: TeamFetched,
+    #[allow(dead_code)]
+    created_by: UserRecord,
+    #[allow(dead_code)]
+    created_at: Datetime,
+}
+
+#[derive(Serialize)]
+struct InvitationCreate {
+    team: Thing,
+    created_by: Thing,
+}
+
+#[derive(Debug, Deserialize)]
+struct InvitationIdRow {
+    #[allow(dead_code)]
+    id: Thing,
+}
+
+impl InvitationRow {
+    fn into_invitation(self) -> Result<TeamInvitation, AppError> {
+        let u = self.created_by.into_user();
+        Ok(TeamInvitation {
+            id: record_id_string(&self.id),
+            team_id: record_id_string(&self.team),
+            created_by: TeamUser {
+                id: u.id,
+                email: u.email,
+            },
+            created_at: self.created_at.into(),
+        })
+    }
+}
+
+async fn assert_shared_team_admin(
+    db: &Database,
+    user_id: &str,
+    team_id: &str,
+) -> Result<Thing, AppError> {
+    let resource = team_resource_or_reject_public(team_id)?;
+    let team_thing = Thing::from(resource.clone());
+    let row = db
+        .db
+        .query("SELECT * FROM $tid FETCH owner, members.user")
+        .bind(("tid", team_thing.clone()))
+        .await?
+        .take::<Option<TeamFetched>>(0)?
+        .ok_or_else(|| AppError::NotFound("team not found".into()))?;
+
+    let stored = team_fetched_to_stored(&row)?;
+    if stored.owner.is_some() {
+        return Err(AppError::invalid_request(
+            "team invitations are only supported for shared teams",
+        ));
+    }
+    if !member_or_owner_readable(user_id, &stored) {
+        return Err(AppError::NotFound("team not found".into()));
+    }
+    if !effective_admin(user_id, &stored) {
+        return Err(AppError::forbidden());
+    }
+    Ok(team_thing)
+}
+
+fn invitation_thing(invitation_id: &str) -> Result<Thing, AppError> {
+    let id = invitation_id.trim();
+    if id.is_empty() {
+        return Err(AppError::NotFound("invitation not found".into()));
+    }
+    if let Ok(thing) = id.parse::<Thing>()
+        && thing.tb == "team_invitation"
+    {
+        return Ok(thing);
+    }
+    Ok(Thing::from(("team_invitation".to_owned(), id.to_owned())))
+}
+
+fn team_things_match(a: &Thing, b: &Thing) -> bool {
+    a.tb == b.tb && record_id_string(a) == record_id_string(b)
+}
+
+impl TeamInvitationModel for Database {
+    async fn create_team_invitation(
+        &self,
+        user_id: &str,
+        team_id: &str,
+    ) -> Result<TeamInvitation, AppError> {
+        let team_thing = assert_shared_team_admin(self, user_id, team_id).await?;
+        let inv_id = Uuid::new_v4().to_string();
+        let create = InvitationCreate {
+            team: team_thing.clone(),
+            created_by: user_thing(user_id),
+        };
+        let created: Option<InvitationIdRow> = self
+            .db
+            .create(("team_invitation", inv_id.as_str()))
+            .content(create)
+            .await
+            .map_err(AppError::database)?;
+        if created.is_none() {
+            return Err(AppError::database("failed to create team invitation"));
+        }
+
+        self.get_team_invitation(user_id, team_id, &inv_id).await
+    }
+
+    async fn list_team_invitations(
+        &self,
+        user_id: &str,
+        team_id: &str,
+    ) -> Result<Vec<TeamInvitation>, AppError> {
+        let team_thing = assert_shared_team_admin(self, user_id, team_id).await?;
+        let rows: Vec<InvitationRow> = self
+            .db
+            .query(
+                "SELECT * FROM team_invitation WHERE team = $team ORDER BY created_at ASC FETCH created_by",
+            )
+            .bind(("team", team_thing))
+            .await?
+            .take(0)?;
+        rows.into_iter()
+            .map(InvitationRow::into_invitation)
+            .collect::<Result<Vec<_>, _>>()
+    }
+
+    async fn get_team_invitation(
+        &self,
+        user_id: &str,
+        team_id: &str,
+        invitation_id: &str,
+    ) -> Result<TeamInvitation, AppError> {
+        let team_thing = assert_shared_team_admin(self, user_id, team_id).await?;
+        let inv_thing = invitation_thing(invitation_id)?;
+        let row = self
+            .db
+            .query("SELECT * FROM $iid FETCH created_by")
+            .bind(("iid", inv_thing))
+            .await?
+            .take::<Option<InvitationRow>>(0)?
+            .ok_or_else(|| AppError::NotFound("invitation not found".into()))?;
+
+        if !team_things_match(&row.team, &team_thing) {
+            return Err(AppError::NotFound("invitation not found".into()));
+        }
+
+        row.into_invitation()
+    }
+
+    async fn delete_team_invitation(
+        &self,
+        user_id: &str,
+        team_id: &str,
+        invitation_id: &str,
+    ) -> Result<(), AppError> {
+        let team_thing = assert_shared_team_admin(self, user_id, team_id).await?;
+        let inv_thing = invitation_thing(invitation_id)?;
+        let row = self
+            .db
+            .query("SELECT * FROM $iid FETCH created_by")
+            .bind(("iid", inv_thing.clone()))
+            .await?
+            .take::<Option<InvitationRow>>(0)?
+            .ok_or_else(|| AppError::NotFound("invitation not found".into()))?;
+
+        if !team_things_match(&row.team, &team_thing) {
+            return Err(AppError::NotFound("invitation not found".into()));
+        }
+
+        let key = record_id_string(&inv_thing);
+        let deleted: Option<InvitationRow> =
+            self.db.delete(("team_invitation", key.as_str())).await?;
+        if deleted.is_none() {
+            return Err(AppError::NotFound("invitation not found".into()));
+        }
+        Ok(())
+    }
+
+    async fn accept_team_invitation(
+        &self,
+        user_id: &str,
+        invitation_id: &str,
+    ) -> Result<Team, AppError> {
+        let inv_thing = invitation_thing(invitation_id)?;
+        let row = self
+            .db
+            .query("SELECT * FROM $iid FETCH team, created_by")
+            .bind(("iid", inv_thing))
+            .await?
+            .take::<Option<InvitationAcceptRow>>(0)?
+            .ok_or_else(|| AppError::NotFound("invitation not found".into()))?;
+
+        let team_row = row.team;
+        let res = (team_row.id.tb.clone(), record_id_string(&team_row.id));
+        if is_public_resource(&res) {
+            return Err(AppError::NotFound("invitation not found".into()));
+        }
+
+        let stored = team_fetched_to_stored(&team_row)?;
+        if stored.owner.is_some() {
+            return Err(AppError::NotFound("invitation not found".into()));
+        }
+
+        let team_id_str = record_id_string(&team_row.id);
+        let uid = user_id.to_owned();
+        let mut map: std::collections::BTreeMap<String, DbTeamMember> =
+            std::collections::BTreeMap::new();
+        for m in &stored.members {
+            map.insert(thing_user_id(&m.user), m.clone());
+        }
+        let needs_guest = match map.get(&uid).map(|m| m.role.as_str()) {
+            Some("admin") | Some("content_maintainer") | Some("guest") => false,
+            None => true,
+            Some(_) => true,
+        };
+
+        if !needs_guest {
+            return load_team_display(self, &team_id_str).await;
+        }
+
+        map.insert(
+            uid.clone(),
+            DbTeamMember {
+                user: user_thing(&uid),
+                role: "guest".to_owned(),
+            },
+        );
+        let members: Vec<DbTeamMember> = map.into_values().collect();
+
+        let tid = team_row.id.clone();
+        self.db
+            .query("UPDATE $tid SET members = $members")
+            .bind(("tid", tid))
+            .bind(("members", members))
+            .await?
+            .check()
+            .map_err(AppError::database)?;
+
+        load_team_display(self, &team_id_str).await
+    }
+}

--- a/backend/src/resources/team/mod.rs
+++ b/backend/src/resources/team/mod.rs
@@ -1,4 +1,6 @@
+mod invitation_model;
 mod model;
 pub mod rest;
 
 pub use model::{TeamModel, content_read_team_things, content_write_team_things};
+pub use rest::invitations_accept_scope;

--- a/backend/src/resources/team/model.rs
+++ b/backend/src/resources/team/model.rs
@@ -461,14 +461,14 @@ struct TeamCreatePayload {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-struct DbTeamMember {
-    user: Thing,
-    role: String,
+pub(crate) struct DbTeamMember {
+    pub(crate) user: Thing,
+    pub(crate) role: String,
 }
 
 #[derive(Clone, Debug, Deserialize)]
-struct TeamFetched {
-    id: Thing,
+pub(crate) struct TeamFetched {
+    pub(crate) id: Thing,
     name: String,
     #[serde(default)]
     owner: Option<UserRecord>,
@@ -483,7 +483,7 @@ struct TeamMemberFetched {
 }
 
 impl TeamFetched {
-    fn into_team(self) -> Result<Team, AppError> {
+    pub(crate) fn into_team(self) -> Result<Team, AppError> {
         let id = self.id.id.to_string();
         let owner = self.owner.map(user_record_to_team_user).transpose()?;
         let mut members = Vec::with_capacity(self.members.len());
@@ -516,12 +516,12 @@ struct TeamIdRow {
 }
 
 #[derive(Clone, Debug)]
-struct TeamStored {
-    owner: Option<Thing>,
-    members: Vec<DbTeamMember>,
+pub(crate) struct TeamStored {
+    pub(crate) owner: Option<Thing>,
+    pub(crate) members: Vec<DbTeamMember>,
 }
 
-fn team_fetched_to_stored(row: &TeamFetched) -> Result<TeamStored, AppError> {
+pub(crate) fn team_fetched_to_stored(row: &TeamFetched) -> Result<TeamStored, AppError> {
     let owner = row
         .owner
         .as_ref()
@@ -537,7 +537,7 @@ fn team_fetched_to_stored(row: &TeamFetched) -> Result<TeamStored, AppError> {
     Ok(TeamStored { owner, members })
 }
 
-async fn load_team_display(db: &Database, id: &str) -> Result<Team, AppError> {
+pub(crate) async fn load_team_display(db: &Database, id: &str) -> Result<Team, AppError> {
     let resource = team_resource_or_reject_public(id)?;
     let row = db
         .db
@@ -549,20 +549,20 @@ async fn load_team_display(db: &Database, id: &str) -> Result<Team, AppError> {
     row.into_team()
 }
 
-fn user_thing(user_id: &str) -> Thing {
+pub(crate) fn user_thing(user_id: &str) -> Thing {
     Thing::from(("user".to_owned(), user_id.to_owned()))
 }
 
-fn public_team_thing() -> Thing {
+pub(crate) fn public_team_thing() -> Thing {
     Thing::from(("team".to_owned(), "public".to_owned()))
 }
 
-fn is_public_resource(resource: &(String, String)) -> bool {
+pub(crate) fn is_public_resource(resource: &(String, String)) -> bool {
     resource.0 == "team" && resource.1 == "public"
 }
 
 /// `team:public` is seeded for internal use only (see migration). It is not exposed through the REST API.
-fn team_resource_or_reject_public(id: &str) -> Result<(String, String), AppError> {
+pub(crate) fn team_resource_or_reject_public(id: &str) -> Result<(String, String), AppError> {
     let resource = team_resource(id)?;
     if is_public_resource(&resource) {
         return Err(AppError::NotFound("team not found".into()));
@@ -582,11 +582,11 @@ fn team_resource(id: &str) -> Result<(String, String), AppError> {
     Ok(("team".to_owned(), id.to_owned()))
 }
 
-fn thing_user_id(t: &Thing) -> String {
+pub(crate) fn thing_user_id(t: &Thing) -> String {
     t.id.to_string()
 }
 
-fn member_or_owner_readable(user_id: &str, stored: &TeamStored) -> bool {
+pub(crate) fn member_or_owner_readable(user_id: &str, stored: &TeamStored) -> bool {
     if let Some(ref o) = stored.owner
         && thing_user_id(o) == user_id
     {
@@ -603,7 +603,7 @@ fn can_read_team(user_id: &str, stored: &TeamStored, app_admin: bool) -> bool {
     app_admin || member_or_owner_readable(user_id, stored)
 }
 
-fn effective_admin(user_id: &str, stored: &TeamStored) -> bool {
+pub(crate) fn effective_admin(user_id: &str, stored: &TeamStored) -> bool {
     if let Some(ref o) = stored.owner
         && thing_user_id(o) == user_id
     {

--- a/backend/src/resources/team/rest.rs
+++ b/backend/src/resources/team/rest.rs
@@ -1,25 +1,195 @@
-use actix_web::{
-    HttpResponse, Scope, delete, get, post, put,
-    web::{self, Data, Json, Path, ReqData},
-};
-
+use super::invitation_model::TeamInvitationModel;
 use super::model::TeamModel;
 use crate::database::Database;
 #[allow(unused_imports)]
 use crate::docs::ErrorResponse;
 use crate::error::AppError;
 use crate::resources::{User, UserRole};
+use actix_web::{
+    HttpResponse, Scope, delete, get, post, put,
+    web::{self, Data, Json, Path, ReqData},
+};
 #[allow(unused_imports)]
 use shared::team::Team;
+#[allow(unused_imports)]
+use shared::team::TeamInvitation;
 use shared::team::{CreateTeam, UpdateTeam};
 
 pub fn scope() -> Scope {
     web::scope("/teams")
+        .service(team_invitations_scope())
         .service(get_teams)
         .service(get_team)
         .service(create_team)
         .service(update_team)
         .service(delete_team)
+}
+
+pub fn invitations_accept_scope() -> Scope {
+    web::scope("/invitations").service(accept_team_invitation)
+}
+
+fn team_invitations_scope() -> Scope {
+    web::scope("/{team_id}/invitations")
+        .service(create_team_invitation)
+        .service(list_team_invitations)
+        .service(get_team_invitation)
+        .service(delete_team_invitation)
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/teams/{team_id}/invitations",
+    params(
+        ("team_id" = String, Path, description = "Shared team identifier")
+    ),
+    responses(
+        (status = 201, description = "Invitation created", body = TeamInvitation),
+        (status = 400, description = "Team is not shared", body = ErrorResponse),
+        (status = 401, description = "Authentication required", body = ErrorResponse),
+        (status = 403, description = "Not a team admin", body = ErrorResponse),
+        (status = 404, description = "Team not found", body = ErrorResponse),
+        (status = 500, description = "Database error", body = ErrorResponse)
+    ),
+    tag = "Teams",
+    security(
+        ("SessionCookie" = []),
+        ("SessionToken" = [])
+    )
+)]
+#[post("")]
+async fn create_team_invitation(
+    db: Data<Database>,
+    user: ReqData<User>,
+    team_id: Path<String>,
+) -> Result<HttpResponse, AppError> {
+    let inv = db
+        .create_team_invitation(&user.id, team_id.as_str())
+        .await?;
+    Ok(HttpResponse::Created().json(inv))
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/teams/{team_id}/invitations",
+    params(
+        ("team_id" = String, Path, description = "Shared team identifier")
+    ),
+    responses(
+        (status = 200, description = "Invitations for the team", body = [TeamInvitation]),
+        (status = 401, description = "Authentication required", body = ErrorResponse),
+        (status = 403, description = "Not a team admin", body = ErrorResponse),
+        (status = 404, description = "Team not found", body = ErrorResponse),
+        (status = 500, description = "Database error", body = ErrorResponse)
+    ),
+    tag = "Teams",
+    security(
+        ("SessionCookie" = []),
+        ("SessionToken" = [])
+    )
+)]
+#[get("")]
+async fn list_team_invitations(
+    db: Data<Database>,
+    user: ReqData<User>,
+    team_id: Path<String>,
+) -> Result<HttpResponse, AppError> {
+    Ok(HttpResponse::Ok().json(db.list_team_invitations(&user.id, team_id.as_str()).await?))
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/teams/{team_id}/invitations/{invitation_id}",
+    params(
+        ("team_id" = String, Path, description = "Shared team identifier"),
+        ("invitation_id" = String, Path, description = "Invitation identifier")
+    ),
+    responses(
+        (status = 200, description = "Invitation details", body = TeamInvitation),
+        (status = 401, description = "Authentication required", body = ErrorResponse),
+        (status = 403, description = "Not a team admin", body = ErrorResponse),
+        (status = 404, description = "Team or invitation not found", body = ErrorResponse),
+        (status = 500, description = "Database error", body = ErrorResponse)
+    ),
+    tag = "Teams",
+    security(
+        ("SessionCookie" = []),
+        ("SessionToken" = [])
+    )
+)]
+#[get("/{invitation_id}")]
+async fn get_team_invitation(
+    db: Data<Database>,
+    user: ReqData<User>,
+    path: Path<(String, String)>,
+) -> Result<HttpResponse, AppError> {
+    let (team_id, invitation_id) = path.into_inner();
+    Ok(HttpResponse::Ok().json(
+        db.get_team_invitation(&user.id, &team_id, &invitation_id)
+            .await?,
+    ))
+}
+
+#[utoipa::path(
+    delete,
+    path = "/api/v1/teams/{team_id}/invitations/{invitation_id}",
+    params(
+        ("team_id" = String, Path, description = "Shared team identifier"),
+        ("invitation_id" = String, Path, description = "Invitation identifier")
+    ),
+    responses(
+        (status = 204, description = "Invitation removed"),
+        (status = 401, description = "Authentication required", body = ErrorResponse),
+        (status = 403, description = "Not a team admin", body = ErrorResponse),
+        (status = 404, description = "Team or invitation not found", body = ErrorResponse),
+        (status = 500, description = "Database error", body = ErrorResponse)
+    ),
+    tag = "Teams",
+    security(
+        ("SessionCookie" = []),
+        ("SessionToken" = [])
+    )
+)]
+#[delete("/{invitation_id}")]
+async fn delete_team_invitation(
+    db: Data<Database>,
+    user: ReqData<User>,
+    path: Path<(String, String)>,
+) -> Result<HttpResponse, AppError> {
+    let (team_id, invitation_id) = path.into_inner();
+    db.delete_team_invitation(&user.id, &team_id, &invitation_id)
+        .await?;
+    Ok(HttpResponse::NoContent().finish())
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/invitations/{invitation_id}/accept",
+    params(
+        ("invitation_id" = String, Path, description = "Invitation identifier")
+    ),
+    responses(
+        (status = 200, description = "Current user is on the team (added as guest if needed)", body = Team),
+        (status = 401, description = "Authentication required", body = ErrorResponse),
+        (status = 404, description = "Invitation not found or not usable", body = ErrorResponse),
+        (status = 500, description = "Database error", body = ErrorResponse)
+    ),
+    tag = "Teams",
+    security(
+        ("SessionCookie" = []),
+        ("SessionToken" = [])
+    )
+)]
+#[post("/{invitation_id}/accept")]
+async fn accept_team_invitation(
+    db: Data<Database>,
+    user: ReqData<User>,
+    invitation_id: Path<String>,
+) -> Result<HttpResponse, AppError> {
+    Ok(HttpResponse::Ok().json(
+        db.accept_team_invitation(&user.id, invitation_id.as_str())
+            .await?,
+    ))
 }
 
 #[utoipa::path(

--- a/backend/tests/team_invitations.yml
+++ b/backend/tests/team_invitations.yml
@@ -1,0 +1,290 @@
+name: Team invitations
+vars:
+  base_url: http://127.0.0.1:8080
+  token_admin: admin
+
+testcases:
+  - name: ti-create-lead-user
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/users"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+          Content-Type: application/json
+        body: |
+          {
+            "email": "ti-lead@test.com"
+          }
+        assertions:
+          - result.statuscode ShouldEqual 201
+        vars:
+          userid:
+            from: result.bodyjson.id
+
+  - name: ti-create-lead-session
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/users/{{.ti-create-lead-user.userid}}/sessions"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 201
+        vars:
+          sessionid:
+            from: result.bodyjson.id
+
+  - name: ti-lead-create-shared
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/teams"
+        headers:
+          Authorization: "Bearer {{.ti-create-lead-session.sessionid}}"
+          Content-Type: application/json
+        body: |
+          {
+            "name": "TI Shared Team"
+          }
+        assertions:
+          - result.statuscode ShouldEqual 201
+        vars:
+          shared_team_id:
+            from: result.bodyjson.id
+
+  - name: ti-create-guest-user
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/users"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+          Content-Type: application/json
+        body: |
+          {
+            "email": "ti-guest@test.com"
+          }
+        assertions:
+          - result.statuscode ShouldEqual 201
+        vars:
+          userid:
+            from: result.bodyjson.id
+
+  - name: ti-create-guest-session
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/users/{{.ti-create-guest-user.userid}}/sessions"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 201
+        vars:
+          sessionid:
+            from: result.bodyjson.id
+
+  - name: ti-admin-create-invitation
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/teams/{{.ti-lead-create-shared.shared_team_id}}/invitations"
+        headers:
+          Authorization: "Bearer {{.ti-create-lead-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 201
+          - result.bodyjson.team_id ShouldEqual "{{.ti-lead-create-shared.shared_team_id}}"
+          - result.body ShouldContainSubstring "-"
+        vars:
+          invitation_id:
+            from: result.bodyjson.id
+
+  - name: ti-admin-list-invitations
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/teams/{{.ti-lead-create-shared.shared_team_id}}/invitations"
+        headers:
+          Authorization: "Bearer {{.ti-create-lead-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 1
+
+  - name: ti-admin-get-invitation
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/teams/{{.ti-lead-create-shared.shared_team_id}}/invitations/{{.ti-admin-create-invitation.invitation_id}}"
+        headers:
+          Authorization: "Bearer {{.ti-create-lead-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson.id ShouldEqual "{{.ti-admin-create-invitation.invitation_id}}"
+
+  - name: ti-guest-accept-invitation
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/invitations/{{.ti-admin-create-invitation.invitation_id}}/accept"
+        headers:
+          Authorization: "Bearer {{.ti-create-guest-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson.id ShouldEqual "{{.ti-lead-create-shared.shared_team_id}}"
+
+  - name: ti-guest-list-invitations-forbidden
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/teams/{{.ti-lead-create-shared.shared_team_id}}/invitations"
+        headers:
+          Authorization: "Bearer {{.ti-create-guest-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 403
+
+  - name: ti-guest-accept-idempotent
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/invitations/{{.ti-admin-create-invitation.invitation_id}}/accept"
+        headers:
+          Authorization: "Bearer {{.ti-create-guest-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+
+  - name: ti-create-maintainer-user
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/users"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+          Content-Type: application/json
+        body: |
+          {
+            "email": "ti-maintainer@test.com"
+          }
+        assertions:
+          - result.statuscode ShouldEqual 201
+        vars:
+          userid:
+            from: result.bodyjson.id
+
+  - name: ti-create-maintainer-session
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/users/{{.ti-create-maintainer-user.userid}}/sessions"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 201
+        vars:
+          sessionid:
+            from: result.bodyjson.id
+
+  - name: ti-lead-add-maintainer
+    steps:
+      - type: http
+        method: PUT
+        url: "{{.base_url}}/api/v1/teams/{{.ti-lead-create-shared.shared_team_id}}"
+        headers:
+          Authorization: "Bearer {{.ti-create-lead-session.sessionid}}"
+          Content-Type: application/json
+        body: |
+          {
+            "name": "TI Shared Team",
+            "members": [
+              { "user": { "id": "{{.ti-create-lead-user.userid}}" }, "role": "admin" },
+              { "user": { "id": "{{.ti-create-guest-user.userid}}" }, "role": "guest" },
+              { "user": { "id": "{{.ti-create-maintainer-user.userid}}" }, "role": "content_maintainer" }
+            ]
+          }
+        assertions:
+          - result.statuscode ShouldEqual 200
+
+  - name: ti-maintainer-accept-no-downgrade
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/invitations/{{.ti-admin-create-invitation.invitation_id}}/accept"
+        headers:
+          Authorization: "Bearer {{.ti-create-maintainer-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+
+  - name: ti-maintainer-still-content-maintainer
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/teams/{{.ti-lead-create-shared.shared_team_id}}"
+        headers:
+          Authorization: "Bearer {{.ti-create-maintainer-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.body ShouldContainSubstring "ti-maintainer@test.com"
+          - result.body ShouldContainSubstring "content_maintainer"
+
+  - name: ti-accept-unknown-invitation-404
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/invitations/00000000-0000-4000-8000-000000000001/accept"
+        headers:
+          Authorization: "Bearer {{.ti-create-guest-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 404
+
+  - name: ti-lead-personal-team-id
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/teams"
+        headers:
+          Authorization: "Bearer {{.ti-create-lead-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson.bodyjson0.owner.email ShouldEqual "ti-lead@test.com"
+        vars:
+          lead_personal_team_id:
+            from: result.bodyjson.bodyjson0.id
+
+  - name: ti-personal-team-invite-bad-request
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/teams/{{.ti-lead-personal-team-id.lead_personal_team_id}}/invitations"
+        headers:
+          Authorization: "Bearer {{.ti-create-lead-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 400
+
+  - name: ti-platform-admin-cannot-invite-without-team-admin
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/teams/{{.ti-lead-create-shared.shared_team_id}}/invitations"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 404
+
+  - name: ti-admin-delete-invitation
+    steps:
+      - type: http
+        method: DELETE
+        url: "{{.base_url}}/api/v1/teams/{{.ti-lead-create-shared.shared_team_id}}/invitations/{{.ti-admin-create-invitation.invitation_id}}"
+        headers:
+          Authorization: "Bearer {{.ti-create-lead-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 204
+
+  - name: ti-accept-after-delete-404
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/invitations/{{.ti-admin-create-invitation.invitation_id}}/accept"
+        headers:
+          Authorization: "Bearer {{.ti-create-guest-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 404

--- a/shared/src/team/invitation.rs
+++ b/shared/src/team/invitation.rs
@@ -1,0 +1,13 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::TeamUser;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "backend", derive(utoipa::ToSchema))]
+pub struct TeamInvitation {
+    pub id: String,
+    pub team_id: String,
+    pub created_by: TeamUser,
+    pub created_at: DateTime<Utc>,
+}

--- a/shared/src/team/mod.rs
+++ b/shared/src/team/mod.rs
@@ -1,5 +1,7 @@
+mod invitation;
 mod team;
 
+pub use invitation::TeamInvitation;
 pub use team::{
     CreateTeam, Team, TeamMember, TeamMemberInput, TeamRole, TeamUser, TeamUserRef, UpdateTeam,
 };


### PR DESCRIPTION
This pull request adds team invitation support: database migration, shared types, REST endpoints, OpenAPI updates, and integration tests.

The `docs/busines-logic-constraints/` changes were intentionally left out of this branch so they can be committed separately.

Made with [Cursor](https://cursor.com)