### PR TITLE
fix(docs): set explicit Swagger API title

### DIFF
--- a/backend/src/docs.rs
+++ b/backend/src/docs.rs
@@ -33,6 +33,7 @@ pub mod rest {
 
 #[derive(OpenApi)]
 #[openapi(
+    info(title = "Worship Viewer API"),
     paths(
         crate::auth::oidc::rest::login,
         crate::auth::oidc::rest::callback,


### PR DESCRIPTION
## Summary
- Set an explicit OpenAPI `info.title` in the backend Swagger configuration.
- Prevent Swagger docs from defaulting to the crate name `backend`.
- Keep API surface unchanged; this is a docs metadata update only.

## Test plan
- [x] Confirm `backend/src/docs.rs` includes `info(title = \"Worship Viewer API\")`.
- [ ] Open `/api/docs` and verify the displayed API title is no longer `backend`.

Made with [Cursor](https://cursor.com)