### PR TITLE
ci: publish Docker image on main and tags

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -4,14 +4,8 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "backend/**"
-      - "shared/**"
-      - "frontend/**"
-      - "rust-toolchain.toml"
-      - "Dockerfile"
-      - ".dockerignore"
-      - ".github/workflows/backend-ci.yml"
+    tags:
+      - "*"
   pull_request:
     branches:
       - main
@@ -58,6 +52,7 @@ jobs:
 
   docker-build:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
     steps:
       - uses: actions/checkout@v4
 
@@ -70,5 +65,51 @@ jobs:
           context: .
           push: false
           tags: worship-viewer:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  docker-publish:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag commit is on main
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          git fetch origin main
+          git branch -r --contains "$GITHUB_SHA" | grep -q "origin/main"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: xilefmusics/worship-viewer
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest
+            type=raw,value=main,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- trigger backend CI on pushes to `main` and on all tags
- add Docker publish job that logs into Docker Hub and pushes `xilefmusics/worship-viewer`
- keep `latest` refreshed on publish, publish tag-specific images on tag pushes, and skip Docker build jobs for feature-branch/PR activity

## Test plan
- [ ] Push a commit to `main` and verify `docker-publish` pushes `:latest`
- [ ] Push a tag from a commit on `main` and verify `:<tag>` and `:latest` are pushed
- [ ] Open/update a PR from a feature branch and verify Docker build/publish jobs do not run
- [ ] Confirm repository secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` are configured

Made with [Cursor](https://cursor.com)