### PR TITLE
feat(api): implement P1 REST API hardening

### DIFF
--- a/backend/src/auth/bearer.rs
+++ b/backend/src/auth/bearer.rs
@@ -12,18 +12,16 @@ pub fn authorization_bearer(msg: &impl HttpMessage) -> Option<String> {
         return None;
     }
 
-    let (scheme, token) = match value.split_once(' ') {
-        Some(pair) => pair,
-        None => return Some(value.to_owned()),
-    };
+    let (scheme, token) = value.split_once(' ')?;
 
     if !scheme.eq_ignore_ascii_case("bearer") {
         return None;
     }
 
-    if token.trim().is_empty() {
+    let token = token.trim();
+    if token.is_empty() {
         None
     } else {
-        Some(token.trim().to_owned())
+        Some(token.to_owned())
     }
 }

--- a/backend/src/docs.rs
+++ b/backend/src/docs.rs
@@ -168,7 +168,7 @@ impl Modify for SessionSecurity {
             "SessionToken",
             SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::with_description(
                 "Authorization",
-                "Optional session override using `Authorization` header (raw value or `Bearer <session>`)",
+                "Session override using `Authorization: Bearer <session>` header",
             ))),
         );
     }

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -1,4 +1,5 @@
 use actix_web::http::StatusCode;
+use actix_web::web::JsonConfig;
 use actix_web::{HttpResponse, ResponseError};
 use serde_json::json;
 use thiserror::Error;
@@ -20,6 +21,21 @@ pub enum AppError {
     TooManyRequests(String),
     #[error("internal error: {0}")]
     Internal(String),
+}
+
+/// Return an actix-web `JsonConfig` that maps deserialization errors
+/// (including unknown fields from `deny_unknown_fields`) to a well-formed
+/// 400 `AppError::InvalidRequest` response instead of the default plain-text
+/// 400 from actix-web.
+pub fn json_config() -> JsonConfig {
+    JsonConfig::default().error_handler(|err, _req| {
+        let message = err.to_string();
+        actix_web::error::InternalError::from_response(
+            err,
+            AppError::InvalidRequest(message).error_response(),
+        )
+        .into()
+    })
 }
 
 impl AppError {
@@ -79,7 +95,11 @@ impl From<surrealdb::Error> for AppError {
                 | surrealdb::error::Db::InvalidUrl { .. }
                 | surrealdb::error::Db::SetCheck { .. }
                 | surrealdb::error::Db::TableCheck { .. } => {
-                    AppError::invalid_request(dberr.to_string())
+                    // Log the raw DB error (contains internal field/index names) and
+                    // return a sanitized message so database internals are not leaked
+                    // to clients.
+                    error!("database validation error: {dberr}");
+                    AppError::invalid_request("invalid request")
                 }
                 surrealdb::error::Db::NoRecordFound | surrealdb::error::Db::IdNotFound { .. } => {
                     AppError::NotFound("record not found".into())
@@ -104,6 +124,21 @@ impl From<reqwest::Error> for AppError {
     }
 }
 
+impl AppError {
+    /// Stable machine-readable code for this error variant.
+    pub fn code(&self) -> &'static str {
+        match self {
+            AppError::Unauthorized => "unauthorized",
+            AppError::Forbidden => "forbidden",
+            AppError::NotFound(_) => "not_found",
+            AppError::InvalidRequest(_) => "invalid_request",
+            AppError::Conflict(_) => "conflict",
+            AppError::TooManyRequests(_) => "too_many_requests",
+            AppError::Internal(_) => "internal",
+        }
+    }
+}
+
 impl ResponseError for AppError {
     fn status_code(&self) -> StatusCode {
         match self {
@@ -121,6 +156,13 @@ impl ResponseError for AppError {
         if matches!(self, AppError::Internal(_)) {
             error!("{}", self);
         }
-        HttpResponse::build(self.status_code()).json(json!({ "error": self.to_string() }))
+        // For Internal errors, strip the internal detail from the client response.
+        let message = if matches!(self, AppError::Internal(_)) {
+            "internal server error".to_owned()
+        } else {
+            self.to_string()
+        };
+        HttpResponse::build(self.status_code())
+            .json(json!({ "code": self.code(), "error": message }))
     }
 }

--- a/backend/src/http_tests.rs
+++ b/backend/src/http_tests.rs
@@ -70,6 +70,7 @@ fn build_app(
     });
 
     App::new()
+        .wrap(crate::request_id::RequestId)
         .app_data(Data::from(db.clone()))
         .app_data(Data::new(blob_service(&db, blob_dir)))
         .app_data(Data::new(collection_service(&db)))
@@ -80,6 +81,7 @@ fn build_app(
         .app_data(Data::new(user_service(&db)))
         .app_data(Data::new(session_service(&db)))
         .app_data(cookie_cfg)
+        .app_data(crate::error::json_config())
         .service(docs::rest::scope())
         .service(resources::rest::scope(20 * 1024 * 1024))
 }
@@ -281,9 +283,9 @@ mod http_contract {
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
-    /// BLC-HTTP-001: correct table prefix is accepted (not 400).
+    /// Table prefix form (`table:id`) is rejected with 400 at the HTTP edge.
     #[actix_web::test]
-    async fn blc_http_001_correct_table_prefix_not_400() {
+    async fn blc_http_001_table_prefix_form_returns_400() {
         let db = test_db().await.unwrap();
         let token = authed_token(&db, "http-contract-c@test.local").await;
         let app = test::init_service(build_app(db.clone())).await;
@@ -292,7 +294,7 @@ mod http_contract {
             .insert_header(("Authorization", format!("Bearer {token}")))
             .to_request();
         let resp = test::call_service(&app, req).await;
-        assert_ne!(resp.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
     /// BLC-HTTP-001: plain ID (no table prefix) is accepted (not 400).
@@ -327,7 +329,7 @@ mod http_contract {
             .insert_header(("Authorization", format!("Bearer {token}")))
             .to_request();
         let first_resp = test::call_service(&app, first).await;
-        assert_eq!(first_resp.status(), StatusCode::OK);
+        assert_eq!(first_resp.status(), StatusCode::NO_CONTENT);
 
         let second = test::TestRequest::delete()
             .uri(&format!("/api/v1/songs/{song_id}"))
@@ -415,10 +417,9 @@ mod user_admin_gates {
         assert_eq!(resp_b["id"], user_b.id);
     }
 
-    /// BLC-USER-006: raw token (no Bearer prefix) on GET /users/me returns 200.
-    /// The `authorization_bearer` function accepts raw tokens (no scheme) on all routes.
+    /// Raw token (no Bearer prefix) on GET /users/me returns 401 — only `Bearer <token>` is accepted.
     #[actix_web::test]
-    async fn blc_user_006_raw_token_on_me_returns_200() {
+    async fn blc_user_006_raw_token_on_me_returns_401() {
         let db = test_db().await.unwrap();
         let user = create_user(&db, "raw-token@test.local").await.unwrap();
         let token = create_session_token(&db, user).await.unwrap();
@@ -427,6 +428,20 @@ mod user_admin_gates {
         let req = test::TestRequest::get()
             .uri("/api/v1/users/me")
             .insert_header(("Authorization", token.clone()));
+        assert_eq!(call_status!(app, req), StatusCode::UNAUTHORIZED);
+    }
+
+    /// Bearer token (with prefix) on GET /users/me returns 200.
+    #[actix_web::test]
+    async fn blc_user_006b_bearer_token_on_me_returns_200() {
+        let db = test_db().await.unwrap();
+        let user = create_user(&db, "bearer-token@test.local").await.unwrap();
+        let token = create_session_token(&db, user).await.unwrap();
+
+        let app = test::init_service(build_app(db.clone())).await;
+        let req = test::TestRequest::get()
+            .uri("/api/v1/users/me")
+            .insert_header(("Authorization", format!("Bearer {token}")));
         assert_eq!(call_status!(app, req), StatusCode::OK);
     }
 
@@ -616,7 +631,7 @@ mod session_admin_gates {
             .insert_header(("Authorization", format!("Bearer {token}")))
             .to_request();
         let resp = test::call_service(&app, req).await;
-        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
     }
 
     /// BLC-SESS-004: GET /users/me/sessions/{other_user_session} should return 404.
@@ -704,9 +719,9 @@ mod session_admin_gates {
         assert_eq!(resp.status(), StatusCode::CREATED);
     }
 
-    /// BLC-SESS-006: admin DELETE /users/{user_id}/sessions/{id} returns 200.
+    /// BLC-SESS-006: admin DELETE /users/{user_id}/sessions/{id} returns 204.
     #[actix_web::test]
-    async fn blc_sess_006_admin_delete_other_session_returns_200() {
+    async fn blc_sess_006_admin_delete_other_session_returns_204() {
         let db = test_db().await.unwrap();
         let (_, admin_token) = make_admin(&db, "admin-ds@test.local").await;
         let other = create_user(&db, "admin-ds-other@test.local").await.unwrap();
@@ -721,7 +736,7 @@ mod session_admin_gates {
             .insert_header(("Authorization", format!("Bearer {admin_token}")))
             .to_request();
         let resp = test::call_service(&app, req).await;
-        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
     }
 
     /// BLC-SESS-009: deleted session token on an authenticated route returns 401.
@@ -855,24 +870,18 @@ mod list_pagination {
         );
     }
 
-    /// BLC-LP-006: page_size=0 returns all items.
+    /// page_size=0 is now rejected with 400 (BLC-LP-004a).
     #[actix_web::test]
-    async fn blc_lp_006_page_size_zero_returns_all() {
+    async fn blc_lp_006_page_size_zero_returns_400() {
         let db = test_db().await.unwrap();
-        let (user, token) = authed_user_and_token(&db, "lp006@test.local").await;
-        for i in 0..3 {
-            create_song_with_title(&db, &user, &format!("LP006 Song {i}"))
-                .await
-                .unwrap();
-        }
-
+        let (_, token) = authed_user_and_token(&db, "lp006@test.local").await;
         let app = test::init_service(build_app(db.clone())).await;
         let req = test::TestRequest::get()
             .uri("/api/v1/songs?page_size=0")
             .insert_header(("Authorization", format!("Bearer {token}")))
             .to_request();
-        let resp: serde_json::Value = test::call_and_read_body_json(&app, req).await;
-        assert_eq!(resp.as_array().unwrap().len(), 3);
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
     /// BLC-LP-007: only `page` supplied (no page_size) returns 200.

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -6,6 +6,7 @@ pub mod docs;
 pub mod error;
 pub mod frontend;
 pub mod mail;
+pub mod request_id;
 pub mod resources;
 pub mod settings;
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -135,6 +135,8 @@ async fn main() -> AnyResult<()> {
 
     HttpServer::new(move || {
         App::new()
+            .wrap(backend::request_id::RequestId)
+            .app_data(backend::error::json_config())
             .app_data(db_data.clone())
             .app_data(Data::new(mail_service.clone()))
             .app_data(Data::new(blob_service.clone()))

--- a/backend/src/request_id.rs
+++ b/backend/src/request_id.rs
@@ -1,0 +1,63 @@
+use std::future::{Ready, ready};
+use std::rc::Rc;
+
+use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready};
+use actix_web::http::header::HeaderName;
+use actix_web::{Error, HttpMessage};
+use futures_util::future::LocalBoxFuture;
+use uuid::Uuid;
+
+static X_REQUEST_ID: HeaderName = HeaderName::from_static("x-request-id");
+
+/// Middleware that generates a UUID v4 per request, stores it in the request
+/// extensions as a `String`, and attaches it as an `X-Request-Id` response
+/// header.
+#[derive(Clone, Default)]
+pub struct RequestId;
+
+impl<S, B> Transform<S, ServiceRequest> for RequestId
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type InitError = ();
+    type Transform = RequestIdMiddleware<S>;
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ready(Ok(RequestIdMiddleware {
+            service: Rc::new(service),
+        }))
+    }
+}
+
+pub struct RequestIdMiddleware<S> {
+    service: Rc<S>,
+}
+
+impl<S, B> Service<ServiceRequest> for RequestIdMiddleware<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    forward_ready!(service);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let id = Uuid::new_v4().to_string();
+        req.extensions_mut().insert(id.clone());
+
+        let service = Rc::clone(&self.service);
+        Box::pin(async move {
+            let mut resp = service.call(req).await?;
+            resp.headers_mut()
+                .insert(X_REQUEST_ID.clone(), id.parse().unwrap());
+            Ok(resp)
+        })
+    }
+}

--- a/backend/src/resources/blob/repository.rs
+++ b/backend/src/resources/blob/repository.rs
@@ -15,6 +15,9 @@ pub trait BlobRepository: Send + Sync {
         pagination: ListQuery,
     ) -> Result<Vec<Blob>, AppError>;
 
+    /// Count all blobs visible to `read_teams`.
+    async fn count_blobs(&self, read_teams: &[Thing]) -> Result<u64, AppError>;
+
     async fn get_blob(&self, read_teams: &[Thing], id: &str) -> Result<Blob, AppError>;
 
     async fn create_blob(&self, owner: &str, blob: CreateBlob) -> Result<Blob, AppError>;

--- a/backend/src/resources/blob/rest.rs
+++ b/backend/src/resources/blob/rest.rs
@@ -3,6 +3,7 @@ use actix_web::{
     HttpResponse, Scope, delete, get, patch, post, put,
     web::{self, Bytes, Data, Json, Path as PathParam, Query, ReqData},
 };
+use actix_web::http::header;
 
 #[allow(unused_imports)]
 use crate::docs::ErrorResponse;
@@ -36,11 +37,12 @@ pub fn scope(blob_upload_max_bytes: usize) -> Scope {
     get,
     path = "/api/v1/blobs",
     params(
-        ("page" = Option<u32>, Query, description = "Optional page index (zero-based)"),
-        ("page_size" = Option<u32>, Query, description = "Optional page size (number of items per page)")
+        ("page" = Option<u32>, Query, description = "Page index, zero-based. Defaults to 0."),
+        ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50.")
     ),
     responses(
-        (status = 200, description = "Return all blobs", body = [Blob]),
+        (status = 200, description = "Return all blobs. `X-Total-Count` header contains the total number of blobs.", body = [Blob]),
+        (status = 400, description = "Invalid pagination parameters", body = ErrorResponse),
         (status = 401, description = "Authentication required", body = ErrorResponse),
         (status = 500, description = "Failed to fetch blobs", body = ErrorResponse)
     ),
@@ -56,8 +58,16 @@ async fn get_blobs(
     user: ReqData<User>,
     query: Query<ListQuery>,
 ) -> Result<HttpResponse, AppError> {
+    let query = query
+        .into_inner()
+        .validate()
+        .map_err(AppError::invalid_request)?;
     let perms = UserPermissions::new(&user, &svc.teams);
-    Ok(HttpResponse::Ok().json(svc.list_blobs_for_user(&perms, query.into_inner()).await?))
+    let blobs = svc.list_blobs_for_user(&perms, query).await?;
+    let total = svc.count_blobs_for_user(&perms).await?;
+    Ok(HttpResponse::Ok()
+        .insert_header((header::HeaderName::from_static("x-total-count"), total.to_string()))
+        .json(blobs))
 }
 
 #[utoipa::path(
@@ -193,7 +203,7 @@ async fn patch_blob(
         ("id" = String, Path, description = "Blob identifier")
     ),
     responses(
-        (status = 200, description = "Delete a blob", body = Blob),
+        (status = 204, description = "Blob deleted"),
         (status = 400, description = "Invalid blob identifier", body = ErrorResponse),
         (status = 401, description = "Authentication required", body = ErrorResponse),
         (status = 404, description = "Blob not found", body = ErrorResponse),
@@ -212,7 +222,8 @@ async fn delete_blob(
     id: PathParam<String>,
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::new(&user, &svc.teams);
-    Ok(HttpResponse::Ok().json(svc.delete_blob_for_user(&perms, &id).await?))
+    svc.delete_blob_for_user(&perms, &id).await?;
+    Ok(HttpResponse::NoContent().finish())
 }
 
 #[utoipa::path(
@@ -222,7 +233,13 @@ async fn delete_blob(
         ("id" = String, Path, description = "Blob identifier")
     ),
     responses(
-        (status = 200, description = "Download the blob image", body = Vec<u8>),
+        (
+            status = 200,
+            description = "Binary image data. `Content-Type` reflects the stored file type \
+                           (`image/png`, `image/jpeg`, or `image/svg`).",
+            content_type = "image/*",
+            body = Vec<u8>
+        ),
         (status = 400, description = "Invalid blob identifier", body = ErrorResponse),
         (status = 401, description = "Authentication required", body = ErrorResponse),
         (status = 404, description = "Blob not found", body = ErrorResponse),

--- a/backend/src/resources/blob/rest.rs
+++ b/backend/src/resources/blob/rest.rs
@@ -1,9 +1,9 @@
 use actix_files::NamedFile;
+use actix_web::http::header;
 use actix_web::{
     HttpResponse, Scope, delete, get, patch, post, put,
     web::{self, Bytes, Data, Json, Path as PathParam, Query, ReqData},
 };
-use actix_web::http::header;
 
 #[allow(unused_imports)]
 use crate::docs::ErrorResponse;
@@ -66,7 +66,10 @@ async fn get_blobs(
     let blobs = svc.list_blobs_for_user(&perms, query).await?;
     let total = svc.count_blobs_for_user(&perms).await?;
     Ok(HttpResponse::Ok()
-        .insert_header((header::HeaderName::from_static("x-total-count"), total.to_string()))
+        .insert_header((
+            header::HeaderName::from_static("x-total-count"),
+            total.to_string(),
+        ))
         .json(blobs))
 }
 

--- a/backend/src/resources/blob/service.rs
+++ b/backend/src/resources/blob/service.rs
@@ -42,6 +42,14 @@ impl<R: BlobRepository, T: TeamResolver, S: BlobStorage> BlobService<R, T, S> {
         self.repo.get_blobs(read_teams, pagination).await
     }
 
+    pub async fn count_blobs_for_user(
+        &self,
+        perms: &UserPermissions<'_, T>,
+    ) -> Result<u64, AppError> {
+        let read_teams = perms.read_teams().await?;
+        self.repo.count_blobs(read_teams).await
+    }
+
     pub async fn get_blob_for_user(
         &self,
         perms: &UserPermissions<'_, T>,
@@ -170,6 +178,10 @@ mod tests {
             _pagination: ListQuery,
         ) -> Result<Vec<Blob>, AppError> {
             Ok(self.blobs.clone())
+        }
+
+        async fn count_blobs(&self, _read_teams: &[Thing]) -> Result<u64, AppError> {
+            Ok(self.blobs.len() as u64)
         }
 
         async fn get_blob(&self, _read_teams: &[Thing], _id: &str) -> Result<Blob, AppError> {

--- a/backend/src/resources/blob/surreal_repo.rs
+++ b/backend/src/resources/blob/surreal_repo.rs
@@ -40,9 +40,8 @@ impl BlobRepository for SurrealBlobRepo {
     ) -> Result<Vec<Blob>, AppError> {
         let db = self.inner();
         let (offset, limit) = pagination.effective_offset_limit();
-        let query = String::from(
-            "SELECT * FROM blob WHERE owner IN $teams LIMIT $limit START $start",
-        );
+        let query =
+            String::from("SELECT * FROM blob WHERE owner IN $teams LIMIT $limit START $start");
 
         let mut response = db
             .db

--- a/backend/src/resources/blob/surreal_repo.rs
+++ b/backend/src/resources/blob/surreal_repo.rs
@@ -4,6 +4,8 @@ use async_trait::async_trait;
 use chrono::Utc;
 use surrealdb::sql::Thing;
 
+use serde::Deserialize;
+
 use shared::api::ListQuery;
 use shared::blob::{Blob, CreateBlob};
 
@@ -37,23 +39,44 @@ impl BlobRepository for SurrealBlobRepo {
         pagination: ListQuery,
     ) -> Result<Vec<Blob>, AppError> {
         let db = self.inner();
-        let mut query = String::from("SELECT * FROM blob WHERE owner IN $teams");
-        if pagination.to_offset_limit().is_some() {
-            query.push_str(" LIMIT $limit START $start");
-        }
+        let (offset, limit) = pagination.effective_offset_limit();
+        let query = String::from(
+            "SELECT * FROM blob WHERE owner IN $teams LIMIT $limit START $start",
+        );
 
-        let mut request = db.db.query(query).bind(("teams", read_teams.to_vec()));
-        if let Some((offset, limit)) = pagination.to_offset_limit() {
-            request = request.bind(("limit", limit)).bind(("start", offset));
-        }
-
-        let mut response = request.await.map_err(AppError::database)?;
+        let mut response = db
+            .db
+            .query(query)
+            .bind(("teams", read_teams.to_vec()))
+            .bind(("limit", limit))
+            .bind(("start", offset))
+            .await
+            .map_err(AppError::database)?;
 
         Ok(response
             .take::<Vec<BlobRecord>>(0)?
             .into_iter()
             .map(BlobRecord::into_blob)
             .collect())
+    }
+
+    async fn count_blobs(&self, read_teams: &[Thing]) -> Result<u64, AppError> {
+        #[derive(Deserialize)]
+        struct CountResult {
+            count: u64,
+        }
+        let mut response = self
+            .inner()
+            .db
+            .query("SELECT count() FROM blob WHERE owner IN $teams GROUP ALL")
+            .bind(("teams", read_teams.to_vec()))
+            .await?;
+        Ok(response
+            .take::<Vec<CountResult>>(0)?
+            .into_iter()
+            .next()
+            .map(|r| r.count)
+            .unwrap_or(0))
     }
 
     async fn get_blob(&self, read_teams: &[Thing], id: &str) -> Result<Blob, AppError> {

--- a/backend/src/resources/collection/repository.rs
+++ b/backend/src/resources/collection/repository.rs
@@ -17,7 +17,11 @@ pub trait CollectionRepository: Send + Sync {
     ) -> Result<Vec<Collection>, AppError>;
 
     /// Count all collections visible to `read_teams`, optionally filtered by `q`.
-    async fn count_collections(&self, read_teams: &[Thing], q: Option<&str>) -> Result<u64, AppError>;
+    async fn count_collections(
+        &self,
+        read_teams: &[Thing],
+        q: Option<&str>,
+    ) -> Result<u64, AppError>;
 
     async fn get_collection(&self, read_teams: &[Thing], id: &str) -> Result<Collection, AppError>;
 

--- a/backend/src/resources/collection/repository.rs
+++ b/backend/src/resources/collection/repository.rs
@@ -16,6 +16,9 @@ pub trait CollectionRepository: Send + Sync {
         pagination: ListQuery,
     ) -> Result<Vec<Collection>, AppError>;
 
+    /// Count all collections visible to `read_teams`, optionally filtered by `q`.
+    async fn count_collections(&self, read_teams: &[Thing], q: Option<&str>) -> Result<u64, AppError>;
+
     async fn get_collection(&self, read_teams: &[Thing], id: &str) -> Result<Collection, AppError>;
 
     async fn get_collection_songs(

--- a/backend/src/resources/collection/rest.rs
+++ b/backend/src/resources/collection/rest.rs
@@ -2,6 +2,7 @@ use actix_web::{
     HttpResponse, Scope, delete, get, patch, post, put,
     web::{self, Data, Json, Path, Query, ReqData},
 };
+use actix_web::http::header;
 
 #[allow(unused_imports)]
 use crate::docs::ErrorResponse;
@@ -35,12 +36,13 @@ pub fn scope() -> Scope {
     get,
     path = "/api/v1/collections",
     params(
-        ("page" = Option<u32>, Query, description = "Optional page index (zero-based)"),
-        ("page_size" = Option<u32>, Query, description = "Optional page size (number of items per page)"),
+        ("page" = Option<u32>, Query, description = "Page index, zero-based. Defaults to 0."),
+        ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50."),
         ("q" = Option<String>, Query, description = "Full-text search query (title); uses text_search analyzer (stemming)")
     ),
     responses(
-        (status = 200, description = "Return all collections", body = [Collection]),
+        (status = 200, description = "Return all collections. `X-Total-Count` header contains the total number of matching collections.", body = [Collection]),
+        (status = 400, description = "Invalid pagination parameters", body = ErrorResponse),
         (status = 401, description = "Authentication required", body = ErrorResponse),
         (status = 500, description = "Failed to fetch collections", body = ErrorResponse)
     ),
@@ -56,11 +58,17 @@ async fn get_collections(
     user: ReqData<User>,
     query: Query<ListQuery>,
 ) -> Result<HttpResponse, AppError> {
+    let query = query
+        .into_inner()
+        .validate()
+        .map_err(AppError::invalid_request)?;
     let perms = UserPermissions::new(&user, &svc.teams);
-    Ok(HttpResponse::Ok().json(
-        svc.list_collections_for_user(&perms, query.into_inner())
-            .await?,
-    ))
+    let q_ref = query.q.clone();
+    let collections = svc.list_collections_for_user(&perms, query).await?;
+    let total = svc.count_collections_for_user(&perms, q_ref.as_deref()).await?;
+    Ok(HttpResponse::Ok()
+        .insert_header((header::HeaderName::from_static("x-total-count"), total.to_string()))
+        .json(collections))
 }
 
 #[utoipa::path(
@@ -254,7 +262,7 @@ async fn patch_collection(
         ("id" = String, Path, description = "Collection identifier")
     ),
     responses(
-        (status = 200, description = "Delete a collection", body = Collection),
+        (status = 204, description = "Collection deleted"),
         (status = 400, description = "Invalid collection identifier", body = ErrorResponse),
         (status = 401, description = "Authentication required", body = ErrorResponse),
         (status = 404, description = "Collection not found", body = ErrorResponse),
@@ -273,5 +281,6 @@ async fn delete_collection(
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::new(&user, &svc.teams);
-    Ok(HttpResponse::Ok().json(svc.delete_collection_for_user(&perms, &id).await?))
+    svc.delete_collection_for_user(&perms, &id).await?;
+    Ok(HttpResponse::NoContent().finish())
 }

--- a/backend/src/resources/collection/rest.rs
+++ b/backend/src/resources/collection/rest.rs
@@ -1,8 +1,8 @@
+use actix_web::http::header;
 use actix_web::{
     HttpResponse, Scope, delete, get, patch, post, put,
     web::{self, Data, Json, Path, Query, ReqData},
 };
-use actix_web::http::header;
 
 #[allow(unused_imports)]
 use crate::docs::ErrorResponse;
@@ -65,9 +65,14 @@ async fn get_collections(
     let perms = UserPermissions::new(&user, &svc.teams);
     let q_ref = query.q.clone();
     let collections = svc.list_collections_for_user(&perms, query).await?;
-    let total = svc.count_collections_for_user(&perms, q_ref.as_deref()).await?;
+    let total = svc
+        .count_collections_for_user(&perms, q_ref.as_deref())
+        .await?;
     Ok(HttpResponse::Ok()
-        .insert_header((header::HeaderName::from_static("x-total-count"), total.to_string()))
+        .insert_header((
+            header::HeaderName::from_static("x-total-count"),
+            total.to_string(),
+        ))
         .json(collections))
 }
 

--- a/backend/src/resources/collection/service.rs
+++ b/backend/src/resources/collection/service.rs
@@ -38,6 +38,15 @@ impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionServic
         self.repo.get_collections(read_teams, pagination).await
     }
 
+    pub async fn count_collections_for_user(
+        &self,
+        perms: &UserPermissions<'_, T>,
+        q: Option<&str>,
+    ) -> Result<u64, AppError> {
+        let read_teams = perms.read_teams().await?;
+        self.repo.count_collections(read_teams, q).await
+    }
+
     pub async fn get_collection_for_user(
         &self,
         perms: &UserPermissions<'_, T>,

--- a/backend/src/resources/collection/surreal_repo.rs
+++ b/backend/src/resources/collection/surreal_repo.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use surrealdb::sql::Thing;
 
+use serde::Deserialize;
+
 use shared::api::ListQuery;
 use shared::collection::{Collection, CreateCollection};
 use shared::song::{Link as SongLink, LinkOwned as SongLinkOwned};
@@ -48,9 +50,8 @@ impl CollectionRepository for SurrealCollectionRepo {
         if q_nonempty {
             query.push_str(" AND title @0@ $q ORDER BY score DESC");
         }
-        if pagination.to_offset_limit().is_some() {
-            query.push_str(" LIMIT $limit START $start");
-        }
+        let (offset, limit) = pagination.effective_offset_limit();
+        query.push_str(" LIMIT $limit START $start");
 
         let mut request = db.db.query(query).bind(("teams", read_teams.to_vec()));
         if let Some(ref q) = pagination.q
@@ -58,9 +59,7 @@ impl CollectionRepository for SurrealCollectionRepo {
         {
             request = request.bind(("q", q.trim().to_string()));
         }
-        if let Some((offset, limit)) = pagination.to_offset_limit() {
-            request = request.bind(("limit", limit)).bind(("start", offset));
-        }
+        request = request.bind(("limit", limit)).bind(("start", offset));
 
         let mut response = request.await?;
 
@@ -69,6 +68,40 @@ impl CollectionRepository for SurrealCollectionRepo {
             .into_iter()
             .map(CollectionRecord::into_collection)
             .collect())
+    }
+
+    async fn count_collections(
+        &self,
+        read_teams: &[Thing],
+        q: Option<&str>,
+    ) -> Result<u64, AppError> {
+        #[derive(Deserialize)]
+        struct CountResult {
+            count: u64,
+        }
+        let q_nonempty = q.is_some_and(|s| !s.trim().is_empty());
+        let mut query =
+            String::from("SELECT count() FROM collection WHERE owner IN $teams");
+        if q_nonempty {
+            query.push_str(" AND title @0@ $q");
+        }
+        query.push_str(" GROUP ALL");
+
+        let mut request = self
+            .inner()
+            .db
+            .query(query)
+            .bind(("teams", read_teams.to_vec()));
+        if q_nonempty {
+            request = request.bind(("q", q.unwrap().trim().to_string()));
+        }
+        let mut response = request.await?;
+        Ok(response
+            .take::<Vec<CountResult>>(0)?
+            .into_iter()
+            .next()
+            .map(|r| r.count)
+            .unwrap_or(0))
     }
 
     async fn get_collection(&self, read_teams: &[Thing], id: &str) -> Result<Collection, AppError> {

--- a/backend/src/resources/collection/surreal_repo.rs
+++ b/backend/src/resources/collection/surreal_repo.rs
@@ -80,8 +80,7 @@ impl CollectionRepository for SurrealCollectionRepo {
             count: u64,
         }
         let q_nonempty = q.is_some_and(|s| !s.trim().is_empty());
-        let mut query =
-            String::from("SELECT count() FROM collection WHERE owner IN $teams");
+        let mut query = String::from("SELECT count() FROM collection WHERE owner IN $teams");
         if q_nonempty {
             query.push_str(" AND title @0@ $q");
         }

--- a/backend/src/resources/common.rs
+++ b/backend/src/resources/common.rs
@@ -11,13 +11,10 @@ use crate::resources::song::SongRecord;
 
 /// Parse and validate a resource ID for the given table.
 ///
-/// Accepts both plain IDs (`"abc"`) and `Thing` strings (`"setlist:abc"`).
-/// Returns an error when the parsed table prefix does not match `table`.
+/// Accepts only plain IDs (`"abc"`). The `table:id` form is rejected with a `400` error
+/// to prevent two distinct URLs from mapping to the same resource.
 pub fn resource_id(table: &str, id: &str) -> Result<(String, String), AppError> {
-    if let Ok(thing) = id.parse::<Thing>() {
-        if thing.tb == table {
-            return Ok((thing.tb, thing.id.to_string()));
-        }
+    if id.contains(':') {
         return Err(AppError::invalid_request(format!("invalid {table} id")));
     }
     Ok((table.to_owned(), id.to_owned()))
@@ -145,15 +142,13 @@ mod tests {
     }
 
     #[test]
-    fn resource_id_thing_string_matching_table() {
-        assert_eq!(
-            resource_id("setlist", "setlist:myid").unwrap(),
-            ("setlist".to_owned(), "myid".to_owned())
-        );
+    fn resource_id_rejects_table_colon_id() {
+        let err = resource_id("setlist", "setlist:myid").unwrap_err();
+        assert!(matches!(err, AppError::InvalidRequest(_)));
     }
 
     #[test]
-    fn resource_id_thing_string_wrong_table() {
+    fn resource_id_rejects_any_colon_form() {
         let err = resource_id("setlist", "song:foo").unwrap_err();
         assert!(matches!(err, AppError::InvalidRequest(_)));
     }
@@ -161,11 +156,11 @@ mod tests {
     #[test]
     fn resource_id_works_for_different_tables() {
         assert_eq!(
-            resource_id("song", "song:s1").unwrap(),
+            resource_id("song", "s1").unwrap(),
             ("song".to_owned(), "s1".to_owned())
         );
         assert_eq!(
-            resource_id("blob", "blob:b1").unwrap(),
+            resource_id("blob", "b1").unwrap(),
             ("blob".to_owned(), "b1".to_owned())
         );
     }

--- a/backend/src/resources/setlist/repository.rs
+++ b/backend/src/resources/setlist/repository.rs
@@ -16,6 +16,9 @@ pub trait SetlistRepository: Send + Sync {
         pagination: ListQuery,
     ) -> Result<Vec<Setlist>, AppError>;
 
+    /// Count all setlists visible to `read_teams`, optionally filtered by `q`.
+    async fn count_setlists(&self, read_teams: &[Thing], q: Option<&str>) -> Result<u64, AppError>;
+
     async fn get_setlist(&self, read_teams: &[Thing], id: &str) -> Result<Setlist, AppError>;
 
     async fn get_setlist_songs(

--- a/backend/src/resources/setlist/rest.rs
+++ b/backend/src/resources/setlist/rest.rs
@@ -2,6 +2,7 @@ use actix_web::{
     HttpResponse, Scope, delete, get, patch, post, put,
     web::{self, Data, Json, Path, Query, ReqData},
 };
+use actix_web::http::header;
 
 #[allow(unused_imports)]
 use crate::docs::ErrorResponse;
@@ -35,12 +36,13 @@ pub fn scope() -> Scope {
     get,
     path = "/api/v1/setlists",
     params(
-        ("page" = Option<u32>, Query, description = "Optional page index (zero-based)"),
-        ("page_size" = Option<u32>, Query, description = "Optional page size (number of items per page)"),
+        ("page" = Option<u32>, Query, description = "Page index, zero-based. Defaults to 0."),
+        ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50."),
         ("q" = Option<String>, Query, description = "Full-text search query (title); uses text_search analyzer (stemming)")
     ),
     responses(
-        (status = 200, description = "Return all setlists", body = [Setlist]),
+        (status = 200, description = "Return all setlists. `X-Total-Count` header contains the total number of matching setlists.", body = [Setlist]),
+        (status = 400, description = "Invalid pagination parameters", body = ErrorResponse),
         (status = 401, description = "Authentication required", body = ErrorResponse),
         (status = 500, description = "Failed to fetch setlists", body = ErrorResponse)
     ),
@@ -56,11 +58,17 @@ async fn get_setlists(
     user: ReqData<User>,
     query: Query<ListQuery>,
 ) -> Result<HttpResponse, AppError> {
+    let query = query
+        .into_inner()
+        .validate()
+        .map_err(AppError::invalid_request)?;
     let perms = UserPermissions::new(&user, &svc.teams);
-    Ok(HttpResponse::Ok().json(
-        svc.list_setlists_for_user(&perms, query.into_inner())
-            .await?,
-    ))
+    let q_ref = query.q.clone();
+    let setlists = svc.list_setlists_for_user(&perms, query).await?;
+    let total = svc.count_setlists_for_user(&perms, q_ref.as_deref()).await?;
+    Ok(HttpResponse::Ok()
+        .insert_header((header::HeaderName::from_static("x-total-count"), total.to_string()))
+        .json(setlists))
 }
 
 #[utoipa::path(
@@ -253,7 +261,7 @@ async fn patch_setlist(
         ("id" = String, Path, description = "Setlist identifier")
     ),
     responses(
-        (status = 200, description = "Delete a setlist", body = Setlist),
+        (status = 204, description = "Setlist deleted"),
         (status = 400, description = "Invalid setlist identifier", body = ErrorResponse),
         (status = 401, description = "Authentication required", body = ErrorResponse),
         (status = 404, description = "Setlist not found", body = ErrorResponse),
@@ -272,5 +280,6 @@ async fn delete_setlist(
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::new(&user, &svc.teams);
-    Ok(HttpResponse::Ok().json(svc.delete_setlist_for_user(&perms, &id).await?))
+    svc.delete_setlist_for_user(&perms, &id).await?;
+    Ok(HttpResponse::NoContent().finish())
 }

--- a/backend/src/resources/setlist/rest.rs
+++ b/backend/src/resources/setlist/rest.rs
@@ -1,8 +1,8 @@
+use actix_web::http::header;
 use actix_web::{
     HttpResponse, Scope, delete, get, patch, post, put,
     web::{self, Data, Json, Path, Query, ReqData},
 };
-use actix_web::http::header;
 
 #[allow(unused_imports)]
 use crate::docs::ErrorResponse;
@@ -65,9 +65,14 @@ async fn get_setlists(
     let perms = UserPermissions::new(&user, &svc.teams);
     let q_ref = query.q.clone();
     let setlists = svc.list_setlists_for_user(&perms, query).await?;
-    let total = svc.count_setlists_for_user(&perms, q_ref.as_deref()).await?;
+    let total = svc
+        .count_setlists_for_user(&perms, q_ref.as_deref())
+        .await?;
     Ok(HttpResponse::Ok()
-        .insert_header((header::HeaderName::from_static("x-total-count"), total.to_string()))
+        .insert_header((
+            header::HeaderName::from_static("x-total-count"),
+            total.to_string(),
+        ))
         .json(setlists))
 }
 

--- a/backend/src/resources/setlist/service.rs
+++ b/backend/src/resources/setlist/service.rs
@@ -513,14 +513,22 @@ mod tests {
             .list_setlists_for_user(&owner_p, ListQuery::new().with_page(1))
             .await
             .expect("page only");
-        assert_eq!(page_only.len(), 0, "page=1 with default page_size beyond last page");
+        assert_eq!(
+            page_only.len(),
+            0,
+            "page=1 with default page_size beyond last page"
+        );
 
         // page_size=1 with default page=0 → first item only
         let page_size_only = sl
             .list_setlists_for_user(&owner_p, ListQuery::new().with_page_size(1))
             .await
             .expect("page_size only");
-        assert_eq!(page_size_only.len(), 1, "page_size=1 with default page=0 returns 1 item");
+        assert_eq!(
+            page_size_only.len(),
+            1,
+            "page_size=1 with default page=0 returns 1 item"
+        );
     }
 
     /// BLC-SETL-009d: full-text search with `q` narrows results; blank/whitespace-only q

--- a/backend/src/resources/setlist/service.rs
+++ b/backend/src/resources/setlist/service.rs
@@ -36,6 +36,15 @@ impl<R: SetlistRepository, T: TeamResolver, L: LikedSongIds> SetlistService<R, T
         self.repo.get_setlists(read_teams, pagination).await
     }
 
+    pub async fn count_setlists_for_user(
+        &self,
+        perms: &UserPermissions<'_, T>,
+        q: Option<&str>,
+    ) -> Result<u64, AppError> {
+        let read_teams = perms.read_teams().await?;
+        self.repo.count_setlists(read_teams, q).await
+    }
+
     pub async fn get_setlist_for_user(
         &self,
         perms: &UserPermissions<'_, T>,
@@ -166,6 +175,14 @@ mod tests {
             _pagination: ListQuery,
         ) -> Result<Vec<Setlist>, AppError> {
             Ok(self.setlists.clone())
+        }
+
+        async fn count_setlists(
+            &self,
+            _read_teams: &[Thing],
+            _q: Option<&str>,
+        ) -> Result<u64, AppError> {
+            Ok(self.setlists.len() as u64)
         }
 
         async fn get_setlist(&self, _read_teams: &[Thing], _id: &str) -> Result<Setlist, AppError> {
@@ -472,8 +489,9 @@ mod tests {
         assert_eq!(noperm_list.len(), 0);
     }
 
-    /// BLC-SETL-009c: partial pagination parameters (only page or only page_size) and
-    /// zero page_size fall back to returning all results.
+    /// Partial pagination parameters use server defaults:
+    /// - only `page` supplied → page_size defaults to 50
+    /// - only `page_size` supplied → page defaults to 0
     #[tokio::test]
     async fn blc_setl_list_partial_pagination() {
         let (db, owner, _read_u, _write_u, _noperm, _team_id) = four_user_setlist_fixture().await;
@@ -490,27 +508,19 @@ mod tests {
             .await
             .expect("B");
 
+        // page=1 with default page_size=50 → offset=50, but only 2 items exist → empty
         let page_only = sl
             .list_setlists_for_user(&owner_p, ListQuery::new().with_page(1))
             .await
             .expect("page only");
-        assert_eq!(page_only.len(), 2, "page without page_size returns all");
+        assert_eq!(page_only.len(), 0, "page=1 with default page_size beyond last page");
 
+        // page_size=1 with default page=0 → first item only
         let page_size_only = sl
             .list_setlists_for_user(&owner_p, ListQuery::new().with_page_size(1))
             .await
             .expect("page_size only");
-        assert_eq!(
-            page_size_only.len(),
-            2,
-            "page_size without page returns all"
-        );
-
-        let zero_size = sl
-            .list_setlists_for_user(&owner_p, ListQuery::new().with_page(0).with_page_size(0))
-            .await
-            .expect("zero size");
-        assert_eq!(zero_size.len(), 2, "page_size=0 returns all");
+        assert_eq!(page_size_only.len(), 1, "page_size=1 with default page=0 returns 1 item");
     }
 
     /// BLC-SETL-009d: full-text search with `q` narrows results; blank/whitespace-only q

--- a/backend/src/resources/setlist/surreal_repo.rs
+++ b/backend/src/resources/setlist/surreal_repo.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use surrealdb::sql::Thing;
 
+use serde::Deserialize;
+
 use shared::api::ListQuery;
 use shared::setlist::{CreateSetlist, Setlist};
 use shared::song::LinkOwned as SongLinkOwned;
@@ -49,9 +51,8 @@ impl SetlistRepository for SurrealSetlistRepo {
         if q_nonempty {
             query.push_str(" AND title @0@ $q ORDER BY score DESC");
         }
-        if pagination.to_offset_limit().is_some() {
-            query.push_str(" LIMIT $limit START $start");
-        }
+        let (offset, limit) = pagination.effective_offset_limit();
+        query.push_str(" LIMIT $limit START $start");
 
         let mut request = db.db.query(query).bind(("teams", read_teams.to_vec()));
         if let Some(ref q) = pagination.q
@@ -59,9 +60,7 @@ impl SetlistRepository for SurrealSetlistRepo {
         {
             request = request.bind(("q", q.trim().to_string()));
         }
-        if let Some((offset, limit)) = pagination.to_offset_limit() {
-            request = request.bind(("limit", limit)).bind(("start", offset));
-        }
+        request = request.bind(("limit", limit)).bind(("start", offset));
 
         let mut response = request.await?;
         Ok(response
@@ -69,6 +68,40 @@ impl SetlistRepository for SurrealSetlistRepo {
             .into_iter()
             .map(SetlistRecord::into_setlist)
             .collect())
+    }
+
+    async fn count_setlists(
+        &self,
+        read_teams: &[Thing],
+        q: Option<&str>,
+    ) -> Result<u64, AppError> {
+        #[derive(Deserialize)]
+        struct CountResult {
+            count: u64,
+        }
+        let q_nonempty = q.is_some_and(|s| !s.trim().is_empty());
+        let mut query =
+            String::from("SELECT count() FROM setlist WHERE owner IN $teams");
+        if q_nonempty {
+            query.push_str(" AND title @0@ $q");
+        }
+        query.push_str(" GROUP ALL");
+
+        let mut request = self
+            .inner()
+            .db
+            .query(query)
+            .bind(("teams", read_teams.to_vec()));
+        if q_nonempty {
+            request = request.bind(("q", q.unwrap().trim().to_string()));
+        }
+        let mut response = request.await?;
+        Ok(response
+            .take::<Vec<CountResult>>(0)?
+            .into_iter()
+            .next()
+            .map(|r| r.count)
+            .unwrap_or(0))
     }
 
     async fn get_setlist(&self, read_teams: &[Thing], id: &str) -> Result<Setlist, AppError> {

--- a/backend/src/resources/setlist/surreal_repo.rs
+++ b/backend/src/resources/setlist/surreal_repo.rs
@@ -70,18 +70,13 @@ impl SetlistRepository for SurrealSetlistRepo {
             .collect())
     }
 
-    async fn count_setlists(
-        &self,
-        read_teams: &[Thing],
-        q: Option<&str>,
-    ) -> Result<u64, AppError> {
+    async fn count_setlists(&self, read_teams: &[Thing], q: Option<&str>) -> Result<u64, AppError> {
         #[derive(Deserialize)]
         struct CountResult {
             count: u64,
         }
         let q_nonempty = q.is_some_and(|s| !s.trim().is_empty());
-        let mut query =
-            String::from("SELECT count() FROM setlist WHERE owner IN $teams");
+        let mut query = String::from("SELECT count() FROM setlist WHERE owner IN $teams");
         if q_nonempty {
             query.push_str(" AND title @0@ $q");
         }

--- a/backend/src/resources/song/repository.rs
+++ b/backend/src/resources/song/repository.rs
@@ -42,6 +42,9 @@ pub trait SongRepository: Send + Sync {
 
     async fn delete_song(&self, write_teams: &[Thing], id: &str) -> Result<Song, AppError>;
 
+    /// Count all songs visible to `read_teams`, optionally filtered by `q`.
+    async fn count_songs(&self, read_teams: &[Thing], q: Option<&str>) -> Result<u64, AppError>;
+
     async fn get_song_like(
         &self,
         read_teams: &[Thing],

--- a/backend/src/resources/song/rest.rs
+++ b/backend/src/resources/song/rest.rs
@@ -1,8 +1,8 @@
+use actix_web::http::header;
 use actix_web::{
     HttpResponse, Scope, delete, get, patch, post, put,
     web::{self, Data, Json, Path, Query, ReqData},
 };
-use actix_web::http::header;
 
 #[allow(unused_imports)]
 use crate::docs::ErrorResponse;
@@ -67,7 +67,10 @@ async fn get_songs(
     let songs = svc.list_songs_for_user(&perms, query).await?;
     let total = svc.count_songs_for_user(&perms, q_ref.as_deref()).await?;
     Ok(HttpResponse::Ok()
-        .insert_header((header::HeaderName::from_static("x-total-count"), total.to_string()))
+        .insert_header((
+            header::HeaderName::from_static("x-total-count"),
+            total.to_string(),
+        ))
         .json(songs))
 }
 

--- a/backend/src/resources/song/rest.rs
+++ b/backend/src/resources/song/rest.rs
@@ -2,6 +2,7 @@ use actix_web::{
     HttpResponse, Scope, delete, get, patch, post, put,
     web::{self, Data, Json, Path, Query, ReqData},
 };
+use actix_web::http::header;
 
 #[allow(unused_imports)]
 use crate::docs::ErrorResponse;
@@ -35,12 +36,13 @@ pub fn scope() -> Scope {
     get,
     path = "/api/v1/songs",
     params(
-        ("page" = Option<u32>, Query, description = "Optional page index (zero-based)"),
-        ("page_size" = Option<u32>, Query, description = "Optional page size (number of items per page)"),
+        ("page" = Option<u32>, Query, description = "Page index, zero-based. Defaults to 0."),
+        ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50."),
         ("q" = Option<String>, Query, description = "Full-text search query (titles, artists, line lyrics); uses text_search analyzer (stemming)")
     ),
     responses(
-        (status = 200, description = "Return all songs", body = [Song]),
+        (status = 200, description = "Return all songs. `X-Total-Count` header contains the total number of matching songs.", body = [Song]),
+        (status = 400, description = "Invalid pagination parameters", body = ErrorResponse),
         (status = 401, description = "Authentication required", body = ErrorResponse),
         (status = 500, description = "Failed to fetch songs", body = ErrorResponse)
     ),
@@ -56,8 +58,17 @@ async fn get_songs(
     user: ReqData<User>,
     query: Query<ListQuery>,
 ) -> Result<HttpResponse, AppError> {
+    let query = query
+        .into_inner()
+        .validate()
+        .map_err(AppError::invalid_request)?;
     let perms = UserPermissions::new(&user, &svc.teams);
-    Ok(HttpResponse::Ok().json(svc.list_songs_for_user(&perms, query.into_inner()).await?))
+    let q_ref = query.q.clone();
+    let songs = svc.list_songs_for_user(&perms, query).await?;
+    let total = svc.count_songs_for_user(&perms, q_ref.as_deref()).await?;
+    Ok(HttpResponse::Ok()
+        .insert_header((header::HeaderName::from_static("x-total-count"), total.to_string()))
+        .json(songs))
 }
 
 #[utoipa::path(
@@ -222,7 +233,7 @@ async fn patch_song(
         ("id" = String, Path, description = "Song identifier")
     ),
     responses(
-        (status = 200, description = "Delete a song", body = Song),
+        (status = 204, description = "Song deleted"),
         (status = 400, description = "Invalid song identifier", body = ErrorResponse),
         (status = 401, description = "Authentication required", body = ErrorResponse),
         (status = 404, description = "Song not found", body = ErrorResponse),
@@ -241,7 +252,8 @@ async fn delete_song(
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::new(&user, &svc.teams);
-    Ok(HttpResponse::Ok().json(svc.delete_song_for_user(&perms, &id).await?))
+    svc.delete_song_for_user(&perms, &id).await?;
+    Ok(HttpResponse::NoContent().finish())
 }
 
 #[utoipa::path(

--- a/backend/src/resources/song/service.rs
+++ b/backend/src/resources/song/service.rs
@@ -143,6 +143,15 @@ impl<
             .collect())
     }
 
+    pub async fn count_songs_for_user(
+        &self,
+        perms: &UserPermissions<'_, T>,
+        q: Option<&str>,
+    ) -> Result<u64, AppError> {
+        let read_teams = perms.read_teams().await?;
+        self.repo.count_songs(read_teams, q).await
+    }
+
     pub async fn get_song_for_user(
         &self,
         perms: &UserPermissions<'_, T>,

--- a/backend/src/resources/song/surreal_repo.rs
+++ b/backend/src/resources/song/surreal_repo.rs
@@ -5,6 +5,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use surrealdb::sql::Thing;
 
+use serde::Deserialize;
+
 use shared::api::ListQuery;
 use shared::song::{CreateSong, Song};
 
@@ -55,9 +57,8 @@ impl SongRepository for SurrealSongRepo {
                 " AND (data.titles @0@ $q OR data.artists @1@ $q OR search_content @2@ $q) ORDER BY score DESC",
             );
         }
-        if pagination.to_offset_limit().is_some() {
-            query.push_str(" LIMIT $limit START $start");
-        }
+        let (offset, limit) = pagination.effective_offset_limit();
+        query.push_str(" LIMIT $limit START $start");
 
         let mut request = db.db.query(query).bind(("teams", read_teams.to_vec()));
         if let Some(ref q) = pagination.q
@@ -65,9 +66,7 @@ impl SongRepository for SurrealSongRepo {
         {
             request = request.bind(("q", q.trim().to_string()));
         }
-        if let Some((offset, limit)) = pagination.to_offset_limit() {
-            request = request.bind(("limit", limit)).bind(("start", offset));
-        }
+        request = request.bind(("limit", limit)).bind(("start", offset));
 
         let mut response = request.await?;
 
@@ -85,6 +84,37 @@ impl SongRepository for SurrealSongRepo {
             Some(r) if belongs_to(&r.owner, read_teams) => Ok(r.into_song()),
             _ => Err(AppError::NotFound("song not found".into())),
         }
+    }
+
+    async fn count_songs(&self, read_teams: &[Thing], q: Option<&str>) -> Result<u64, AppError> {
+        let db = self.inner();
+        let q_nonempty = q.is_some_and(|s| !s.trim().is_empty());
+        let mut query =
+            String::from("SELECT count() FROM song WHERE owner IN $teams");
+        if q_nonempty {
+            query.push_str(
+                " AND (data.titles @0@ $q OR data.artists @1@ $q OR search_content @2@ $q)",
+            );
+        }
+        query.push_str(" GROUP ALL");
+
+        let mut request = db.db.query(query).bind(("teams", read_teams.to_vec()));
+        if q_nonempty {
+            request = request.bind(("q", q.unwrap().trim().to_string()));
+        }
+
+        #[derive(Deserialize)]
+        struct CountResult {
+            count: u64,
+        }
+
+        let mut response = request.await?;
+        Ok(response
+            .take::<Vec<CountResult>>(0)?
+            .into_iter()
+            .next()
+            .map(|r| r.count)
+            .unwrap_or(0))
     }
 
     async fn create_song(&self, owner: &str, song: CreateSong) -> Result<Song, AppError> {

--- a/backend/src/resources/song/surreal_repo.rs
+++ b/backend/src/resources/song/surreal_repo.rs
@@ -89,8 +89,7 @@ impl SongRepository for SurrealSongRepo {
     async fn count_songs(&self, read_teams: &[Thing], q: Option<&str>) -> Result<u64, AppError> {
         let db = self.inner();
         let q_nonempty = q.is_some_and(|s| !s.trim().is_empty());
-        let mut query =
-            String::from("SELECT count() FROM song WHERE owner IN $teams");
+        let mut query = String::from("SELECT count() FROM song WHERE owner IN $teams");
         if q_nonempty {
             query.push_str(
                 " AND (data.titles @0@ $q OR data.artists @1@ $q OR search_content @2@ $q)",

--- a/backend/src/resources/team/rest.rs
+++ b/backend/src/resources/team/rest.rs
@@ -179,7 +179,7 @@ async fn patch_team(
         ("id" = String, Path, description = "Team identifier")
     ),
     responses(
-        (status = 200, description = "Shared team deleted", body = Team),
+        (status = 204, description = "Team deleted"),
         (status = 401, description = "Authentication required", body = ErrorResponse),
         (status = 403, description = "Cannot delete personal team or insufficient role", body = ErrorResponse),
         (status = 404, description = "Team not found", body = ErrorResponse),
@@ -198,5 +198,6 @@ async fn delete_team(
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::new(&user, &svc.resolver);
-    Ok(HttpResponse::Ok().json(svc.delete_team_for_user(&perms, &id).await?))
+    svc.delete_team_for_user(&perms, &id).await?;
+    Ok(HttpResponse::NoContent().finish())
 }

--- a/backend/src/resources/user/repository.rs
+++ b/backend/src/resources/user/repository.rs
@@ -9,6 +9,8 @@ use crate::error::AppError;
 #[async_trait]
 pub trait UserRepository: Send + Sync {
     async fn get_users(&self, pagination: ListQuery) -> Result<Vec<User>, AppError>;
+    /// Count all users in the system.
+    async fn count_users(&self) -> Result<u64, AppError>;
     async fn get_user(&self, id: &str) -> Result<User, AppError>;
     async fn get_user_by_email(&self, email: &str) -> Result<Option<User>, AppError>;
     /// Insert a user record. Does NOT create a personal team — service layer handles that.

--- a/backend/src/resources/user/rest.rs
+++ b/backend/src/resources/user/rest.rs
@@ -8,6 +8,7 @@ use actix_web::{
     HttpResponse, Scope, delete, get, post,
     web::{self, Data, Json, Path, Query, ReqData},
 };
+use actix_web::http::header;
 use shared::api::ListQuery;
 
 pub fn scope() -> Scope {
@@ -80,11 +81,12 @@ async fn get_user(
     get,
     path = "/api/v1/users",
     params(
-        ("page" = Option<u32>, Query, description = "Optional page index (zero-based)"),
-        ("page_size" = Option<u32>, Query, description = "Optional page size (number of items per page)")
+        ("page" = Option<u32>, Query, description = "Page index, zero-based. Defaults to 0."),
+        ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50.")
     ),
     responses(
-        (status = 200, description = "Returns list of all users", body = [User]),
+        (status = 200, description = "Returns list of all users. `X-Total-Count` header contains the total user count.", body = [User]),
+        (status = 400, description = "Invalid pagination parameters", body = ErrorResponse),
         (status = 401, description = "Authentication required", body = ErrorResponse),
         (status = 403, description = "Admin role required", body = ErrorResponse),
         (status = 500, description = "Failed to list users", body = ErrorResponse)
@@ -100,7 +102,15 @@ async fn get_users(
     svc: Data<UserServiceHandle>,
     query: Query<ListQuery>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Ok().json(svc.get_users(query.into_inner()).await?))
+    let query = query
+        .into_inner()
+        .validate()
+        .map_err(AppError::invalid_request)?;
+    let users = svc.get_users(query).await?;
+    let total = svc.count_users().await?;
+    Ok(HttpResponse::Ok()
+        .insert_header((header::HeaderName::from_static("x-total-count"), total.to_string()))
+        .json(users))
 }
 
 #[utoipa::path(
@@ -136,7 +146,7 @@ async fn create_user(
         ("id" = String, Path, description = "User identifier")
     ),
     responses(
-        (status = 200, description = "Deletes the provided user", body = User),
+        (status = 204, description = "User deleted"),
         (status = 400, description = "Invalid user identifier", body = ErrorResponse),
         (status = 401, description = "Authentication required", body = ErrorResponse),
         (status = 403, description = "Admin role required", body = ErrorResponse),
@@ -153,5 +163,6 @@ async fn delete_user(
     svc: Data<UserServiceHandle>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Ok().json(svc.delete_user(&id).await?))
+    svc.delete_user(&id).await?;
+    Ok(HttpResponse::NoContent().finish())
 }

--- a/backend/src/resources/user/rest.rs
+++ b/backend/src/resources/user/rest.rs
@@ -4,11 +4,11 @@ use crate::auth::middleware::RequireAdmin;
 use crate::docs::ErrorResponse;
 use crate::error::AppError;
 use crate::resources::user::service::UserServiceHandle;
+use actix_web::http::header;
 use actix_web::{
     HttpResponse, Scope, delete, get, post,
     web::{self, Data, Json, Path, Query, ReqData},
 };
-use actix_web::http::header;
 use shared::api::ListQuery;
 
 pub fn scope() -> Scope {
@@ -109,7 +109,10 @@ async fn get_users(
     let users = svc.get_users(query).await?;
     let total = svc.count_users().await?;
     Ok(HttpResponse::Ok()
-        .insert_header((header::HeaderName::from_static("x-total-count"), total.to_string()))
+        .insert_header((
+            header::HeaderName::from_static("x-total-count"),
+            total.to_string(),
+        ))
         .json(users))
 }
 

--- a/backend/src/resources/user/service.rs
+++ b/backend/src/resources/user/service.rs
@@ -29,6 +29,10 @@ impl<R: UserRepository, T: TeamRepository> UserService<R, T> {
         self.repo.get_users(pagination).await
     }
 
+    pub async fn count_users(&self) -> Result<u64, AppError> {
+        self.repo.count_users().await
+    }
+
     pub async fn get_user(&self, id: &str) -> Result<User, AppError> {
         self.repo.get_user(id).await
     }
@@ -151,6 +155,10 @@ mod tests {
     #[async_trait]
     impl UserRepository for MockUserRepo {
         async fn get_users(&self, _pagination: ListQuery) -> Result<Vec<User>, AppError> {
+            unreachable!("not used in these tests")
+        }
+
+        async fn count_users(&self) -> Result<u64, AppError> {
             unreachable!("not used in these tests")
         }
 

--- a/backend/src/resources/user/session/rest.rs
+++ b/backend/src/resources/user/session/rest.rs
@@ -68,7 +68,7 @@ pub async fn get_session_for_current_user(
         ("id" = String, Path, description = "Session identifier")
     ),
     responses(
-        (status = 200, description = "Deletes a session for the current user", body = Session),
+        (status = 204, description = "Session deleted"),
         (status = 401, description = "Authentication required", body = ErrorResponse),
         (status = 404, description = "Session not found for current user", body = ErrorResponse),
         (status = 500, description = "Failed to delete session", body = ErrorResponse)
@@ -85,7 +85,8 @@ pub async fn delete_session_for_current_user(
     user: ReqData<User>,
     path: Path<SessionPath>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Ok().json(svc.delete_session_for_user(&path.id, &user.id).await?))
+    svc.delete_session_for_user(&path.id, &user.id).await?;
+    Ok(HttpResponse::NoContent().finish())
 }
 
 #[utoipa::path(
@@ -181,7 +182,7 @@ pub async fn get_session_for_user(
         ("id" = String, Path, description = "Session identifier")
     ),
     responses(
-        (status = 200, description = "Deletes a session for the specified user", body = Session),
+        (status = 204, description = "Session deleted"),
         (status = 401, description = "Authentication required", body = ErrorResponse),
         (status = 403, description = "Admin role required", body = ErrorResponse),
         (status = 404, description = "Session not found for specified user", body = ErrorResponse),
@@ -198,7 +199,8 @@ pub async fn delete_session_for_user(
     svc: Data<SessionServiceHandle>,
     path: Path<UserSessionPath>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Ok().json(svc.delete_session_for_user(&path.id, &path.user_id).await?))
+    svc.delete_session_for_user(&path.id, &path.user_id).await?;
+    Ok(HttpResponse::NoContent().finish())
 }
 
 #[derive(Debug, Deserialize)]

--- a/backend/src/resources/user/session/service.rs
+++ b/backend/src/resources/user/session/service.rs
@@ -230,6 +230,10 @@ mod tests {
             unreachable!("not used in session tests")
         }
 
+        async fn count_users(&self) -> Result<u64, AppError> {
+            unreachable!("not used in session tests")
+        }
+
         async fn get_user_by_email(&self, _email: &str) -> Result<Option<User>, AppError> {
             unreachable!("not used in session tests")
         }

--- a/backend/src/resources/user/surreal_repo.rs
+++ b/backend/src/resources/user/surreal_repo.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use surrealdb::sql::Thing;
 
+use serde::Deserialize;
+
 use shared::api::ListQuery;
 use shared::user::User;
 
@@ -30,30 +32,37 @@ impl SurrealUserRepo {
 #[async_trait]
 impl UserRepository for SurrealUserRepo {
     async fn get_users(&self, pagination: ListQuery) -> Result<Vec<User>, AppError> {
-        if let Some((offset, limit)) = pagination.to_offset_limit() {
-            let mut response = self
-                .inner()
-                .db
-                .query("SELECT * FROM user LIMIT $limit START $start")
-                .bind(("limit", limit))
-                .bind(("start", offset))
-                .await?;
+        let (offset, limit) = pagination.effective_offset_limit();
+        let mut response = self
+            .inner()
+            .db
+            .query("SELECT * FROM user LIMIT $limit START $start")
+            .bind(("limit", limit))
+            .bind(("start", offset))
+            .await?;
+        Ok(response
+            .take::<Vec<UserRecord>>(0)?
+            .into_iter()
+            .map(UserRecord::into_user)
+            .collect())
+    }
 
-            Ok(response
-                .take::<Vec<UserRecord>>(0)?
-                .into_iter()
-                .map(UserRecord::into_user)
-                .collect())
-        } else {
-            Ok(self
-                .inner()
-                .db
-                .select("user")
-                .await?
-                .into_iter()
-                .map(UserRecord::into_user)
-                .collect())
+    async fn count_users(&self) -> Result<u64, AppError> {
+        #[derive(Deserialize)]
+        struct CountResult {
+            count: u64,
         }
+        let mut response = self
+            .inner()
+            .db
+            .query("SELECT count() FROM user GROUP ALL")
+            .await?;
+        Ok(response
+            .take::<Vec<CountResult>>(0)?
+            .into_iter()
+            .next()
+            .map(|r| r.count)
+            .unwrap_or(0))
     }
 
     async fn get_user(&self, id: &str) -> Result<User, AppError> {

--- a/backend/tests/1_teams.yml
+++ b/backend/tests/1_teams.yml
@@ -726,7 +726,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.team-create-lead-session.sessionid}}"
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-TEAM-007, BLC-TEAM-018
   - name: team-lead-get-deleted-shared-not-found

--- a/backend/tests/2_users.yml
+++ b/backend/tests/2_users.yml
@@ -24,7 +24,7 @@ testcases:
         headers:
           Authorization: "{{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 401
 
   # BLC: BLC-AUTH-002
   - name: get-users-me-invalid-token
@@ -219,15 +219,14 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
-          - result.bodyjson.__Len__ ShouldBeGreaterThanOrEqualTo 2
+          - result.statuscode ShouldEqual 400
 
   # BLC: BLC-LP-007
   - name: get-users-admin-page-only
     steps:
       - type: http
         method: GET
-        url: "{{.base_url}}/api/v1/users?page=1"
+        url: "{{.base_url}}/api/v1/users?page=0"
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
@@ -244,7 +243,7 @@ testcases:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
           - result.statuscode ShouldEqual 200
-          - result.bodyjson.__Len__ ShouldBeGreaterThanOrEqualTo 2
+          - result.bodyjson.__Len__ ShouldEqual 1
 
   # BLC: BLC-LP-008
   - name: get-users-admin-page-beyond-range
@@ -581,10 +580,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
-          - result.bodyjson.id ShouldEqual "{{.post-users.userid}}"
-          - result.bodyjson.email ShouldEqual "anormaluser@test.com"
-          - result.bodyjson.role ShouldEqual "default"
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-USER-013
   - name: get-default-user-session-after-delete

--- a/backend/tests/3_sessions.yml
+++ b/backend/tests/3_sessions.yml
@@ -197,8 +197,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.create-session-primary.sessionid_primary}}"
         assertions:
-          - result.statuscode ShouldEqual 200
-          - result.bodyjson.id ShouldEqual "{{.create-session-secondary.sessionid_secondary}}"
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-SESS-003, BLC-USER-010
   - name: get-me-sessions-after-delete
@@ -446,7 +445,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-SESS-006, BLC-USER-011
   - name: delete-session-for-user-admin
@@ -457,8 +456,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
-          - result.bodyjson.id ShouldEqual "{{.create-session-primary.sessionid_primary}}"
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-AUTH-002
   - name: delete-session-for-user-admin-invalid-token
@@ -491,7 +489,5 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
-          - result.bodyjson.id ShouldEqual "{{.create-session-user.userid}}"
-          - result.bodyjson.email ShouldEqual "sessionuser@test.com"
+          - result.statuscode ShouldEqual 204
 

--- a/backend/tests/4_songs.yml
+++ b/backend/tests/4_songs.yml
@@ -957,18 +957,19 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 400
 
   # BLC: BLC-LP-007
   - name: get-songs-page-only-admin
     steps:
       - type: http
         method: GET
-        url: "{{.base_url}}/api/v1/songs?page=1"
+        url: "{{.base_url}}/api/v1/songs?page=0"
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
           - result.statuscode ShouldEqual 200
+          - result.bodyjson.__Len__ ShouldBeGreaterThanOrEqualTo 2
 
   # BLC: BLC-LP-007
   - name: get-songs-page-size-only-admin
@@ -980,6 +981,7 @@ testcases:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
           - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 1
 
   # BLC: BLC-LP-008
   - name: get-songs-page-beyond-range-admin
@@ -1490,8 +1492,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.create-song-owner-session.sessionid}}"
         assertions:
-          - result.statuscode ShouldEqual 200
-          - result.bodyjson.id ShouldEqual "{{.post-song-for-delete.songid}}"
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-SONG-008, BLC-SONG-014
   - name: delete-song-success-with-write-permission
@@ -1502,8 +1503,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.create-write-user-session.sessionid}}"
         assertions:
-          - result.statuscode ShouldEqual 200
-          - result.bodyjson.id ShouldEqual "{{.post-song-for-delete-with-write-permission.songid}}"
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-HTTP-001
   - name: delete-song-invalid-id
@@ -1696,8 +1696,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.create-song-owner-session.sessionid}}"
         assertions:
-          - result.statuscode ShouldEqual 200
-          - result.bodyjson.id ShouldEqual "{{.put-song-cascade-target.songid}}"
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-SONG-015, BLC-SETL-014, BLC-COLL-019
   - name: get-setlist-after-song-delete
@@ -2154,7 +2153,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 204
 
   - name: delete-song-owner-user
     steps:
@@ -2164,7 +2163,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-USER-011
   - name: delete-read-user
@@ -2175,7 +2174,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-USER-011
   - name: delete-write-user
@@ -2186,7 +2185,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-USER-011
   - name: delete-no-permission-user
@@ -2197,5 +2196,5 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 204
 

--- a/backend/tests/5_collections.yml
+++ b/backend/tests/5_collections.yml
@@ -521,15 +521,14 @@ testcases:
         headers:
           Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
         assertions:
-          - result.statuscode ShouldEqual 200
-          - result.bodyjson ShouldHaveLength 3
+          - result.statuscode ShouldEqual 400
 
   # BLC: BLC-LP-007, BLC-COLL-010, BLC-COLL-005, BLC-LP-001, BLC-LP-002
   - name: get-collections-owner-page-only
     steps:
       - type: http
         method: GET
-        url: "{{.base_url}}/api/v1/collections?page=1"
+        url: "{{.base_url}}/api/v1/collections?page=0"
         headers:
           Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
         assertions:
@@ -546,7 +545,7 @@ testcases:
           Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
         assertions:
           - result.statuscode ShouldEqual 200
-          - result.bodyjson ShouldHaveLength 3
+          - result.bodyjson ShouldHaveLength 1
 
   # BLC: BLC-LP-008, BLC-COLL-010, BLC-COLL-005, BLC-LP-001, BLC-LP-002
   - name: get-collections-owner-page-beyond-range
@@ -1145,8 +1144,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
         assertions:
-          - result.statuscode ShouldEqual 200
-          - result.bodyjson.id ShouldEqual "{{.post-collection-for-delete.collectionid}}"
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-COLL-008, BLC-COLL-015, BLC-USER-011
   - name: delete-collection-success-write-user
@@ -1157,8 +1155,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.create-collection-write-session.sessionid}}"
         assertions:
-          - result.statuscode ShouldEqual 200
-          - result.bodyjson.id ShouldEqual "{{.post-collection-for-delete-write.collectionid}}"
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-HTTP-001
   - name: delete-collection-invalid-id
@@ -1233,8 +1230,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
         assertions:
-          - result.statuscode ShouldEqual 200
-          - result.bodyjson.id ShouldEqual "{{.post-collection-cover-blob.blobid}}"
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-BLOB-014, BLC-COLL-017
   - name: get-collection-after-cover-delete
@@ -1257,7 +1253,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-COLL-007, BLC-COLL-006, BLC-USER-011
   - name: delete-collection-read-user
@@ -1268,7 +1264,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-USER-011
   - name: delete-collection-write-user
@@ -1279,7 +1275,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-COLL-007, BLC-COLL-006, BLC-USER-011
   - name: delete-collection-noperm-user
@@ -1290,5 +1286,5 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 204
 

--- a/backend/tests/6_setlists.yml
+++ b/backend/tests/6_setlists.yml
@@ -468,15 +468,14 @@ testcases:
         headers:
           Authorization: "Bearer {{.create-setlist-owner-session.sessionid}}"
         assertions:
-          - result.statuscode ShouldEqual 200
-          - result.bodyjson ShouldHaveLength 2
+          - result.statuscode ShouldEqual 400
 
   # BLC: BLC-LP-007, BLC-SETL-010, BLC-SETL-005, BLC-LP-001, BLC-LP-002
   - name: get-setlists-owner-page-only
     steps:
       - type: http
         method: GET
-        url: "{{.base_url}}/api/v1/setlists?page=1"
+        url: "{{.base_url}}/api/v1/setlists?page=0"
         headers:
           Authorization: "Bearer {{.create-setlist-owner-session.sessionid}}"
         assertions:
@@ -493,7 +492,7 @@ testcases:
           Authorization: "Bearer {{.create-setlist-owner-session.sessionid}}"
         assertions:
           - result.statuscode ShouldEqual 200
-          - result.bodyjson ShouldHaveLength 2
+          - result.bodyjson ShouldHaveLength 1
 
   # BLC: BLC-LP-008, BLC-SETL-010, BLC-SETL-005, BLC-LP-001, BLC-LP-002
   - name: get-setlists-owner-page-beyond-range
@@ -1017,8 +1016,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.create-setlist-write-session.sessionid}}"
         assertions:
-          - result.statuscode ShouldEqual 200
-          - result.bodyjson.id ShouldEqual "{{.post-setlist-for-delete-by-write.setlistid}}"
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-SETL-008, BLC-SETL-012
   - name: delete-setlist-success
@@ -1029,8 +1027,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.create-setlist-owner-session.sessionid}}"
         assertions:
-          - result.statuscode ShouldEqual 200
-          - result.bodyjson.id ShouldEqual "{{.post-setlist-success.setlistid}}"
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-HTTP-002
   - name: delete-setlist-again
@@ -1053,7 +1050,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-USER-011
   - name: cleanup-delete-setlist-read-user
@@ -1064,7 +1061,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-USER-011
   - name: cleanup-delete-setlist-write-user
@@ -1075,7 +1072,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-USER-011
   - name: cleanup-delete-setlist-noperm-user
@@ -1086,5 +1083,5 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 204
 

--- a/backend/tests/7_blobs.yml
+++ b/backend/tests/7_blobs.yml
@@ -460,7 +460,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.create-blob-owner-session.sessionid}}"
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 400
 
   # BLC: BLC-LP-007
   - name: get-blobs-owner-page-only
@@ -860,8 +860,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.create-blob-owner-session.sessionid}}"
         assertions:
-          - result.statuscode ShouldEqual 200
-          - result.bodyjson.id ShouldEqual "{{.post-blob-for-delete.blobid}}"
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-BLOB-008, BLC-BLOB-013
   - name: delete-blob-success-write
@@ -872,8 +871,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.create-blob-write-session.sessionid}}"
         assertions:
-          - result.statuscode ShouldEqual 200
-          - result.bodyjson.id ShouldEqual "{{.post-blob-for-delete-write.blobid}}"
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-HTTP-001
   - name: delete-blob-invalid-id
@@ -1016,7 +1014,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-USER-011
   - name: delete-blob-read-user
@@ -1027,7 +1025,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-USER-011
   - name: delete-blob-write-user
@@ -1038,7 +1036,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 204
 
   # BLC: BLC-USER-011
   - name: delete-blob-noperm-user
@@ -1049,5 +1047,5 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 204
 

--- a/backend/tests/8_team_invitations.yml
+++ b/backend/tests/8_team_invitations.yml
@@ -320,7 +320,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.ti-create-lead-session.sessionid}}"
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 204
 
   # Teardown: keep suites isolated regardless of file execution order.
   - name: ti-cleanup-delete-maintainer-user
@@ -331,8 +331,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
-          - result.bodyjson.id ShouldEqual "{{.ti-create-maintainer-user.userid}}"
+          - result.statuscode ShouldEqual 204
 
   # Teardown: remove invited guest user and related memberships/sessions.
   - name: ti-cleanup-delete-guest-user
@@ -343,8 +342,7 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
-          - result.bodyjson.id ShouldEqual "{{.ti-create-guest-user.userid}}"
+          - result.statuscode ShouldEqual 204
 
   # Teardown: remove lead user and any remaining invitation suite artifacts.
   - name: ti-cleanup-delete-lead-user
@@ -355,5 +353,4 @@ testcases:
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:
-          - result.statuscode ShouldEqual 200
-          - result.bodyjson.id ShouldEqual "{{.ti-create-lead-user.userid}}"
+          - result.statuscode ShouldEqual 204

--- a/cli/src/handlers/blobs.rs
+++ b/cli/src/handlers/blobs.rs
@@ -87,8 +87,8 @@ pub async fn handle_blobs(
                 output::print_json(&planned, &output)?;
                 return Ok(());
             }
-            let blob = client.delete_blob(&id).await?;
-            output::print_json(&blob, &output)
+            client.delete_blob(&id).await?;
+            output::print_json(&serde_json::json!({"deleted": true}), &output)
         }
         BlobsCommand::DownloadUrl { id } => {
             validate_resource_id(&id)?;

--- a/cli/src/handlers/collections.rs
+++ b/cli/src/handlers/collections.rs
@@ -100,8 +100,8 @@ pub async fn handle_collections(
                 output::print_json(&planned, &output)?;
                 return Ok(());
             }
-            let collection = client.delete_collection(&id).await?;
-            output::print_json(&collection, &output)
+            client.delete_collection(&id).await?;
+            output::print_json(&serde_json::json!({"deleted": true}), &output)
         }
     }
 }

--- a/cli/src/handlers/sessions.rs
+++ b/cli/src/handlers/sessions.rs
@@ -34,8 +34,8 @@ pub async fn handle_sessions(
                 output::print_json(&planned, &output)?;
                 return Ok(());
             }
-            let session = client.delete_my_session(&id).await?;
-            output::print_json(&session, &output)
+            client.delete_my_session(&id).await?;
+            output::print_json(&serde_json::json!({"deleted": true}), &output)
         }
         SessionsCommand::CreateForUser { user_id } => {
             validate_resource_id(&user_id)?;
@@ -76,8 +76,8 @@ pub async fn handle_sessions(
                 output::print_json(&planned, &output)?;
                 return Ok(());
             }
-            let session = client.delete_session_for_user(&user_id, &id).await?;
-            output::print_json(&session, &output)
+            client.delete_session_for_user(&user_id, &id).await?;
+            output::print_json(&serde_json::json!({"deleted": true}), &output)
         }
     }
 }

--- a/cli/src/handlers/setlists.rs
+++ b/cli/src/handlers/setlists.rs
@@ -100,8 +100,8 @@ pub async fn handle_setlists(
                 output::print_json(&planned, &output)?;
                 return Ok(());
             }
-            let setlist = client.delete_setlist(&id).await?;
-            output::print_json(&setlist, &output)
+            client.delete_setlist(&id).await?;
+            output::print_json(&serde_json::json!({"deleted": true}), &output)
         }
     }
 }

--- a/cli/src/handlers/songs.rs
+++ b/cli/src/handlers/songs.rs
@@ -92,8 +92,8 @@ pub async fn handle_songs(
                 output::print_json(&planned, &output)?;
                 return Ok(());
             }
-            let song = client.delete_song(&id).await?;
-            output::print_json(&song, &output)
+            client.delete_song(&id).await?;
+            output::print_json(&serde_json::json!({"deleted": true}), &output)
         }
         SongsCommand::LikeStatus { id } => {
             validate_resource_id(&id)?;

--- a/cli/src/handlers/teams.rs
+++ b/cli/src/handlers/teams.rs
@@ -79,8 +79,8 @@ pub async fn handle_teams(
                 output::print_json(&planned, &output)?;
                 return Ok(());
             }
-            let team = client.delete_team(&id).await?;
-            output::print_json(&team, &output)
+            client.delete_team(&id).await?;
+            output::print_json(&serde_json::json!({"deleted": true}), &output)
         }
     }
 }

--- a/cli/src/handlers/users.rs
+++ b/cli/src/handlers/users.rs
@@ -56,8 +56,8 @@ pub async fn handle_users(
                 output::print_json(&planned, &output)?;
                 return Ok(());
             }
-            let user = client.delete_user(&id).await?;
-            output::print_json(&user, &output)
+            client.delete_user(&id).await?;
+            output::print_json(&serde_json::json!({"deleted": true}), &output)
         }
     }
 }

--- a/cli/src/validate.rs
+++ b/cli/src/validate.rs
@@ -28,10 +28,10 @@ pub fn validate_resource_id(id: &str) -> Result<&str, ValidationError> {
 
     if id
         .chars()
-        .any(|c| c.is_control() || c == '?' || c == '#' || c == '%')
+        .any(|c| c.is_control() || c == '?' || c == '#' || c == '%' || c == ':')
     {
         return Err(ValidationError::new(
-            "id contains forbidden characters (control, '?', '#', '%')",
+            "id contains forbidden characters (control, '?', '#', '%', ':')",
         ));
     }
 

--- a/docs/business-logic-constraints/list-pagination.md
+++ b/docs/business-logic-constraints/list-pagination.md
@@ -6,18 +6,20 @@ Applies to **GET** list routes that support paging: **`/users`** (admin), **`/bl
 
 - **BLC-LP-001:** **`page`** — 0-based index of the page.
 - **BLC-LP-002:** **`page_size`** — maximum number of items per page.
-- **BLC-LP-003:** **`q`** — optional search filter on **`/songs`**, **`/collections`**, and **`/setlists`** only (not on **`/users`** or **`/blobs`**). Collection and setlist lists match **title**; song list also matches **artists** and lyric text per the product’s list-search rules (including stemming where applicable).
+- **BLC-LP-003:** **`q`** — optional search filter on **`/songs`**, **`/collections`**, and **`/setlists`** only (not on **`/users`** or **`/blobs`**). Collection and setlist lists match **title**; song list also matches **artists** and lyric text per the product's list-search rules (including stemming where applicable).
 
 ## Validation
 
 - **BLC-LP-004:** WHEN **`page`** or **`page_size`** is present but not a valid integer THEN the API responds **400**.
+- **BLC-LP-004a:** WHEN **`page_size`** IS **`0`** THEN the API responds **400** (zero is not a valid page size).
+- **BLC-LP-004b:** WHEN **`page_size`** EXCEEDS **500** THEN the API responds **400**.
 - **BLC-LP-005:** WHEN **`q`** IS only whitespace THEN it IS treated as absent: the same result as omitting **`q`**, after applying visibility rules for the caller.
 
 ## Pagination behavior
 
-- **BLC-LP-006:** WHEN **`page_size`** IS **`0`** THEN no page-size cap IS applied for that request (all items for the current **`page`** index that match visibility and **`q`** are returned).
-- **BLC-LP-007:** WHEN only **`page`** OR only **`page_size`** IS supplied THEN the omitted parameter uses a server default; the request still succeeds (**200**).
+- **BLC-LP-006:** ~~WHEN **`page_size`** IS **`0`** THEN no page-size cap IS applied~~ — **removed**: `page_size=0` is now rejected with `400` (see BLC-LP-004a).
+- **BLC-LP-007:** WHEN **`page`** is absent it defaults to **0**. WHEN **`page_size`** is absent it defaults to **50**. The server hard cap is **500**.
 - **BLC-LP-008:** WHEN **`page`** IS beyond the last page THEN the API responds **200** with an **empty array** (not **404**).
 - **BLC-LP-009:** WHEN **`q`** IS combined with **`page`** / **`page_size`** THEN filtering runs first, then pagination over those results.
 
-List responses documented here do not define a separate total-count field; clients infer “no more pages” from an empty page or a page shorter than **`page_size`** where applicable.
+All list responses include an **`X-Total-Count`** response header containing the total number of matching records (before pagination), allowing clients to calculate the total number of pages.

--- a/frontend/src/api/api.rs
+++ b/frontend/src/api/api.rs
@@ -137,7 +137,7 @@ impl Api {
     }
 
     #[allow(dead_code)]
-    pub async fn delete_user(&self, id: &str) -> Result<User, ApiError> {
+    pub async fn delete_user(&self, id: &str) -> Result<(), ApiError> {
         ApiError::check_and_notify_offline(OperationType::Write);
         self.client
             .delete_user(id)
@@ -173,7 +173,7 @@ impl Api {
     }
 
     #[allow(dead_code)]
-    pub async fn delete_session_for_current_user(&self, id: &str) -> Result<Session, ApiError> {
+    pub async fn delete_session_for_current_user(&self, id: &str) -> Result<(), ApiError> {
         ApiError::check_and_notify_offline(OperationType::Write);
         self.client
             .delete_my_session(id)
@@ -213,7 +213,7 @@ impl Api {
         &self,
         user_id: &str,
         id: &str,
-    ) -> Result<Session, ApiError> {
+    ) -> Result<(), ApiError> {
         ApiError::check_and_notify_offline(OperationType::Write);
         self.client
             .delete_session_for_user(user_id, id)
@@ -268,7 +268,7 @@ impl Api {
     }
 
     #[allow(dead_code)]
-    pub async fn delete_song(&self, id: &str) -> Result<Song, ApiError> {
+    pub async fn delete_song(&self, id: &str) -> Result<(), ApiError> {
         ApiError::check_and_notify_offline(OperationType::Write);
         self.client
             .delete_song(id)
@@ -357,7 +357,7 @@ impl Api {
     }
 
     #[allow(dead_code)]
-    pub async fn delete_collection(&self, id: &str) -> Result<Collection, ApiError> {
+    pub async fn delete_collection(&self, id: &str) -> Result<(), ApiError> {
         ApiError::check_and_notify_offline(OperationType::Write);
         self.client
             .delete_collection(id)
@@ -425,7 +425,7 @@ impl Api {
     }
 
     #[allow(dead_code)]
-    pub async fn delete_setlist(&self, id: &str) -> Result<Setlist, ApiError> {
+    pub async fn delete_setlist(&self, id: &str) -> Result<(), ApiError> {
         ApiError::check_and_notify_offline(OperationType::Write);
         self.client
             .delete_setlist(id)
@@ -470,7 +470,7 @@ impl Api {
     }
 
     #[allow(dead_code)]
-    pub async fn delete_blob(&self, id: &str) -> Result<Blob, ApiError> {
+    pub async fn delete_blob(&self, id: &str) -> Result<(), ApiError> {
         ApiError::check_and_notify_offline(OperationType::Write);
         self.client
             .delete_blob(id)

--- a/shared/src/api/list_query.rs
+++ b/shared/src/api/list_query.rs
@@ -1,5 +1,10 @@
 use serde::{Deserialize, Serialize};
 
+/// Default page size when `page_size` is not supplied.
+pub const PAGE_SIZE_DEFAULT: u32 = 50;
+/// Hard cap on `page_size`; requests above this are rejected with 400.
+pub const PAGE_SIZE_MAX: u32 = 500;
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ListQuery {
     pub page: Option<u32>,
@@ -25,6 +30,36 @@ impl ListQuery {
     pub fn with_q(mut self, q: impl Into<String>) -> Self {
         self.q = Some(q.into());
         self
+    }
+
+    /// Validate the query parameters and return `Err` with a human-readable
+    /// message when they are out of range.
+    ///
+    /// - `page_size = 0` is rejected (non-standard and a DoS footgun).
+    /// - `page_size > PAGE_SIZE_MAX` is rejected.
+    pub fn validate(self) -> Result<Self, String> {
+        if let Some(ps) = self.page_size {
+            if ps == 0 {
+                return Err("page_size must be greater than 0".into());
+            }
+            if ps > PAGE_SIZE_MAX {
+                return Err(format!("page_size must not exceed {PAGE_SIZE_MAX}"));
+            }
+        }
+        Ok(self)
+    }
+
+    /// Return `(offset, limit)`, applying [`PAGE_SIZE_DEFAULT`] and page 0
+    /// when either parameter is absent.  Always returns a finite pair;
+    /// callers should run [`validate`] first to ensure the stored values are
+    /// in range.
+    pub fn effective_offset_limit(&self) -> (u32, u32) {
+        let page = self.page.unwrap_or(0);
+        let page_size = match self.page_size {
+            Some(0) | None => PAGE_SIZE_DEFAULT,
+            Some(ps) => ps,
+        };
+        (page.saturating_mul(page_size), page_size)
     }
 
     pub fn to_offset_limit(&self) -> Option<(u32, u32)> {

--- a/shared/src/api/mod.rs
+++ b/shared/src/api/mod.rs
@@ -81,8 +81,10 @@ impl<C: HttpClient> ApiClient<C> {
         self.client.post("api/v1/users", &payload).await
     }
 
-    pub async fn delete_user(&self, id: &str) -> Result<User, NetworkClientError> {
-        self.client.delete(&format!("api/v1/users/{id}")).await
+    pub async fn delete_user(&self, id: &str) -> Result<(), NetworkClientError> {
+        self.client
+            .delete_no_content(&format!("api/v1/users/{id}"))
+            .await
     }
 
     pub async fn list_my_sessions(&self) -> Result<Vec<Session>, NetworkClientError> {
@@ -95,9 +97,9 @@ impl<C: HttpClient> ApiClient<C> {
             .await
     }
 
-    pub async fn delete_my_session(&self, id: &str) -> Result<Session, NetworkClientError> {
+    pub async fn delete_my_session(&self, id: &str) -> Result<(), NetworkClientError> {
         self.client
-            .delete(&format!("api/v1/users/me/sessions/{id}"))
+            .delete_no_content(&format!("api/v1/users/me/sessions/{id}"))
             .await
     }
 
@@ -136,9 +138,9 @@ impl<C: HttpClient> ApiClient<C> {
         &self,
         user_id: &str,
         id: &str,
-    ) -> Result<Session, NetworkClientError> {
+    ) -> Result<(), NetworkClientError> {
         self.client
-            .delete(&format!("api/v1/users/{user_id}/sessions/{id}"))
+            .delete_no_content(&format!("api/v1/users/{user_id}/sessions/{id}"))
             .await
     }
 
@@ -164,8 +166,10 @@ impl<C: HttpClient> ApiClient<C> {
             .await
     }
 
-    pub async fn delete_team(&self, id: &str) -> Result<Team, NetworkClientError> {
-        self.client.delete(&format!("api/v1/teams/{id}")).await
+    pub async fn delete_team(&self, id: &str) -> Result<(), NetworkClientError> {
+        self.client
+            .delete_no_content(&format!("api/v1/teams/{id}"))
+            .await
     }
 
     pub async fn patch_team(
@@ -205,8 +209,10 @@ impl<C: HttpClient> ApiClient<C> {
             .await
     }
 
-    pub async fn delete_song(&self, id: &str) -> Result<Song, NetworkClientError> {
-        self.client.delete(&format!("api/v1/songs/{id}")).await
+    pub async fn delete_song(&self, id: &str) -> Result<(), NetworkClientError> {
+        self.client
+            .delete_no_content(&format!("api/v1/songs/{id}"))
+            .await
     }
 
     pub async fn patch_song(
@@ -278,9 +284,9 @@ impl<C: HttpClient> ApiClient<C> {
             .await
     }
 
-    pub async fn delete_collection(&self, id: &str) -> Result<Collection, NetworkClientError> {
+    pub async fn delete_collection(&self, id: &str) -> Result<(), NetworkClientError> {
         self.client
-            .delete(&format!("api/v1/collections/{id}"))
+            .delete_no_content(&format!("api/v1/collections/{id}"))
             .await
     }
 
@@ -335,8 +341,10 @@ impl<C: HttpClient> ApiClient<C> {
             .await
     }
 
-    pub async fn delete_setlist(&self, id: &str) -> Result<Setlist, NetworkClientError> {
-        self.client.delete(&format!("api/v1/setlists/{id}")).await
+    pub async fn delete_setlist(&self, id: &str) -> Result<(), NetworkClientError> {
+        self.client
+            .delete_no_content(&format!("api/v1/setlists/{id}"))
+            .await
     }
 
     pub async fn patch_setlist(
@@ -372,8 +380,10 @@ impl<C: HttpClient> ApiClient<C> {
             .await
     }
 
-    pub async fn delete_blob(&self, id: &str) -> Result<Blob, NetworkClientError> {
-        self.client.delete(&format!("api/v1/blobs/{id}")).await
+    pub async fn delete_blob(&self, id: &str) -> Result<(), NetworkClientError> {
+        self.client
+            .delete_no_content(&format!("api/v1/blobs/{id}"))
+            .await
     }
 
     pub async fn patch_blob(

--- a/shared/src/auth/otp.rs
+++ b/shared/src/auth/otp.rs
@@ -2,12 +2,14 @@ use serde::{Deserialize, Serialize};
 
 #[cfg_attr(feature = "backend", derive(utoipa::ToSchema))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct OtpRequest {
     pub email: String,
 }
 
 #[cfg_attr(feature = "backend", derive(utoipa::ToSchema))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct OtpVerify {
     pub email: String,
     pub code: String,

--- a/shared/src/blob/blob.rs
+++ b/shared/src/blob/blob.rs
@@ -26,6 +26,7 @@ impl Blob {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "backend", derive(ToSchema))]
 pub struct CreateBlob {
     pub file_type: FileType,

--- a/shared/src/collection/collection.rs
+++ b/shared/src/collection/collection.rs
@@ -15,6 +15,7 @@ pub struct Collection {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "backend", derive(ToSchema))]
 pub struct CreateCollection {
     pub title: String,

--- a/shared/src/error/mod.rs
+++ b/shared/src/error/mod.rs
@@ -1,9 +1,16 @@
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+/// Standard error envelope returned by all API error responses.
+///
+/// `code` is a stable, machine-readable identifier; `error` is a human-readable
+/// description.
 #[cfg_attr(feature = "backend", derive(utoipa::ToSchema))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ErrorResponse {
+    /// Stable machine-readable error code, e.g. `"unauthorized"`, `"not_found"`.
+    pub code: String,
+    /// Human-readable description of the error.
     pub error: String,
 }
 

--- a/shared/src/like/like.rs
+++ b/shared/src/like/like.rs
@@ -11,6 +11,7 @@ pub struct Like {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "backend", derive(ToSchema))]
 pub struct LikeStatus {
     pub liked: bool,

--- a/shared/src/net/desktop.rs
+++ b/shared/src/net/desktop.rs
@@ -160,4 +160,20 @@ impl HttpClient for DesktopHttpClient {
 
         Ok(value)
     }
+
+    async fn delete_no_content(&self, path: &str) -> Result<(), NetworkClientError> {
+        let url = self.make_url(path);
+
+        let mut request = self.client.delete(url);
+        if let Some(cookie) = &self.config.session_cookie {
+            request = request.header(reqwest::header::COOKIE, format!("sso_session={cookie}"));
+        }
+        if let Some(token) = &self.config.bearer_token {
+            request = request.bearer_auth(token);
+        }
+
+        let response = request.send().await?;
+        response.error_for_status()?;
+        Ok(())
+    }
 }

--- a/shared/src/net/mod.rs
+++ b/shared/src/net/mod.rs
@@ -45,6 +45,9 @@ pub trait HttpClient: Send + Sync {
     async fn delete<T>(&self, path: &str) -> Result<T, NetworkClientError>
     where
         T: DeserializeOwned + Send + 'static;
+
+    /// Send a DELETE request and treat `204 No Content` (empty body) as success.
+    async fn delete_no_content(&self, path: &str) -> Result<(), NetworkClientError>;
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -76,6 +79,9 @@ pub trait HttpClient: Send + Sync {
     async fn delete<T>(&self, path: &str) -> Result<T, NetworkClientError>
     where
         T: DeserializeOwned + Send + 'static;
+
+    /// Send a DELETE request and treat `204 No Content` (empty body) as success.
+    async fn delete_no_content(&self, path: &str) -> Result<(), NetworkClientError>;
 }
 
 #[cfg(all(feature = "cli", not(target_arch = "wasm32")))]

--- a/shared/src/net/wasm.rs
+++ b/shared/src/net/wasm.rs
@@ -184,4 +184,24 @@ impl HttpClient for WasmHttpClient {
         let value = serde_json::from_str::<T>(&text)?;
         Ok(value)
     }
+
+    async fn delete_no_content(&self, path: &str) -> Result<(), NetworkClientError> {
+        let url = self.make_url(path);
+
+        let response = gloo_net::http::Request::delete(&url)
+            .credentials(RequestCredentials::Include)
+            .send()
+            .await?;
+        let status = response.status();
+
+        if !(200..300).contains(&status) {
+            let text = response.text().await.unwrap_or_default();
+            return Err(NetworkClientError::RequestFailed {
+                status: Some(status as u16),
+                message: text,
+            });
+        }
+
+        Ok(())
+    }
 }

--- a/shared/src/setlist/setlist.rs
+++ b/shared/src/setlist/setlist.rs
@@ -14,6 +14,7 @@ pub struct Setlist {
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone)]
+#[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "backend", derive(ToSchema))]
 pub struct CreateSetlist {
     pub title: String,

--- a/shared/src/song/song.rs
+++ b/shared/src/song/song.rs
@@ -28,6 +28,7 @@ pub struct Song {
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone)]
+#[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "backend", derive(ToSchema))]
 pub struct CreateSong {
     pub not_a_song: bool,

--- a/shared/src/team/team.rs
+++ b/shared/src/team/team.rs
@@ -48,6 +48,7 @@ pub struct Team {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "backend", derive(ToSchema))]
 pub struct CreateTeam {
     pub name: String,
@@ -57,6 +58,7 @@ pub struct CreateTeam {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "backend", derive(ToSchema))]
 pub struct UpdateTeam {
     pub name: String,

--- a/shared/src/user/request.rs
+++ b/shared/src/user/request.rs
@@ -8,6 +8,7 @@ use super::User;
 
 #[cfg_attr(feature = "backend", derive(utoipa::ToSchema))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct CreateUserRequest {
     pub email: String,
     #[serde(default)]


### PR DESCRIPTION
## Summary

- **DELETE → 204 No Content**: All delete endpoints now return `204`; `delete_no_content` added to `HttpClient` trait; CLI prints `{"deleted":true}`, frontend/API client return `Result<(), _>`
- **Error response improvements**: Stable machine-readable `code` field on every error; `X-Request-Id` middleware for request correlation; internal SurrealDB error details sanitized from client responses
- **Strict deserialization**: `#[serde(deny_unknown_fields)]` on all request DTOs; Actix `JsonConfig` maps serde errors to structured `400` responses
- **Pagination hardening**: `page_size=0` → `400`; `page_size` capped at 500; default page/page_size applied when omitted; all list queries bounded; `X-Total-Count` header on every list response; BLC doc updated
- **Resource ID tightening**: `resource_id` rejects `table:id` format at the HTTP edge; CLI `validate_resource_id` updated to match
- **Bearer-only auth**: `Authorization` header must use `Bearer <token>` prefix; raw tokens rejected with `401`; OpenAPI `SessionSecurity` description updated
- **OpenAPI fix**: Blob download endpoint annotated with `content_type = "image/*"`

## Test plan

- [ ] `cargo test` passes in `backend/` (270 tests)
- [ ] `cargo test` passes in `shared/` and `cli/`
- [ ] `cargo build --target wasm32-unknown-unknown` succeeds in `frontend/`
- [ ] DELETE endpoints return `204` in integration/manual testing
- [ ] `page_size=0` and `page_size>500` return `400`
- [ ] Raw token (no `Bearer` prefix) returns `401`
- [ ] `table:id` resource IDs return `400`
- [ ] Error responses include `code` and `X-Request-Id` header
- [ ] List responses include `X-Total-Count` header

Made with [Cursor](https://cursor.com)