### PR TITLE
refactor(backend): thin REST handlers via database helpers

### DIFF
--- a/backend/src/resources/blob/mod.rs
+++ b/backend/src/resources/blob/mod.rs
@@ -1,6 +1,7 @@
 pub use shared::blob::{Blob, CreateBlob};
 
 mod model;
+#[allow(unused_imports)]
 pub use model::Model;
 
 pub mod rest;

--- a/backend/src/resources/blob/model.rs
+++ b/backend/src/resources/blob/model.rs
@@ -10,8 +10,8 @@ use shared::blob::{Blob, CreateBlob};
 
 use crate::database::Database;
 use crate::error::AppError;
-use crate::resources::team::{content_read_team_things, content_write_team_things};
 use crate::resources::User;
+use crate::resources::team::{content_read_team_things, content_write_team_things};
 use crate::settings::Settings;
 
 pub trait Model {
@@ -193,10 +193,8 @@ impl Database {
         let file_name = blob
             .file_name()
             .ok_or_else(|| AppError::NotFound("blob has no id".into()))?;
-        NamedFile::open(
-            Path::new(&Settings::global().blob_dir).join(PathBuf::from(file_name)),
-        )
-        .map_err(|err| AppError::Internal(format!("{}", err)))
+        NamedFile::open(Path::new(&Settings::global().blob_dir).join(PathBuf::from(file_name)))
+            .map_err(|err| AppError::Internal(format!("{}", err)))
     }
 }
 

--- a/backend/src/resources/blob/model.rs
+++ b/backend/src/resources/blob/model.rs
@@ -1,5 +1,6 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
+use actix_files::NamedFile;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use surrealdb::sql::{Datetime, Thing};
@@ -9,6 +10,8 @@ use shared::blob::{Blob, CreateBlob};
 
 use crate::database::Database;
 use crate::error::AppError;
+use crate::resources::team::{content_read_team_things, content_write_team_things};
+use crate::resources::User;
 use crate::settings::Settings;
 
 pub trait Model {
@@ -139,6 +142,61 @@ impl Model for Database {
             let _ = std::fs::remove_file(path);
         }
         Ok(deleted)
+    }
+}
+
+impl Database {
+    pub async fn list_blobs_for_user(
+        &self,
+        user: &User,
+        pagination: ListQuery,
+    ) -> Result<Vec<Blob>, AppError> {
+        let read_teams = content_read_team_things(self, user).await?;
+        self.get_blobs(read_teams, pagination).await
+    }
+
+    pub async fn get_blob_for_user(&self, user: &User, id: &str) -> Result<Blob, AppError> {
+        let read_teams = content_read_team_things(self, user).await?;
+        self.get_blob(read_teams, id).await
+    }
+
+    pub async fn create_blob_for_user(
+        &self,
+        user: &User,
+        blob: CreateBlob,
+    ) -> Result<Blob, AppError> {
+        self.create_blob(&user.id, blob).await
+    }
+
+    pub async fn update_blob_for_user(
+        &self,
+        user: &User,
+        id: &str,
+        blob: CreateBlob,
+    ) -> Result<Blob, AppError> {
+        let write_teams = content_write_team_things(self, user).await?;
+        self.update_blob(write_teams, id, blob).await
+    }
+
+    pub async fn delete_blob_for_user(&self, user: &User, id: &str) -> Result<Blob, AppError> {
+        let write_teams = content_write_team_things(self, user).await?;
+        self.delete_blob(write_teams, id).await
+    }
+
+    pub async fn open_blob_data_file_for_user(
+        &self,
+        user: &User,
+        id: &str,
+    ) -> Result<NamedFile, AppError> {
+        let read_teams = content_read_team_things(self, user).await?;
+        let blob = self.get_blob(read_teams, id).await?;
+        let file_name = blob
+            .file_name()
+            .ok_or_else(|| AppError::NotFound("blob has no id".into()))?;
+        NamedFile::open(
+            Path::new(&Settings::global().blob_dir).join(PathBuf::from(file_name)),
+        )
+        .map_err(|err| AppError::Internal(format!("{}", err)))
     }
 }
 

--- a/backend/src/resources/blob/rest.rs
+++ b/backend/src/resources/blob/rest.rs
@@ -1,12 +1,9 @@
-use std::path::{Path, PathBuf};
-
 use actix_files::NamedFile;
 use actix_web::{
     HttpResponse, Scope, delete, get, post, put,
     web::{self, Data, Json, Path as PathParam, Query, ReqData},
 };
 
-use super::Model;
 use crate::database::Database;
 #[allow(unused_imports)]
 use crate::docs::ErrorResponse;
@@ -15,8 +12,6 @@ use crate::resources::User;
 #[allow(unused_imports)]
 use crate::resources::blob::Blob;
 use crate::resources::blob::CreateBlob;
-use crate::resources::team::{content_read_team_things, content_write_team_things};
-use crate::settings::Settings;
 use shared::api::ListQuery;
 
 pub fn scope() -> Scope {
@@ -53,9 +48,9 @@ async fn get_blobs(
     user: ReqData<User>,
     query: Query<ListQuery>,
 ) -> Result<HttpResponse, AppError> {
-    let list_query = query.into_inner();
-    let read_teams = content_read_team_things(db.get_ref(), &user).await?;
-    Ok(HttpResponse::Ok().json(db.get_blobs(read_teams, list_query).await?))
+    Ok(HttpResponse::Ok().json(
+        db.list_blobs_for_user(&user, query.into_inner()).await?,
+    ))
 }
 
 #[utoipa::path(
@@ -83,8 +78,7 @@ async fn get_blob(
     user: ReqData<User>,
     id: PathParam<String>,
 ) -> Result<HttpResponse, AppError> {
-    let read_teams = content_read_team_things(db.get_ref(), &user).await?;
-    Ok(HttpResponse::Ok().json(db.get_blob(read_teams, &id).await?))
+    Ok(HttpResponse::Ok().json(db.get_blob_for_user(&user, &id).await?))
 }
 
 #[utoipa::path(
@@ -109,7 +103,9 @@ async fn create_blob(
     user: ReqData<User>,
     payload: Json<CreateBlob>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Created().json(db.create_blob(&user.id, payload.into_inner()).await?))
+    Ok(HttpResponse::Created().json(
+        db.create_blob_for_user(&user, payload.into_inner()).await?,
+    ))
 }
 
 #[utoipa::path(
@@ -139,10 +135,8 @@ async fn update_blob(
     id: PathParam<String>,
     payload: Json<CreateBlob>,
 ) -> Result<HttpResponse, AppError> {
-    let write_teams = content_write_team_things(db.get_ref(), &user).await?;
     Ok(HttpResponse::Ok().json(
-        db.update_blob(write_teams, &id, payload.into_inner())
-            .await?,
+        db.update_blob_for_user(&user, &id, payload.into_inner()).await?,
     ))
 }
 
@@ -171,8 +165,7 @@ async fn delete_blob(
     user: ReqData<User>,
     id: PathParam<String>,
 ) -> Result<HttpResponse, AppError> {
-    let write_teams = content_write_team_things(db.get_ref(), &user).await?;
-    Ok(HttpResponse::Ok().json(db.delete_blob(write_teams, &id).await?))
+    Ok(HttpResponse::Ok().json(db.delete_blob_for_user(&user, &id).await?))
 }
 
 #[utoipa::path(
@@ -200,14 +193,5 @@ async fn download_blob_image(
     user: ReqData<User>,
     id: PathParam<String>,
 ) -> Result<NamedFile, AppError> {
-    let read_teams = content_read_team_things(db.get_ref(), &user).await?;
-    NamedFile::open(
-        Path::new(&Settings::global().blob_dir).join(PathBuf::from(
-            db.get_blob(read_teams, &id.into_inner())
-                .await?
-                .file_name()
-                .ok_or(AppError::NotFound("blob has no id".into()))?,
-        )),
-    )
-    .map_err(|err| AppError::Internal(format!("{}", err)))
+    db.open_blob_data_file_for_user(&user, &id.into_inner()).await
 }

--- a/backend/src/resources/blob/rest.rs
+++ b/backend/src/resources/blob/rest.rs
@@ -48,9 +48,7 @@ async fn get_blobs(
     user: ReqData<User>,
     query: Query<ListQuery>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Ok().json(
-        db.list_blobs_for_user(&user, query.into_inner()).await?,
-    ))
+    Ok(HttpResponse::Ok().json(db.list_blobs_for_user(&user, query.into_inner()).await?))
 }
 
 #[utoipa::path(
@@ -103,9 +101,7 @@ async fn create_blob(
     user: ReqData<User>,
     payload: Json<CreateBlob>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Created().json(
-        db.create_blob_for_user(&user, payload.into_inner()).await?,
-    ))
+    Ok(HttpResponse::Created().json(db.create_blob_for_user(&user, payload.into_inner()).await?))
 }
 
 #[utoipa::path(
@@ -136,7 +132,8 @@ async fn update_blob(
     payload: Json<CreateBlob>,
 ) -> Result<HttpResponse, AppError> {
     Ok(HttpResponse::Ok().json(
-        db.update_blob_for_user(&user, &id, payload.into_inner()).await?,
+        db.update_blob_for_user(&user, &id, payload.into_inner())
+            .await?,
     ))
 }
 
@@ -193,5 +190,6 @@ async fn download_blob_image(
     user: ReqData<User>,
     id: PathParam<String>,
 ) -> Result<NamedFile, AppError> {
-    db.open_blob_data_file_for_user(&user, &id.into_inner()).await
+    db.open_blob_data_file_for_user(&user, &id.into_inner())
+        .await
 }

--- a/backend/src/resources/collection/mod.rs
+++ b/backend/src/resources/collection/mod.rs
@@ -1,6 +1,7 @@
 pub use shared::collection::{Collection, CreateCollection};
 
 mod model;
+#[allow(unused_imports)]
 pub use model::Model;
 
 pub mod rest;

--- a/backend/src/resources/collection/model.rs
+++ b/backend/src/resources/collection/model.rs
@@ -1,15 +1,19 @@
+use actix_web::HttpResponse;
 use serde::{Deserialize, Serialize};
 use surrealdb::sql::Thing;
 
 use shared::{
     api::ListQuery,
     collection::{Collection, CreateCollection},
-    song::{Link as SongLink, LinkOwned as SongLinkOwned, SimpleChord},
+    player::Player,
+    song::{Link as SongLink, LinkOwned as SongLinkOwned, SimpleChord, Song},
 };
 
 use crate::database::Database;
 use crate::error::AppError;
-use crate::resources::song::SongRecord;
+use crate::resources::song::{Model as SongDbModel, SongRecord, export, Format};
+use crate::resources::team::{content_read_team_things, content_write_team_things};
+use crate::resources::User;
 
 pub trait Model {
     async fn get_collections(
@@ -230,6 +234,117 @@ impl Model for Database {
 
         Ok(())
     }
+}
+
+impl Database {
+    pub async fn list_collections_for_user(
+        &self,
+        user: &User,
+        pagination: ListQuery,
+    ) -> Result<Vec<Collection>, AppError> {
+        let read_teams = content_read_team_things(self, user).await?;
+        self.get_collections(read_teams, pagination).await
+    }
+
+    pub async fn get_collection_for_user(
+        &self,
+        user: &User,
+        id: &str,
+    ) -> Result<Collection, AppError> {
+        let read_teams = content_read_team_things(self, user).await?;
+        self.get_collection(read_teams, id).await
+    }
+
+    pub async fn collection_player_for_user(
+        &self,
+        user: &User,
+        id: &str,
+    ) -> Result<Player, AppError> {
+        let liked_set = SongDbModel::get_liked_set(self, &user.id).await?;
+        let read_teams = content_read_team_things(self, user).await?;
+        let links = self.get_collection_songs(read_teams, id).await?;
+        collection_player_from_links(liked_set, links)
+    }
+
+    pub async fn export_collection_for_user(
+        &self,
+        user: &User,
+        id: &str,
+        format: Format,
+    ) -> Result<HttpResponse, AppError> {
+        let read_teams = content_read_team_things(self, user).await?;
+        let songs: Vec<Song> = self
+            .get_collection_songs(read_teams, id)
+            .await?
+            .into_iter()
+            .map(|l| l.song)
+            .collect();
+        export(songs, format).await
+    }
+
+    pub async fn collection_songs_for_user(
+        &self,
+        user: &User,
+        id: &str,
+    ) -> Result<Vec<Song>, AppError> {
+        let liked_set = SongDbModel::get_liked_set(self, &user.id).await?;
+        let read_teams = content_read_team_things(self, user).await?;
+        Ok(self
+            .get_collection_songs(read_teams, id)
+            .await?
+            .into_iter()
+            .map(|song_link_owned| {
+                let mut song = song_link_owned.song;
+                song.user_specific_addons.liked = liked_set.contains(&song.id);
+                song
+            })
+            .collect())
+    }
+
+    pub async fn create_collection_for_user(
+        &self,
+        user: &User,
+        collection: CreateCollection,
+    ) -> Result<Collection, AppError> {
+        self.create_collection(&user.id, collection).await
+    }
+
+    pub async fn update_collection_for_user(
+        &self,
+        user: &User,
+        id: &str,
+        collection: CreateCollection,
+    ) -> Result<Collection, AppError> {
+        let write_teams = content_write_team_things(self, user).await?;
+        self.update_collection(write_teams, id, collection).await
+    }
+
+    pub async fn delete_collection_for_user(
+        &self,
+        user: &User,
+        id: &str,
+    ) -> Result<Collection, AppError> {
+        let write_teams = content_write_team_things(self, user).await?;
+        self.delete_collection(write_teams, id).await
+    }
+}
+
+fn collection_player_from_links(
+    liked_set: std::collections::HashSet<String>,
+    links: Vec<SongLinkOwned>,
+) -> Result<Player, AppError> {
+    links
+        .into_iter()
+        .enumerate()
+        .map(|(idx, link)| {
+            Player::from(SongLinkOwned {
+                liked: liked_set.contains(&link.song.id),
+                song: link.song,
+                nr: Some(link.nr.unwrap_or_else(|| (idx + 1).to_string())),
+                key: link.key,
+            })
+        })
+        .try_fold(Player::default(), |acc, player| Ok::<Player, AppError>(acc + player))
 }
 
 fn collection_resource(id: &str) -> Result<(String, String), AppError> {

--- a/backend/src/resources/collection/model.rs
+++ b/backend/src/resources/collection/model.rs
@@ -11,9 +11,9 @@ use shared::{
 
 use crate::database::Database;
 use crate::error::AppError;
-use crate::resources::song::{Model as SongDbModel, SongRecord, export, Format};
-use crate::resources::team::{content_read_team_things, content_write_team_things};
 use crate::resources::User;
+use crate::resources::song::{Format, Model as SongDbModel, SongRecord, export};
+use crate::resources::team::{content_read_team_things, content_write_team_things};
 
 pub trait Model {
     async fn get_collections(
@@ -344,7 +344,9 @@ fn collection_player_from_links(
                 key: link.key,
             })
         })
-        .try_fold(Player::default(), |acc, player| Ok::<Player, AppError>(acc + player))
+        .try_fold(Player::default(), |acc, player| {
+            Ok::<Player, AppError>(acc + player)
+        })
 }
 
 fn collection_resource(id: &str) -> Result<(String, String), AppError> {

--- a/backend/src/resources/collection/rest.rs
+++ b/backend/src/resources/collection/rest.rs
@@ -55,7 +55,8 @@ async fn get_collections(
     query: Query<ListQuery>,
 ) -> Result<HttpResponse, AppError> {
     Ok(HttpResponse::Ok().json(
-        db.list_collections_for_user(&user, query.into_inner()).await?,
+        db.list_collections_for_user(&user, query.into_inner())
+            .await?,
     ))
 }
 
@@ -202,7 +203,8 @@ async fn create_collection(
     payload: Json<CreateCollection>,
 ) -> Result<HttpResponse, AppError> {
     Ok(HttpResponse::Created().json(
-        db.create_collection_for_user(&user, payload.into_inner()).await?,
+        db.create_collection_for_user(&user, payload.into_inner())
+            .await?,
     ))
 }
 

--- a/backend/src/resources/collection/rest.rs
+++ b/backend/src/resources/collection/rest.rs
@@ -3,7 +3,6 @@ use actix_web::{
     web::{self, Data, Json, Path, Query, ReqData},
 };
 
-use super::Model;
 use crate::database::Database;
 #[allow(unused_imports)]
 use crate::docs::ErrorResponse;
@@ -12,13 +11,11 @@ use crate::resources::User;
 #[allow(unused_imports)]
 use crate::resources::collection::Collection;
 use crate::resources::collection::CreateCollection;
-use crate::resources::song::Model as SongModel;
 #[allow(unused_imports)]
-use crate::resources::song::{Format, QueryParams, Song, export};
-use crate::resources::team::{content_read_team_things, content_write_team_things};
+use crate::resources::song::{Format, QueryParams, Song};
 use shared::api::ListQuery;
+#[allow(unused_imports)]
 use shared::player::Player;
-use shared::song::LinkOwned as SongLinkOwned;
 
 pub fn scope() -> Scope {
     web::scope("/collections")
@@ -57,9 +54,9 @@ async fn get_collections(
     user: ReqData<User>,
     query: Query<ListQuery>,
 ) -> Result<HttpResponse, AppError> {
-    let list_query = query.into_inner();
-    let read_teams = content_read_team_things(db.get_ref(), &user).await?;
-    Ok(HttpResponse::Ok().json(db.get_collections(read_teams, list_query).await?))
+    Ok(HttpResponse::Ok().json(
+        db.list_collections_for_user(&user, query.into_inner()).await?,
+    ))
 }
 
 #[utoipa::path(
@@ -87,8 +84,7 @@ async fn get_collection(
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    let read_teams = content_read_team_things(db.get_ref(), &user).await?;
-    Ok(HttpResponse::Ok().json(db.get_collection(read_teams, &id).await?))
+    Ok(HttpResponse::Ok().json(db.get_collection_for_user(&user, &id).await?))
 }
 
 #[utoipa::path(
@@ -116,25 +112,7 @@ async fn get_collection_player(
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    let liked_set = db.get_liked_set(&user.id).await?;
-    let read_teams = content_read_team_things(db.get_ref(), &user).await?;
-    Ok(HttpResponse::Ok().json(
-        db.get_collection_songs(read_teams, &id)
-            .await?
-            .into_iter()
-            .enumerate()
-            .map(|(idx, link)| {
-                Player::from(SongLinkOwned {
-                    liked: liked_set.contains(&link.song.id),
-                    song: link.song,
-                    nr: Some(link.nr.unwrap_or_else(|| (idx + 1).to_string())),
-                    key: link.key,
-                })
-            })
-            .try_fold(Player::default(), |acc, player| {
-                Ok::<Player, AppError>(acc + player)
-            })?,
-    ))
+    Ok(HttpResponse::Ok().json(db.collection_player_for_user(&user, &id).await?))
 }
 
 #[utoipa::path(
@@ -169,16 +147,8 @@ async fn get_collection_export(
     id: Path<String>,
     query: Query<QueryParams>,
 ) -> Result<HttpResponse, AppError> {
-    let read_teams = content_read_team_things(db.get_ref(), &user).await?;
-    export(
-        db.get_collection_songs(read_teams, &id)
-            .await?
-            .into_iter()
-            .map(|song_link_owned| song_link_owned.song)
-            .collect::<Vec<Song>>(),
-        query.into_inner().format,
-    )
-    .await
+    db.export_collection_for_user(&user, &id, query.into_inner().format)
+        .await
 }
 
 #[utoipa::path(
@@ -206,19 +176,7 @@ async fn get_collection_songs(
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    let liked_set = db.get_liked_set(&user.id).await?;
-    let read_teams = content_read_team_things(db.get_ref(), &user).await?;
-    Ok(HttpResponse::Ok().json(
-        db.get_collection_songs(read_teams, &id)
-            .await?
-            .into_iter()
-            .map(|song_link_owned| {
-                let mut song = song_link_owned.song;
-                song.user_specific_addons.liked = liked_set.contains(&song.id);
-                song
-            })
-            .collect::<Vec<Song>>(),
-    ))
+    Ok(HttpResponse::Ok().json(db.collection_songs_for_user(&user, &id).await?))
 }
 
 #[utoipa::path(
@@ -243,7 +201,9 @@ async fn create_collection(
     user: ReqData<User>,
     payload: Json<CreateCollection>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Created().json(db.create_collection(&user.id, payload.into_inner()).await?))
+    Ok(HttpResponse::Created().json(
+        db.create_collection_for_user(&user, payload.into_inner()).await?,
+    ))
 }
 
 #[utoipa::path(
@@ -273,9 +233,8 @@ async fn update_collection(
     id: Path<String>,
     payload: Json<CreateCollection>,
 ) -> Result<HttpResponse, AppError> {
-    let write_teams = content_write_team_things(db.get_ref(), &user).await?;
     Ok(HttpResponse::Ok().json(
-        db.update_collection(write_teams, &id, payload.into_inner())
+        db.update_collection_for_user(&user, &id, payload.into_inner())
             .await?,
     ))
 }
@@ -305,6 +264,5 @@ async fn delete_collection(
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    let write_teams = content_write_team_things(db.get_ref(), &user).await?;
-    Ok(HttpResponse::Ok().json(db.delete_collection(write_teams, &id).await?))
+    Ok(HttpResponse::Ok().json(db.delete_collection_for_user(&user, &id).await?))
 }

--- a/backend/src/resources/setlist/mod.rs
+++ b/backend/src/resources/setlist/mod.rs
@@ -1,6 +1,7 @@
 pub use shared::setlist::{CreateSetlist, Setlist};
 
 mod model;
+#[allow(unused_imports)]
 pub use model::Model;
 
 pub mod rest;

--- a/backend/src/resources/setlist/model.rs
+++ b/backend/src/resources/setlist/model.rs
@@ -1,15 +1,19 @@
+use actix_web::HttpResponse;
 use serde::{Deserialize, Serialize};
 use surrealdb::sql::Thing;
 
 use shared::{
     api::ListQuery,
+    player::Player,
     setlist::{CreateSetlist, Setlist},
-    song::{Link as SongLink, LinkOwned as SongLinkOwned, SimpleChord},
+    song::{Link as SongLink, LinkOwned as SongLinkOwned, SimpleChord, Song},
 };
 
 use crate::database::Database;
 use crate::error::AppError;
-use crate::resources::song::SongRecord;
+use crate::resources::song::{Model as SongDbModel, SongRecord, export, Format};
+use crate::resources::team::{content_read_team_things, content_write_team_things};
+use crate::resources::User;
 
 pub trait Model {
     async fn get_setlists(
@@ -185,6 +189,113 @@ impl Model for Database {
             .map(SetlistRecord::into_setlist)
             .ok_or_else(|| AppError::NotFound("setlist not found".into()))
     }
+}
+
+impl Database {
+    pub async fn list_setlists_for_user(
+        &self,
+        user: &User,
+        pagination: ListQuery,
+    ) -> Result<Vec<Setlist>, AppError> {
+        let read_teams = content_read_team_things(self, user).await?;
+        self.get_setlists(read_teams, pagination).await
+    }
+
+    pub async fn get_setlist_for_user(&self, user: &User, id: &str) -> Result<Setlist, AppError> {
+        let read_teams = content_read_team_things(self, user).await?;
+        self.get_setlist(read_teams, id).await
+    }
+
+    pub async fn setlist_player_for_user(
+        &self,
+        user: &User,
+        id: &str,
+    ) -> Result<Player, AppError> {
+        let liked_set = SongDbModel::get_liked_set(self, &user.id).await?;
+        let read_teams = content_read_team_things(self, user).await?;
+        let links = self.get_setlist_songs(read_teams, id).await?;
+        player_from_song_links(liked_set, links)
+    }
+
+    pub async fn export_setlist_for_user(
+        &self,
+        user: &User,
+        id: &str,
+        format: Format,
+    ) -> Result<HttpResponse, AppError> {
+        let read_teams = content_read_team_things(self, user).await?;
+        let songs: Vec<Song> = self
+            .get_setlist_songs(read_teams, id)
+            .await?
+            .into_iter()
+            .map(|l| l.song)
+            .collect();
+        export(songs, format).await
+    }
+
+    pub async fn setlist_songs_for_user(
+        &self,
+        user: &User,
+        id: &str,
+    ) -> Result<Vec<Song>, AppError> {
+        let liked_set = SongDbModel::get_liked_set(self, &user.id).await?;
+        let read_teams = content_read_team_things(self, user).await?;
+        Ok(self
+            .get_setlist_songs(read_teams, id)
+            .await?
+            .into_iter()
+            .map(|song_link_owned| {
+                let mut song = song_link_owned.song;
+                song.user_specific_addons.liked = liked_set.contains(&song.id);
+                song
+            })
+            .collect())
+    }
+
+    pub async fn create_setlist_for_user(
+        &self,
+        user: &User,
+        setlist: CreateSetlist,
+    ) -> Result<Setlist, AppError> {
+        self.create_setlist(&user.id, setlist).await
+    }
+
+    pub async fn update_setlist_for_user(
+        &self,
+        user: &User,
+        id: &str,
+        setlist: CreateSetlist,
+    ) -> Result<Setlist, AppError> {
+        let write_teams = content_write_team_things(self, user).await?;
+        self.update_setlist(write_teams, id, setlist).await
+    }
+
+    pub async fn delete_setlist_for_user(
+        &self,
+        user: &User,
+        id: &str,
+    ) -> Result<Setlist, AppError> {
+        let write_teams = content_write_team_things(self, user).await?;
+        self.delete_setlist(write_teams, id).await
+    }
+}
+
+fn player_from_song_links(
+    liked_set: std::collections::HashSet<String>,
+    links: Vec<SongLinkOwned>,
+) -> Result<Player, AppError> {
+    links
+        .into_iter()
+        .enumerate()
+        .map(|(idx, link)| {
+            Player::from(SongLinkOwned {
+                liked: liked_set.contains(&link.song.id),
+                song: link.song,
+                nr: Some(link.nr.unwrap_or_else(|| (idx + 1).to_string())),
+                key: link.key,
+            })
+        })
+        .try_fold(Player::default(), |acc, player| Ok::<Player, AppError>(acc + player))
 }
 
 fn setlist_resource(id: &str) -> Result<(String, String), AppError> {

--- a/backend/src/resources/setlist/model.rs
+++ b/backend/src/resources/setlist/model.rs
@@ -11,9 +11,9 @@ use shared::{
 
 use crate::database::Database;
 use crate::error::AppError;
-use crate::resources::song::{Model as SongDbModel, SongRecord, export, Format};
-use crate::resources::team::{content_read_team_things, content_write_team_things};
 use crate::resources::User;
+use crate::resources::song::{Format, Model as SongDbModel, SongRecord, export};
+use crate::resources::team::{content_read_team_things, content_write_team_things};
 
 pub trait Model {
     async fn get_setlists(
@@ -206,11 +206,7 @@ impl Database {
         self.get_setlist(read_teams, id).await
     }
 
-    pub async fn setlist_player_for_user(
-        &self,
-        user: &User,
-        id: &str,
-    ) -> Result<Player, AppError> {
+    pub async fn setlist_player_for_user(&self, user: &User, id: &str) -> Result<Player, AppError> {
         let liked_set = SongDbModel::get_liked_set(self, &user.id).await?;
         let read_teams = content_read_team_things(self, user).await?;
         let links = self.get_setlist_songs(read_teams, id).await?;
@@ -295,7 +291,9 @@ fn player_from_song_links(
                 key: link.key,
             })
         })
-        .try_fold(Player::default(), |acc, player| Ok::<Player, AppError>(acc + player))
+        .try_fold(Player::default(), |acc, player| {
+            Ok::<Player, AppError>(acc + player)
+        })
 }
 
 fn setlist_resource(id: &str) -> Result<(String, String), AppError> {

--- a/backend/src/resources/setlist/rest.rs
+++ b/backend/src/resources/setlist/rest.rs
@@ -54,9 +54,7 @@ async fn get_setlists(
     user: ReqData<User>,
     query: Query<ListQuery>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Ok().json(
-        db.list_setlists_for_user(&user, query.into_inner()).await?,
-    ))
+    Ok(HttpResponse::Ok().json(db.list_setlists_for_user(&user, query.into_inner()).await?))
 }
 
 #[utoipa::path(
@@ -202,7 +200,8 @@ async fn create_setlist(
     payload: Json<CreateSetlist>,
 ) -> Result<HttpResponse, AppError> {
     Ok(HttpResponse::Created().json(
-        db.create_setlist_for_user(&user, payload.into_inner()).await?,
+        db.create_setlist_for_user(&user, payload.into_inner())
+            .await?,
     ))
 }
 

--- a/backend/src/resources/setlist/rest.rs
+++ b/backend/src/resources/setlist/rest.rs
@@ -3,7 +3,6 @@ use actix_web::{
     web::{self, Data, Json, Path, Query, ReqData},
 };
 
-use super::Model;
 use crate::database::Database;
 #[allow(unused_imports)]
 use crate::docs::ErrorResponse;
@@ -12,13 +11,11 @@ use crate::resources::User;
 use crate::resources::setlist::CreateSetlist;
 #[allow(unused_imports)]
 use crate::resources::setlist::Setlist;
-use crate::resources::song::Model as SongModel;
 #[allow(unused_imports)]
-use crate::resources::song::{Format, QueryParams, Song, export};
-use crate::resources::team::{content_read_team_things, content_write_team_things};
+use crate::resources::song::{Format, QueryParams, Song};
 use shared::api::ListQuery;
+#[allow(unused_imports)]
 use shared::player::Player;
-use shared::song::LinkOwned as SongLinkOwned;
 
 pub fn scope() -> Scope {
     web::scope("/setlists")
@@ -57,9 +54,9 @@ async fn get_setlists(
     user: ReqData<User>,
     query: Query<ListQuery>,
 ) -> Result<HttpResponse, AppError> {
-    let list_query = query.into_inner();
-    let read_teams = content_read_team_things(db.get_ref(), &user).await?;
-    Ok(HttpResponse::Ok().json(db.get_setlists(read_teams, list_query).await?))
+    Ok(HttpResponse::Ok().json(
+        db.list_setlists_for_user(&user, query.into_inner()).await?,
+    ))
 }
 
 #[utoipa::path(
@@ -87,8 +84,7 @@ async fn get_setlist(
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    let read_teams = content_read_team_things(db.get_ref(), &user).await?;
-    Ok(HttpResponse::Ok().json(db.get_setlist(read_teams, &id).await?))
+    Ok(HttpResponse::Ok().json(db.get_setlist_for_user(&user, &id).await?))
 }
 
 #[utoipa::path(
@@ -116,25 +112,7 @@ async fn get_setlist_player(
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    let liked_set = db.get_liked_set(&user.id).await?;
-    let read_teams = content_read_team_things(db.get_ref(), &user).await?;
-    Ok(HttpResponse::Ok().json(
-        db.get_setlist_songs(read_teams, &id)
-            .await?
-            .into_iter()
-            .enumerate()
-            .map(|(idx, link)| {
-                Player::from(SongLinkOwned {
-                    liked: liked_set.contains(&link.song.id),
-                    song: link.song,
-                    nr: Some(link.nr.unwrap_or_else(|| (idx + 1).to_string())),
-                    key: link.key,
-                })
-            })
-            .try_fold(Player::default(), |acc, player| {
-                Ok::<Player, AppError>(acc + player)
-            })?,
-    ))
+    Ok(HttpResponse::Ok().json(db.setlist_player_for_user(&user, &id).await?))
 }
 
 #[utoipa::path(
@@ -169,15 +147,8 @@ async fn get_setlist_export(
     id: Path<String>,
     query: Query<QueryParams>,
 ) -> Result<HttpResponse, AppError> {
-    let query = query.into_inner();
-    let read_teams = content_read_team_things(db.get_ref(), &user).await?;
-    let songs = db
-        .get_setlist_songs(read_teams, &id)
-        .await?
-        .into_iter()
-        .map(|song_link_owned| song_link_owned.song)
-        .collect::<Vec<Song>>();
-    export(songs, query.format).await
+    db.export_setlist_for_user(&user, &id, query.into_inner().format)
+        .await
 }
 
 #[utoipa::path(
@@ -205,19 +176,7 @@ async fn get_setlist_songs(
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    let liked_set = db.get_liked_set(&user.id).await?;
-    let read_teams = content_read_team_things(db.get_ref(), &user).await?;
-    Ok(HttpResponse::Ok().json(
-        db.get_setlist_songs(read_teams, &id)
-            .await?
-            .into_iter()
-            .map(|song_link_owned| {
-                let mut song = song_link_owned.song;
-                song.user_specific_addons.liked = liked_set.contains(&song.id);
-                song
-            })
-            .collect::<Vec<Song>>(),
-    ))
+    Ok(HttpResponse::Ok().json(db.setlist_songs_for_user(&user, &id).await?))
 }
 
 #[utoipa::path(
@@ -242,7 +201,9 @@ async fn create_setlist(
     user: ReqData<User>,
     payload: Json<CreateSetlist>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Created().json(db.create_setlist(&user.id, payload.into_inner()).await?))
+    Ok(HttpResponse::Created().json(
+        db.create_setlist_for_user(&user, payload.into_inner()).await?,
+    ))
 }
 
 #[utoipa::path(
@@ -271,9 +232,8 @@ async fn update_setlist(
     id: Path<String>,
     payload: Json<CreateSetlist>,
 ) -> Result<HttpResponse, AppError> {
-    let write_teams = content_write_team_things(db.get_ref(), &user).await?;
     Ok(HttpResponse::Ok().json(
-        db.update_setlist(write_teams, &id, payload.into_inner())
+        db.update_setlist_for_user(&user, &id, payload.into_inner())
             .await?,
     ))
 }
@@ -303,6 +263,5 @@ async fn delete_setlist(
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    let write_teams = content_write_team_things(db.get_ref(), &user).await?;
-    Ok(HttpResponse::Ok().json(db.delete_setlist(write_teams, &id).await?))
+    Ok(HttpResponse::Ok().json(db.delete_setlist_for_user(&user, &id).await?))
 }

--- a/backend/src/resources/song/mod.rs
+++ b/backend/src/resources/song/mod.rs
@@ -1,7 +1,9 @@
 pub use shared::song::{CreateSong, Song};
 
 mod model;
-pub use model::{Model, SongRecord};
+#[allow(unused_imports)]
+pub use model::Model;
+pub use model::SongRecord;
 
 pub mod rest;
 

--- a/backend/src/resources/song/model.rs
+++ b/backend/src/resources/song/model.rs
@@ -1,14 +1,25 @@
 use std::collections::HashSet;
 
+use actix_web::HttpResponse;
 use chordlib::types::Song as SongData;
 use serde::{Deserialize, Serialize};
 use surrealdb::sql::{Id, Thing};
 
 use shared::api::ListQuery;
-use shared::song::{CreateSong, Song, SongUserSpecificAddons};
+use shared::like::LikeStatus;
+use shared::player::Player;
+use shared::song::{
+    CreateSong, Link as SongLink, LinkOwned as SongLinkOwned, Song, SongUserSpecificAddons,
+};
 
 use crate::database::Database;
 use crate::error::AppError;
+use crate::resources::collection::{CreateCollection, Model as CollectionDbModel};
+use crate::resources::user::Model as UserDbModel;
+use crate::resources::team::{content_read_team_things, content_write_team_things};
+use crate::resources::User;
+
+use super::{export, Format};
 
 pub trait Model {
     async fn get_songs(
@@ -254,6 +265,132 @@ impl Model for Database {
             .into_iter()
             .map(|like| like.song.id.to_string())
             .collect())
+    }
+}
+
+impl Database {
+    pub async fn list_songs_for_user(
+        &self,
+        user: &User,
+        pagination: ListQuery,
+    ) -> Result<Vec<Song>, AppError> {
+        let liked_set = self.get_liked_set(&user.id).await?;
+        let read_teams = content_read_team_things(self, user).await?;
+        Ok(self
+            .get_songs(read_teams, pagination)
+            .await?
+            .into_iter()
+            .map(|mut song| {
+                song.user_specific_addons.liked = liked_set.contains(&song.id);
+                song
+            })
+            .collect())
+    }
+
+    pub async fn get_song_for_user(&self, user: &User, id: &str) -> Result<Song, AppError> {
+        let liked_set = self.get_liked_set(&user.id).await?;
+        let read_teams = content_read_team_things(self, user).await?;
+        let mut song = self.get_song(read_teams, id).await?;
+        song.user_specific_addons.liked = liked_set.contains(&song.id);
+        Ok(song)
+    }
+
+    pub async fn song_player_for_user(&self, user: &User, id: &str) -> Result<Player, AppError> {
+        let read_teams = content_read_team_things(self, user).await?;
+        Ok(Player::from(SongLinkOwned {
+            song: self.get_song(read_teams.clone(), id).await?,
+            nr: None,
+            key: None,
+            liked: self.get_song_like(read_teams, &user.id, id).await?,
+        }))
+    }
+
+    pub async fn export_song_for_user(
+        &self,
+        user: &User,
+        id: &str,
+        format: Format,
+    ) -> Result<HttpResponse, AppError> {
+        let read_teams = content_read_team_things(self, user).await?;
+        let song = self.get_song(read_teams, id).await?;
+        export(vec![song], format).await
+    }
+
+    pub async fn create_song_for_user(
+        &self,
+        user: &User,
+        song: CreateSong,
+    ) -> Result<Song, AppError> {
+        let created = self.create_song(&user.id, song).await?;
+
+        if let Some(collection_id) = user.default_collection.as_ref() {
+            let write_teams = content_write_team_things(self, user).await?;
+            CollectionDbModel::add_song_to_collection(
+                self,
+                write_teams,
+                collection_id,
+                SongLink {
+                    id: created.id.clone(),
+                    nr: None,
+                    key: None,
+                },
+            )
+            .await?;
+        } else {
+            let collection = CollectionDbModel::create_collection(
+                self,
+                &user.id,
+                CreateCollection {
+                    title: "Default".to_string(),
+                    cover: "mysongs".to_string(),
+                    songs: vec![SongLink {
+                        id: created.id.clone(),
+                        nr: None,
+                        key: None,
+                    }],
+                },
+            )
+            .await?;
+            UserDbModel::set_default_collection_to_user(self, &user.id, &collection.id).await?;
+        }
+
+        Ok(created)
+    }
+
+    pub async fn update_song_for_user(
+        &self,
+        user: &User,
+        id: &str,
+        song: CreateSong,
+    ) -> Result<Song, AppError> {
+        let write_teams = content_write_team_things(self, user).await?;
+        self.update_song(write_teams, &user.id, id, song).await
+    }
+
+    pub async fn delete_song_for_user(&self, user: &User, id: &str) -> Result<Song, AppError> {
+        let write_teams = content_write_team_things(self, user).await?;
+        self.delete_song(write_teams, id).await
+    }
+
+    pub async fn song_like_status_for_user(
+        &self,
+        user: &User,
+        id: &str,
+    ) -> Result<LikeStatus, AppError> {
+        let read_teams = content_read_team_things(self, user).await?;
+        let liked = self.get_song_like(read_teams, &user.id, id).await?;
+        Ok(LikeStatus { liked })
+    }
+
+    pub async fn set_song_like_status_for_user(
+        &self,
+        user: &User,
+        id: &str,
+        liked: bool,
+    ) -> Result<LikeStatus, AppError> {
+        let read_teams = content_read_team_things(self, user).await?;
+        let liked = self.set_song_like(read_teams, &user.id, id, liked).await?;
+        Ok(LikeStatus { liked })
     }
 }
 

--- a/backend/src/resources/song/model.rs
+++ b/backend/src/resources/song/model.rs
@@ -14,12 +14,12 @@ use shared::song::{
 
 use crate::database::Database;
 use crate::error::AppError;
-use crate::resources::collection::{CreateCollection, Model as CollectionDbModel};
-use crate::resources::user::Model as UserDbModel;
-use crate::resources::team::{content_read_team_things, content_write_team_things};
 use crate::resources::User;
+use crate::resources::collection::{CreateCollection, Model as CollectionDbModel};
+use crate::resources::team::{content_read_team_things, content_write_team_things};
+use crate::resources::user::Model as UserDbModel;
 
-use super::{export, Format};
+use super::{Format, export};
 
 pub trait Model {
     async fn get_songs(

--- a/backend/src/resources/song/rest.rs
+++ b/backend/src/resources/song/rest.rs
@@ -56,9 +56,7 @@ async fn get_songs(
     user: ReqData<User>,
     query: Query<ListQuery>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Ok().json(
-        db.list_songs_for_user(&user, query.into_inner()).await?,
-    ))
+    Ok(HttpResponse::Ok().json(db.list_songs_for_user(&user, query.into_inner()).await?))
 }
 
 #[utoipa::path(
@@ -175,9 +173,7 @@ async fn create_song(
     user: ReqData<User>,
     payload: Json<CreateSong>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Created().json(
-        db.create_song_for_user(&user, payload.into_inner()).await?,
-    ))
+    Ok(HttpResponse::Created().json(db.create_song_for_user(&user, payload.into_inner()).await?))
 }
 
 #[utoipa::path(
@@ -208,7 +204,8 @@ async fn update_song(
     payload: Json<CreateSong>,
 ) -> Result<HttpResponse, AppError> {
     Ok(HttpResponse::Ok().json(
-        db.update_song_for_user(&user, &id, payload.into_inner()).await?,
+        db.update_song_for_user(&user, &id, payload.into_inner())
+            .await?,
     ))
 }
 

--- a/backend/src/resources/song/rest.rs
+++ b/backend/src/resources/song/rest.rs
@@ -3,24 +3,20 @@ use actix_web::{
     web::{self, Data, Json, Path, Query, ReqData},
 };
 
-use super::{Model, QueryParams, export};
 use crate::database::Database;
 #[allow(unused_imports)]
 use crate::docs::ErrorResponse;
 use crate::error::AppError;
 use crate::resources::User;
-use crate::resources::collection::CreateCollection;
-use crate::resources::collection::Model as CollectionModel;
 use crate::resources::song::CreateSong;
 #[allow(unused_imports)]
 use crate::resources::song::Song;
-use crate::resources::team::{content_read_team_things, content_write_team_things};
-use crate::resources::user::Model as UserModel;
+#[allow(unused_imports)]
+use crate::resources::song::{Format, QueryParams};
 use shared::api::ListQuery;
 use shared::like::LikeStatus;
+#[allow(unused_imports)]
 use shared::player::Player;
-use shared::song::Link as SongLink;
-use shared::song::LinkOwned as SongLinkOwned;
 
 pub fn scope() -> Scope {
     web::scope("/songs")
@@ -60,20 +56,9 @@ async fn get_songs(
     user: ReqData<User>,
     query: Query<ListQuery>,
 ) -> Result<HttpResponse, AppError> {
-    let liked_set = db.get_liked_set(&user.id).await?;
-    let list_query = query.into_inner();
-    let read_teams = content_read_team_things(db.get_ref(), &user).await?;
-    let songs = db
-        .get_songs(read_teams, list_query)
-        .await?
-        .into_iter()
-        .map(|song| {
-            let mut song = song;
-            song.user_specific_addons.liked = liked_set.contains(&song.id);
-            song
-        })
-        .collect::<Vec<Song>>();
-    Ok(HttpResponse::Ok().json(songs))
+    Ok(HttpResponse::Ok().json(
+        db.list_songs_for_user(&user, query.into_inner()).await?,
+    ))
 }
 
 #[utoipa::path(
@@ -101,11 +86,7 @@ async fn get_song(
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    let liked_set = db.get_liked_set(&user.id).await?;
-    let read_teams = content_read_team_things(db.get_ref(), &user).await?;
-    let mut song = db.get_song(read_teams, &id).await?;
-    song.user_specific_addons.liked = liked_set.contains(&song.id);
-    Ok(HttpResponse::Ok().json(song))
+    Ok(HttpResponse::Ok().json(db.get_song_for_user(&user, &id).await?))
 }
 
 #[utoipa::path(
@@ -133,13 +114,7 @@ async fn get_song_player(
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    let read_teams = content_read_team_things(db.get_ref(), &user).await?;
-    Ok(HttpResponse::Ok().json(Player::from(SongLinkOwned {
-        song: db.get_song(read_teams.clone(), &id).await?,
-        nr: None,
-        key: None,
-        liked: db.get_song_like(read_teams, &user.id, &id).await?,
-    })))
+    Ok(HttpResponse::Ok().json(db.song_player_for_user(&user, &id).await?))
 }
 
 #[utoipa::path(
@@ -174,10 +149,8 @@ async fn get_song_export(
     id: Path<String>,
     query: Query<QueryParams>,
 ) -> Result<HttpResponse, AppError> {
-    let query = query.into_inner();
-    let read_teams = content_read_team_things(db.get_ref(), &user).await?;
-    let song = db.get_song(read_teams, &id).await?;
-    export(vec![song], query.format).await
+    db.export_song_for_user(&user, &id, query.into_inner().format)
+        .await
 }
 
 #[utoipa::path(
@@ -202,40 +175,9 @@ async fn create_song(
     user: ReqData<User>,
     payload: Json<CreateSong>,
 ) -> Result<HttpResponse, AppError> {
-    let song = db.create_song(&user.id, payload.into_inner()).await?;
-
-    if let Some(collection_id) = user.default_collection.as_ref() {
-        let write_teams = content_write_team_things(db.get_ref(), &user).await?;
-        db.add_song_to_collection(
-            write_teams,
-            collection_id,
-            SongLink {
-                id: song.id.clone(),
-                nr: None,
-                key: None,
-            },
-        )
-        .await?;
-    } else {
-        let collection = db
-            .create_collection(
-                &user.id,
-                CreateCollection {
-                    title: "Default".to_string(),
-                    cover: "mysongs".to_string(),
-                    songs: vec![SongLink {
-                        id: song.id.clone(),
-                        nr: None,
-                        key: None,
-                    }],
-                },
-            )
-            .await?;
-        db.set_default_collection_to_user(&user.id, &collection.id)
-            .await?;
-    }
-
-    Ok(HttpResponse::Created().json(song))
+    Ok(HttpResponse::Created().json(
+        db.create_song_for_user(&user, payload.into_inner()).await?,
+    ))
 }
 
 #[utoipa::path(
@@ -265,10 +207,8 @@ async fn update_song(
     id: Path<String>,
     payload: Json<CreateSong>,
 ) -> Result<HttpResponse, AppError> {
-    let write_teams = content_write_team_things(db.get_ref(), &user).await?;
     Ok(HttpResponse::Ok().json(
-        db.update_song(write_teams, &user.id, &id, payload.into_inner())
-            .await?,
+        db.update_song_for_user(&user, &id, payload.into_inner()).await?,
     ))
 }
 
@@ -297,8 +237,7 @@ async fn delete_song(
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    let write_teams = content_write_team_things(db.get_ref(), &user).await?;
-    Ok(HttpResponse::Ok().json(db.delete_song(write_teams, &id).await?))
+    Ok(HttpResponse::Ok().json(db.delete_song_for_user(&user, &id).await?))
 }
 
 #[utoipa::path(
@@ -326,10 +265,7 @@ async fn get_song_like_status(
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    let read_teams = content_read_team_things(db.get_ref(), &user).await?;
-    let liked = db.get_song_like(read_teams, &user.id, &id).await?;
-
-    Ok(HttpResponse::Ok().json(LikeStatus { liked }))
+    Ok(HttpResponse::Ok().json(db.song_like_status_for_user(&user, &id).await?))
 }
 
 #[utoipa::path(
@@ -359,9 +295,8 @@ async fn update_song_like_status(
     id: Path<String>,
     payload: Json<LikeStatus>,
 ) -> Result<HttpResponse, AppError> {
-    let LikeStatus { liked } = payload.into_inner();
-    let read_teams = content_read_team_things(db.get_ref(), &user).await?;
-    let liked = db.set_song_like(read_teams, &user.id, &id, liked).await?;
-
-    Ok(HttpResponse::Ok().json(LikeStatus { liked }))
+    Ok(HttpResponse::Ok().json(
+        db.set_song_like_status_for_user(&user, &id, payload.into_inner().liked)
+            .await?,
+    ))
 }

--- a/backend/src/resources/team/invitation_model.rs
+++ b/backend/src/resources/team/invitation_model.rs
@@ -6,6 +6,7 @@ use shared::team::{Team, TeamInvitation, TeamUser};
 
 use crate::database::{Database, record_id_string};
 use crate::error::AppError;
+use crate::resources::User;
 use crate::resources::user::UserRecord;
 
 use super::model::{
@@ -307,5 +308,51 @@ impl TeamInvitationModel for Database {
             .map_err(AppError::database)?;
 
         load_team_display(self, &team_id_str).await
+    }
+}
+
+impl Database {
+    pub async fn create_team_invitation_for_user(
+        &self,
+        user: &User,
+        team_id: &str,
+    ) -> Result<TeamInvitation, AppError> {
+        self.create_team_invitation(&user.id, team_id).await
+    }
+
+    pub async fn list_team_invitations_for_user(
+        &self,
+        user: &User,
+        team_id: &str,
+    ) -> Result<Vec<TeamInvitation>, AppError> {
+        self.list_team_invitations(&user.id, team_id).await
+    }
+
+    pub async fn get_team_invitation_for_user(
+        &self,
+        user: &User,
+        team_id: &str,
+        invitation_id: &str,
+    ) -> Result<TeamInvitation, AppError> {
+        self.get_team_invitation(&user.id, team_id, invitation_id)
+            .await
+    }
+
+    pub async fn delete_team_invitation_for_user(
+        &self,
+        user: &User,
+        team_id: &str,
+        invitation_id: &str,
+    ) -> Result<(), AppError> {
+        self.delete_team_invitation(&user.id, team_id, invitation_id)
+            .await
+    }
+
+    pub async fn accept_team_invitation_for_user(
+        &self,
+        user: &User,
+        invitation_id: &str,
+    ) -> Result<Team, AppError> {
+        self.accept_team_invitation(&user.id, invitation_id).await
     }
 }

--- a/backend/src/resources/team/model.rs
+++ b/backend/src/resources/team/model.rs
@@ -255,6 +255,39 @@ impl TeamModel for Database {
     }
 }
 
+impl Database {
+    pub async fn list_teams_for_user(&self, user: &User) -> Result<Vec<Team>, AppError> {
+        let app_admin = user.role == UserRole::Admin;
+        self.get_teams(&user.id, app_admin).await
+    }
+
+    pub async fn get_team_for_user(&self, user: &User, id: &str) -> Result<Team, AppError> {
+        let app_admin = user.role == UserRole::Admin;
+        self.get_team(&user.id, id, app_admin).await
+    }
+
+    pub async fn create_shared_team_for_user(
+        &self,
+        user: &User,
+        payload: CreateTeam,
+    ) -> Result<Team, AppError> {
+        self.create_shared_team(&user.id, payload).await
+    }
+
+    pub async fn update_team_for_user(
+        &self,
+        user: &User,
+        id: &str,
+        payload: UpdateTeam,
+    ) -> Result<Team, AppError> {
+        self.update_team(&user.id, id, payload).await
+    }
+
+    pub async fn delete_team_for_user(&self, user: &User, id: &str) -> Result<Team, AppError> {
+        self.delete_team(&user.id, id).await
+    }
+}
+
 /// Teams whose content the user may list/read (GET), including `team:public` for catalog.
 pub async fn content_read_team_things(db: &Database, user: &User) -> Result<Vec<Thing>, AppError> {
     let app_admin = user.role == UserRole::Admin;

--- a/backend/src/resources/team/rest.rs
+++ b/backend/src/resources/team/rest.rs
@@ -1,10 +1,8 @@
-use super::invitation_model::TeamInvitationModel;
-use super::model::TeamModel;
 use crate::database::Database;
 #[allow(unused_imports)]
 use crate::docs::ErrorResponse;
 use crate::error::AppError;
-use crate::resources::{User, UserRole};
+use crate::resources::User;
 use actix_web::{
     HttpResponse, Scope, delete, get, post, put,
     web::{self, Data, Json, Path, ReqData},
@@ -63,10 +61,10 @@ async fn create_team_invitation(
     user: ReqData<User>,
     team_id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    let inv = db
-        .create_team_invitation(&user.id, team_id.as_str())
-        .await?;
-    Ok(HttpResponse::Created().json(inv))
+    Ok(HttpResponse::Created().json(
+        db.create_team_invitation_for_user(&user, team_id.as_str())
+            .await?,
+    ))
 }
 
 #[utoipa::path(
@@ -94,7 +92,10 @@ async fn list_team_invitations(
     user: ReqData<User>,
     team_id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Ok().json(db.list_team_invitations(&user.id, team_id.as_str()).await?))
+    Ok(HttpResponse::Ok().json(
+        db.list_team_invitations_for_user(&user, team_id.as_str())
+            .await?,
+    ))
 }
 
 #[utoipa::path(
@@ -125,7 +126,7 @@ async fn get_team_invitation(
 ) -> Result<HttpResponse, AppError> {
     let (team_id, invitation_id) = path.into_inner();
     Ok(HttpResponse::Ok().json(
-        db.get_team_invitation(&user.id, &team_id, &invitation_id)
+        db.get_team_invitation_for_user(&user, &team_id, &invitation_id)
             .await?,
     ))
 }
@@ -157,7 +158,7 @@ async fn delete_team_invitation(
     path: Path<(String, String)>,
 ) -> Result<HttpResponse, AppError> {
     let (team_id, invitation_id) = path.into_inner();
-    db.delete_team_invitation(&user.id, &team_id, &invitation_id)
+    db.delete_team_invitation_for_user(&user, &team_id, &invitation_id)
         .await?;
     Ok(HttpResponse::NoContent().finish())
 }
@@ -187,7 +188,7 @@ async fn accept_team_invitation(
     invitation_id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
     Ok(HttpResponse::Ok().json(
-        db.accept_team_invitation(&user.id, invitation_id.as_str())
+        db.accept_team_invitation_for_user(&user, invitation_id.as_str())
             .await?,
     ))
 }
@@ -208,8 +209,7 @@ async fn accept_team_invitation(
 )]
 #[get("")]
 async fn get_teams(db: Data<Database>, user: ReqData<User>) -> Result<HttpResponse, AppError> {
-    let app_admin = user.role == UserRole::Admin;
-    Ok(HttpResponse::Ok().json(db.get_teams(&user.id, app_admin).await?))
+    Ok(HttpResponse::Ok().json(db.list_teams_for_user(&user).await?))
 }
 
 #[utoipa::path(
@@ -236,8 +236,7 @@ async fn get_team(
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    let app_admin = user.role == UserRole::Admin;
-    Ok(HttpResponse::Ok().json(db.get_team(&user.id, &id, app_admin).await?))
+    Ok(HttpResponse::Ok().json(db.get_team_for_user(&user, &id).await?))
 }
 
 #[utoipa::path(
@@ -262,10 +261,9 @@ async fn create_team(
     user: ReqData<User>,
     payload: Json<CreateTeam>,
 ) -> Result<HttpResponse, AppError> {
-    let team = db
-        .create_shared_team(&user.id, payload.into_inner())
-        .await?;
-    Ok(HttpResponse::Created().json(team))
+    Ok(HttpResponse::Created().json(
+        db.create_shared_team_for_user(&user, payload.into_inner()).await?,
+    ))
 }
 
 #[utoipa::path(
@@ -297,7 +295,9 @@ async fn update_team(
     id: Path<String>,
     payload: Json<UpdateTeam>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Ok().json(db.update_team(&user.id, &id, payload.into_inner()).await?))
+    Ok(HttpResponse::Ok().json(
+        db.update_team_for_user(&user, &id, payload.into_inner()).await?,
+    ))
 }
 
 #[utoipa::path(
@@ -325,5 +325,5 @@ async fn delete_team(
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Ok().json(db.delete_team(&user.id, &id).await?))
+    Ok(HttpResponse::Ok().json(db.delete_team_for_user(&user, &id).await?))
 }

--- a/backend/src/resources/team/rest.rs
+++ b/backend/src/resources/team/rest.rs
@@ -262,7 +262,8 @@ async fn create_team(
     payload: Json<CreateTeam>,
 ) -> Result<HttpResponse, AppError> {
     Ok(HttpResponse::Created().json(
-        db.create_shared_team_for_user(&user, payload.into_inner()).await?,
+        db.create_shared_team_for_user(&user, payload.into_inner())
+            .await?,
     ))
 }
 
@@ -296,7 +297,8 @@ async fn update_team(
     payload: Json<UpdateTeam>,
 ) -> Result<HttpResponse, AppError> {
     Ok(HttpResponse::Ok().json(
-        db.update_team_for_user(&user, &id, payload.into_inner()).await?,
+        db.update_team_for_user(&user, &id, payload.into_inner())
+            .await?,
     ))
 }
 

--- a/backend/src/resources/user/model.rs
+++ b/backend/src/resources/user/model.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use surrealdb::sql::Datetime;
 use surrealdb::sql::Thing;
 
-use super::{Role, User};
+use super::{CreateUserRequest, Role, User};
 use crate::database::Database;
 use crate::error::AppError;
 use crate::resources::team::TeamModel;
@@ -108,6 +108,15 @@ impl Model for Database {
             ))
             .await?;
         Ok(())
+    }
+}
+
+impl Database {
+    pub async fn create_user_from_request(
+        &self,
+        request: CreateUserRequest,
+    ) -> Result<User, AppError> {
+        self.create_user(request.into_user()).await
     }
 }
 

--- a/backend/src/resources/user/rest.rs
+++ b/backend/src/resources/user/rest.rs
@@ -121,9 +121,7 @@ async fn create_user(
     db: Data<Database>,
     payload: Json<CreateUserRequest>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Created().json(
-        db.create_user_from_request(payload.into_inner()).await?,
-    ))
+    Ok(HttpResponse::Created().json(db.create_user_from_request(payload.into_inner()).await?))
 }
 
 #[utoipa::path(

--- a/backend/src/resources/user/rest.rs
+++ b/backend/src/resources/user/rest.rs
@@ -121,7 +121,9 @@ async fn create_user(
     db: Data<Database>,
     payload: Json<CreateUserRequest>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Created().json(db.create_user(payload.into_inner().into_user()).await?))
+    Ok(HttpResponse::Created().json(
+        db.create_user_from_request(payload.into_inner()).await?,
+    ))
 }
 
 #[utoipa::path(

--- a/backend/src/resources/user/session/model.rs
+++ b/backend/src/resources/user/session/model.rs
@@ -4,7 +4,7 @@ use surrealdb::sql::{Datetime, Thing};
 use super::Session;
 use crate::database::Database;
 use crate::error::AppError;
-use crate::resources::user::UserRecord;
+use crate::resources::user::{Model as UserDbModel, UserRecord};
 
 pub trait Model {
     async fn get_sessions_by_user_id(&self, user_id: &str) -> Result<Vec<Session>, AppError>;
@@ -86,6 +86,20 @@ impl Model for Database {
             .into_iter()
             .map(|record| record.into_session())
             .collect())
+    }
+}
+
+impl Database {
+    pub async fn create_session_for_user_by_id(
+        &self,
+        user_id: &str,
+        ttl_seconds: i64,
+    ) -> Result<Session, AppError> {
+        self.create_session(Session::new(
+            UserDbModel::get_user(self, user_id).await?,
+            ttl_seconds,
+        ))
+            .await
     }
 }
 

--- a/backend/src/resources/user/session/model.rs
+++ b/backend/src/resources/user/session/model.rs
@@ -99,7 +99,7 @@ impl Database {
             UserDbModel::get_user(self, user_id).await?,
             ttl_seconds,
         ))
-            .await
+        .await
     }
 }
 

--- a/backend/src/resources/user/session/rest.rs
+++ b/backend/src/resources/user/session/rest.rs
@@ -9,7 +9,7 @@ use crate::database::Database;
 #[allow(unused_imports)]
 use crate::docs::ErrorResponse;
 use crate::error::AppError;
-use crate::resources::{Session, User, UserModel};
+use crate::resources::User;
 use crate::settings::Settings;
 
 #[utoipa::path(
@@ -111,8 +111,7 @@ async fn create_session_for_user(
 ) -> Result<HttpResponse, AppError> {
     let ttl = Settings::global().session_ttl_seconds as i64;
     Ok(HttpResponse::Created().json(
-        db.create_session(Session::new(db.get_user(&path.user_id).await?, ttl))
-            .await?,
+        db.create_session_for_user_by_id(&path.user_id, ttl).await?,
     ))
 }
 

--- a/backend/src/resources/user/session/rest.rs
+++ b/backend/src/resources/user/session/rest.rs
@@ -110,9 +110,7 @@ async fn create_session_for_user(
     path: Path<UserIdPath>,
 ) -> Result<HttpResponse, AppError> {
     let ttl = Settings::global().session_ttl_seconds as i64;
-    Ok(HttpResponse::Created().json(
-        db.create_session_for_user_by_id(&path.user_id, ttl).await?,
-    ))
+    Ok(HttpResponse::Created().json(db.create_session_for_user_by_id(&path.user_id, ttl).await?))
 }
 
 #[utoipa::path(


### PR DESCRIPTION
Moves orchestration (team scoping, likes, default collection behavior, exports, etc.) out of actix handlers into `Database` / model-layer helpers for blob, collection, setlist, song, team, and user resources.

Verified with `cargo check` in `backend/`.

Made with [Cursor](https://cursor.com)