### PR TITLE
Close REST API gaps (backend, shared, docs, Venom)

### DIFF
--- a/backend/src/auth/oidc/rest.rs
+++ b/backend/src/auth/oidc/rest.rs
@@ -20,7 +20,7 @@ use utoipa::IntoParams;
 use super::{Model as OidcModel, OidcClients, OidcProvider, PendingOidc};
 use crate::database::Database;
 #[allow(unused_imports)]
-use crate::docs::ErrorResponse;
+use crate::docs::ProblemDetails;
 use crate::error::AppError;
 use crate::resources::Session;
 use crate::resources::user::service::UserServiceHandle;
@@ -33,9 +33,9 @@ use crate::settings::CookieConfig;
     params(LoginQuery),
     responses(
         (status = 302, description = "Redirect to OIDC provider login page"),
-        (status = 400, description = "Invalid login request", body = ErrorResponse),
-        (status = 429, description = "Rate limit exceeded; slow down and retry", body = ErrorResponse),
-        (status = 500, description = "Failed to prepare login flow", body = ErrorResponse)
+        (status = 400, description = "Invalid login request", body = ProblemDetails),
+        (status = 429, description = "Rate limit exceeded; slow down and retry", body = ProblemDetails),
+        (status = 500, description = "Failed to prepare login flow", body = ProblemDetails)
     ),
     tag = "Auth"
 )]
@@ -97,9 +97,9 @@ async fn login(
     params(AuthCallbackQuery),
     responses(
         (status = 302, description = "Successful callback exchange; redirects back to frontend"),
-        (status = 400, description = "Invalid OIDC state", body = ErrorResponse),
-        (status = 401, description = "OIDC user info missing required claims", body = ErrorResponse),
-        (status = 500, description = "OIDC provider or database error", body = ErrorResponse)
+        (status = 400, description = "Invalid OIDC state", body = ProblemDetails),
+        (status = 401, description = "OIDC user info missing required claims", body = ProblemDetails),
+        (status = 500, description = "OIDC provider or database error", body = ProblemDetails)
     ),
     tag = "Auth"
 )]

--- a/backend/src/auth/otp/rest.rs
+++ b/backend/src/auth/otp/rest.rs
@@ -12,7 +12,7 @@ use time::Duration as CookieDuration;
 use super::Model;
 use crate::database::Database;
 #[allow(unused_imports)]
-use crate::docs::ErrorResponse;
+use crate::docs::ProblemDetails;
 use crate::error::AppError;
 use crate::mail::MailService;
 use crate::resources::Session;
@@ -25,10 +25,10 @@ use crate::settings::{CookieConfig, OtpConfig};
     path = "/auth/otp/request",
     request_body = OtpRequest,
     responses(
-        (status = 204, description = "OTP generated and delivered out-of-band"),
-        (status = 400, description = "Email missing or invalid", body = ErrorResponse),
-        (status = 429, description = "Rate limit exceeded; slow down and retry", body = ErrorResponse),
-        (status = 500, description = "Failed to persist or deliver OTP", body = ErrorResponse)
+        (status = 204, description = "OTP generated and delivered out-of-band. Rate limits apply per IP (see server `auth_rate_limit_*` settings). Lockout after too many failed verify attempts is enforced on `/auth/otp/verify`."),
+        (status = 400, description = "Email missing or invalid", body = ProblemDetails),
+        (status = 429, description = "Rate limit exceeded; slow down and retry", body = ProblemDetails),
+        (status = 500, description = "Failed to persist or deliver OTP", body = ProblemDetails)
     ),
     tag = "Auth"
 )]
@@ -64,10 +64,10 @@ async fn otp_request(
     path = "/auth/otp/verify",
     request_body = OtpVerify,
     responses(
-        (status = 200, description = "OTP verified successfully; session cookie issued", body = Session),
-        (status = 400, description = "OTP verification failed", body = ErrorResponse),
-        (status = 429, description = "Too many incorrect attempts; request a new code", body = ErrorResponse),
-        (status = 500, description = "Failed to create session", body = ErrorResponse)
+        (status = 200, description = "OTP verified successfully; session cookie issued. When `WORSHIP_OTP_ALLOW_SELF_SIGNUP` is unset/true, a new user may be created for an unknown email; when false, the email must already exist.", body = Session),
+        (status = 400, description = "OTP verification failed, or signup disabled for unknown email", body = ProblemDetails),
+        (status = 429, description = "Too many incorrect attempts; request a new code", body = ProblemDetails),
+        (status = 500, description = "Failed to create session", body = ProblemDetails)
     ),
     tag = "Auth"
 )]
@@ -97,7 +97,15 @@ async fn otp_verify(
     db.validate_otp(&email, &code, &otp_cfg.pepper, otp_cfg.max_attempts)
         .await?;
 
-    let user = user_svc.get_user_by_email_or_create(&email).await?;
+    let user = if otp_cfg.allow_self_signup {
+        user_svc.get_user_by_email_or_create(&email).await?
+    } else {
+        user_svc.get_user_by_email(&email).await?.ok_or_else(|| {
+            AppError::invalid_request(
+                "no user exists for this email; self-signup via OTP is disabled",
+            )
+        })?
+    };
     let session = session_svc
         .create_session(Session::new(user, cookie_cfg.session_ttl_seconds as i64))
         .await?;

--- a/backend/src/docs.rs
+++ b/backend/src/docs.rs
@@ -10,6 +10,7 @@ use crate::resources::{
     Blob, Collection, CreateBlob, CreateCollection, CreateSetlist, CreateSong, CreateUserRequest,
     Session, Setlist, Song, User,
 };
+use shared::api::{SongListQuery, SongSort};
 use shared::auth::otp::{OtpRequest, OtpVerify};
 use shared::blob::FileType;
 pub use shared::error::{ErrorResponse, ProblemDetails};
@@ -36,7 +37,7 @@ pub mod rest {
         title = "Worship Viewer API",
         version = "1.0.0",
         description = "Versioned REST API under `/api/v1`. Authentication flows live at `/auth/*` (unversioned); clients should treat that split as stable for this major API generation.\n\n\
-            **CSRF:** Cookie sessions use `SameSite=Lax`; state-changing methods are `POST`/`PUT`/`PATCH`/`DELETE` (not `GET`). Cross-site simple requests cannot mutate state via cookies under typical browser rules; API clients using bearer tokens should still avoid exposing tokens to third-party origins.\n\n\
+            **CSRF:** Cookie sessions use `SameSite=Lax`; state-changing methods are `POST`/`PUT`/`PATCH`/`DELETE` (not `GET`). Cross-site simple requests cannot mutate state via cookies under typical browser rules. Browser `fetch` from the SPA should use `credentials: 'same-origin'` (or include cookies only on same-site requests). API clients using bearer tokens should still avoid exposing tokens to third-party origins.\n\n\
             **Errors:** Error responses use `application/problem+json` ([RFC 7807](https://www.rfc-editor.org/rfc/rfc7807)) with `type`, `title`, `status`, `detail`, and `code`.\n\n\
             **Examples:** See schema `example` fields on core DTOs in the components section.",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT")
@@ -116,6 +117,8 @@ pub mod rest {
             CreateUserRequest,
             OtpRequest,
             OtpVerify,
+            SongListQuery,
+            SongSort,
             ErrorResponse,
             ProblemDetails,
             Song,

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -1,6 +1,6 @@
 use actix_web::http::StatusCode;
 use actix_web::web::JsonConfig;
-use actix_web::{HttpResponse, ResponseError};
+use actix_web::{HttpMessage, HttpResponse, ResponseError};
 use thiserror::Error;
 use tracing::error;
 
@@ -31,11 +31,26 @@ pub enum AppError {
 /// 400 `AppError::InvalidRequest` response instead of the default plain-text
 /// 400 from actix-web.
 pub fn json_config() -> JsonConfig {
-    JsonConfig::default().error_handler(|err, _req| {
+    JsonConfig::default().error_handler(|err, req| {
         let message = err.to_string();
+        let instance = req
+            .extensions()
+            .get::<crate::request_id::ApiRequestTarget>()
+            .map(|t| t.0.clone());
+        let problem = ProblemDetails {
+            type_uri: "https://worship-viewer.invalid/problems/invalid_request".into(),
+            title: "Bad Request".into(),
+            status: 400,
+            detail: message.clone(),
+            instance,
+            code: "invalid_request".into(),
+            error: message,
+        };
         actix_web::error::InternalError::from_response(
             err,
-            AppError::InvalidRequest(message).error_response(),
+            HttpResponse::build(StatusCode::BAD_REQUEST)
+                .content_type("application/problem+json")
+                .json(problem),
         )
         .into()
     })
@@ -90,7 +105,10 @@ impl From<surrealdb::Error> for AppError {
                 surrealdb::error::Db::IndexExists { .. }
                 | surrealdb::error::Db::RecordExists { .. }
                 | surrealdb::error::Db::TxKeyAlreadyExists
-                | surrealdb::error::Db::TxConditionNotMet => Self::conflict(dberr.to_string()),
+                | surrealdb::error::Db::TxConditionNotMet => {
+                    error!("database conflict: {dberr}");
+                    Self::conflict("request conflicts with existing data")
+                }
                 surrealdb::error::Db::FieldCheck { .. }
                 | surrealdb::error::Db::FieldValue { .. }
                 | surrealdb::error::Db::InvalidField { .. }

--- a/backend/src/frontend.rs
+++ b/backend/src/frontend.rs
@@ -1,7 +1,7 @@
 pub mod rest {
     use actix_files::{Files, NamedFile};
     use actix_web::dev::{ServiceRequest, ServiceResponse, fn_service};
-    use actix_web::{Error as ActixError, Scope, web};
+    use actix_web::{Error as ActixError, ResponseError, Scope, web};
     use std::path::PathBuf;
 
     use crate::error::AppError;
@@ -20,8 +20,13 @@ pub mod rest {
             move |req: ServiceRequest| {
                 let dir = dir.clone();
                 async move {
-                    let index = index_file(&dir).map_err(ActixError::from)?;
+                    let path = req.path().to_owned();
                     let (http_req, _) = req.into_parts();
+                    if path.starts_with("/api/") || path.starts_with("/auth/") {
+                        let response = AppError::NotFound("not found".into()).error_response();
+                        return Ok(ServiceResponse::new(http_req, response));
+                    }
+                    let index = index_file(&dir).map_err(ActixError::from)?;
                     let response = index.into_response(&http_req);
                     Ok(ServiceResponse::new(http_req, response))
                 }

--- a/backend/src/http_tests.rs
+++ b/backend/src/http_tests.rs
@@ -979,3 +979,70 @@ mod list_pagination {
         );
     }
 }
+
+mod spa_fallback_guard {
+    use actix_web::http::StatusCode;
+    use actix_web::{App, ResponseError, test};
+
+    use crate::error::AppError;
+    use crate::frontend;
+
+    #[actix_web::test]
+    async fn unknown_path_under_api_or_auth_returns_problem_json() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("index.html"), "<html>spa</html>").unwrap();
+        let static_path = dir.path().to_string_lossy().into_owned();
+        let app = test::init_service(App::new().service(frontend::rest::scope(&static_path))).await;
+
+        for uri in [
+            "/api/v1/definitely/not/a/route",
+            "/api/v2/foo",
+            "/auth/not-a-real-endpoint",
+        ] {
+            let req = test::TestRequest::get().uri(uri).to_request();
+            let resp = test::call_service(&app, req).await;
+            assert_eq!(resp.status(), StatusCode::NOT_FOUND, "uri={uri}");
+            let ct = resp
+                .headers()
+                .get("content-type")
+                .and_then(|h| h.to_str().ok())
+                .unwrap_or("");
+            assert!(
+                ct.contains("application/problem+json"),
+                "expected problem+json, got {ct} for {uri}"
+            );
+            let body = test::read_body(resp).await;
+            let s = String::from_utf8_lossy(&body);
+            assert!(
+                !s.contains("<html"),
+                "should not return SPA shell for {uri}"
+            );
+        }
+    }
+
+    #[actix_web::test]
+    async fn spa_route_still_serves_index_html() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("index.html"), "<html>spa</html>").unwrap();
+        let static_path = dir.path().to_string_lossy().into_owned();
+        let app = test::init_service(App::new().service(frontend::rest::scope(&static_path))).await;
+
+        let req = test::TestRequest::get().uri("/app/deep/link").to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = test::read_body(resp).await;
+        assert!(String::from_utf8_lossy(&body).contains("spa"));
+    }
+
+    #[actix_web::test]
+    async fn not_found_body_is_problem_details_shape() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("index.html"), "<html/>").unwrap();
+        let static_path = dir.path().to_string_lossy().into_owned();
+        let app = test::init_service(App::new().service(frontend::rest::scope(&static_path))).await;
+        let req = test::TestRequest::get().uri("/api/missing").to_request();
+        let resp = test::call_service(&app, req).await;
+        let expected = AppError::NotFound("not found".into()).error_response();
+        assert_eq!(resp.status(), expected.status());
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -38,6 +38,25 @@ async fn main() -> AnyResult<()> {
 
     let settings = Settings::from_env()?;
 
+    let production = matches!(
+        std::env::var("WORSHIP_PRODUCTION").ok().as_deref(),
+        Some("true" | "1" | "yes")
+    ) || matches!(
+        std::env::var("RUST_ENV").ok().as_deref(),
+        Some("production")
+    );
+    if production && settings.initial_admin_user_test_session {
+        anyhow::bail!(
+            "refusing to start: initial_admin_user_test_session is enabled under WORSHIP_PRODUCTION or RUST_ENV=production"
+        );
+    }
+
+    let static_dir = std::fs::canonicalize(settings.static_dir.as_str())
+        .with_context(|| format!("static_dir {:?} could not be resolved", settings.static_dir))?
+        .to_string_lossy()
+        .into_owned();
+    info!("Serving static files from {}", static_dir);
+
     let cookie_config = Data::new(settings.cookie_config());
     let otp_config = Data::new(settings.otp_config());
 
@@ -115,17 +134,25 @@ async fn main() -> AnyResult<()> {
 
     let oidc_clients = Data::new(Arc::new(oidc::build_clients(&settings).await?));
 
-    let blob_service = BlobServiceHandle::build(db.clone(), settings.blob_dir.clone());
-    let collection_service = CollectionServiceHandle::build(db.clone());
-    let song_service = SongServiceHandle::build(db.clone());
+    let team_resolver = Arc::new(SurrealTeamResolver::new(db.clone()));
+    let blob_service = BlobServiceHandle::build_with_team_resolver(
+        db.clone(),
+        settings.blob_dir.clone(),
+        team_resolver.clone(),
+    );
+    let collection_service =
+        CollectionServiceHandle::build_with_team_resolver(db.clone(), team_resolver.clone());
+    let song_service =
+        SongServiceHandle::build_with_team_resolver(db.clone(), team_resolver.clone());
     let setlist_service = SetlistService::new(
         SurrealSetlistRepo::new(db.clone()),
-        SurrealTeamResolver::new(db.clone()),
+        team_resolver.clone(),
         db.clone(),
     );
-    let team_service = TeamServiceHandle::build(db.clone());
+    let team_service =
+        TeamServiceHandle::build_with_team_resolver(db.clone(), team_resolver.clone());
+    let team_resolver_data = Data::new(team_resolver);
     let invitation_service = InvitationServiceHandle::build(db.clone());
-    let static_dir = settings.static_dir.clone();
     let db_data = Data::from(db);
 
     info!(
@@ -143,6 +170,7 @@ async fn main() -> AnyResult<()> {
             .app_data(Data::new(collection_service.clone()))
             .app_data(Data::new(song_service.clone()))
             .app_data(Data::new(setlist_service.clone()))
+            .app_data(team_resolver_data.clone())
             .app_data(Data::new(team_service.clone()))
             .app_data(Data::new(invitation_service.clone()))
             .app_data(Data::new(user_service.clone()))
@@ -150,7 +178,9 @@ async fn main() -> AnyResult<()> {
             .app_data(oidc_clients.clone())
             .app_data(cookie_config.clone())
             .app_data(otp_config.clone())
-            .wrap(Logger::default())
+            .wrap(Logger::new(
+                r#"%a "%r" %s %b "%{Referer}i" "%{User-Agent}i" %T"#,
+            ))
             .service(auth::rest::scope(
                 settings.auth_rate_limit_rps,
                 settings.auth_rate_limit_burst,

--- a/backend/src/request_id.rs
+++ b/backend/src/request_id.rs
@@ -9,6 +9,10 @@ use uuid::Uuid;
 
 static X_REQUEST_ID: HeaderName = HeaderName::from_static("x-request-id");
 
+/// Request path and query (`/api/v1/...?a=1`), stored for diagnostics (e.g. Problem Details `instance`).
+#[derive(Clone)]
+pub struct ApiRequestTarget(pub String);
+
 /// If `traceparent` is a valid W3C trace context value (`version-trace_id-span_id-flags`),
 /// returns the 16-hex-character **span id** segment (often aligned with OpenTelemetry span id).
 fn span_id_from_traceparent(traceparent: &str) -> Option<String> {
@@ -76,6 +80,12 @@ where
             .and_then(span_id_from_traceparent)
             .unwrap_or_else(|| Uuid::new_v4().to_string());
         req.extensions_mut().insert(id.clone());
+        let target = req
+            .uri()
+            .path_and_query()
+            .map(|pq| pq.to_string())
+            .unwrap_or_else(|| req.uri().path().to_string());
+        req.extensions_mut().insert(ApiRequestTarget(target));
 
         let service = Rc::clone(&self.service);
         Box::pin(async move {

--- a/backend/src/resources/blob/repository.rs
+++ b/backend/src/resources/blob/repository.rs
@@ -15,8 +15,12 @@ pub trait BlobRepository: Send + Sync {
         pagination: ListQuery,
     ) -> Result<Vec<Blob>, AppError>;
 
-    /// Count all blobs visible to `read_teams`.
-    async fn count_blobs(&self, read_teams: &[Thing]) -> Result<u64, AppError>;
+    /// Count blobs visible to `read_teams`, applying the same optional `q` OCR substring filter as [`get_blobs`](Self::get_blobs).
+    async fn count_blobs(
+        &self,
+        read_teams: &[Thing],
+        pagination: &ListQuery,
+    ) -> Result<u64, AppError>;
 
     async fn get_blob(&self, read_teams: &[Thing], id: &str) -> Result<Blob, AppError>;
 

--- a/backend/src/resources/blob/rest.rs
+++ b/backend/src/resources/blob/rest.rs
@@ -5,7 +5,7 @@ use actix_web::{
 };
 
 #[allow(unused_imports)]
-use crate::docs::ErrorResponse;
+use crate::docs::ProblemDetails;
 use crate::error::AppError;
 use crate::http_cache::{if_none_match_matches, weak_etag_json};
 use crate::resources::User;
@@ -37,14 +37,15 @@ pub fn scope(blob_upload_max_bytes: usize) -> Scope {
     get,
     path = "/api/v1/blobs",
     params(
-        ("page" = Option<u32>, Query, description = "Page index, zero-based. Defaults to 0."),
-        ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50.")
+        ("page" = Option<u32>, Query, description = "Zero-based page (default 0). Track A: `X-Total-Count` = pre-pagination total; last page when `items.len() < page_size` or empty. See `list-pagination.md`."),
+        ("page_size" = Option<u32>, Query, description = "Page size 1–500 (default 50)."),
+        ("q" = Option<String>, Query, description = "Optional case-insensitive substring filter on stored OCR text. Whitespace-only is treated as absent.")
     ),
     responses(
-        (status = 200, description = "Return all blobs. `X-Total-Count` header contains the total number of blobs.", body = [Blob]),
-        (status = 400, description = "Invalid pagination parameters", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 500, description = "Failed to fetch blobs", body = ErrorResponse)
+        (status = 200, description = "Return all blobs. `X-Total-Count` matches the filtered total.", body = [Blob]),
+        (status = 400, description = "Invalid pagination parameters", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 500, description = "Failed to fetch blobs", body = ProblemDetails)
     ),
     tag = "Blobs",
     security(
@@ -62,9 +63,9 @@ async fn get_blobs(
         .into_inner()
         .validate()
         .map_err(AppError::invalid_request)?;
-    let perms = UserPermissions::new(&user, &svc.teams);
-    let blobs = svc.list_blobs_for_user(&perms, query).await?;
-    let total = svc.count_blobs_for_user(&perms).await?;
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
+    let blobs = svc.list_blobs_for_user(&perms, query.clone()).await?;
+    let total = svc.count_blobs_for_user(&perms, &query).await?;
     Ok(HttpResponse::Ok()
         .insert_header((
             header::HeaderName::from_static("x-total-count"),
@@ -82,10 +83,10 @@ async fn get_blobs(
     responses(
         (status = 200, description = "Return a single blob (weak `ETag`; `If-None-Match` supported)", body = Blob),
         (status = 304, description = "Not modified"),
-        (status = 400, description = "Invalid blob identifier", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 404, description = "Blob not found", body = ErrorResponse),
-        (status = 500, description = "Failed to fetch blob", body = ErrorResponse)
+        (status = 400, description = "Invalid blob identifier", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 404, description = "Blob not found", body = ProblemDetails),
+        (status = 500, description = "Failed to fetch blob", body = ProblemDetails)
     ),
     tag = "Blobs",
     security(
@@ -100,7 +101,7 @@ async fn get_blob(
     user: ReqData<User>,
     id: PathParam<String>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     let blob = svc.get_blob_for_user(&perms, &id).await?;
     let etag = weak_etag_json(&blob).map_err(|e| AppError::Internal(e.to_string()))?;
     if if_none_match_matches(&req, &etag) {
@@ -119,9 +120,9 @@ async fn get_blob(
     request_body = CreateBlob,
     responses(
         (status = 201, description = "Create a new blob", body = Blob),
-        (status = 400, description = "Invalid blob payload", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 500, description = "Failed to create blob", body = ErrorResponse)
+        (status = 400, description = "Invalid blob payload", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 500, description = "Failed to create blob", body = ProblemDetails)
     ),
     tag = "Blobs",
     security(
@@ -135,7 +136,7 @@ async fn create_blob(
     user: ReqData<User>,
     payload: Json<CreateBlob>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     Ok(HttpResponse::Created().json(
         svc.create_blob_for_user(&perms, payload.into_inner())
             .await?,
@@ -151,10 +152,10 @@ async fn create_blob(
     request_body = CreateBlob,
     responses(
         (status = 200, description = "Update an existing blob", body = Blob),
-        (status = 400, description = "Invalid blob identifier", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 404, description = "Blob not found", body = ErrorResponse),
-        (status = 500, description = "Failed to update blob", body = ErrorResponse)
+        (status = 400, description = "Invalid blob identifier", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 404, description = "Blob not found", body = ProblemDetails),
+        (status = 500, description = "Failed to update blob", body = ProblemDetails)
     ),
     tag = "Blobs",
     security(
@@ -169,7 +170,7 @@ async fn update_blob(
     id: PathParam<String>,
     payload: Json<CreateBlob>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     Ok(HttpResponse::Ok().json(
         svc.update_blob_for_user(&perms, &id, payload.into_inner())
             .await?,
@@ -185,10 +186,10 @@ async fn update_blob(
     request_body = PatchBlob,
     responses(
         (status = 200, description = "Partially update an existing blob", body = Blob),
-        (status = 400, description = "Invalid blob identifier or payload", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 404, description = "Blob not found", body = ErrorResponse),
-        (status = 500, description = "Failed to patch blob", body = ErrorResponse)
+        (status = 400, description = "Invalid blob identifier or payload", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 404, description = "Blob not found", body = ProblemDetails),
+        (status = 500, description = "Failed to patch blob", body = ProblemDetails)
     ),
     tag = "Blobs",
     security(
@@ -203,7 +204,7 @@ async fn patch_blob(
     id: PathParam<String>,
     payload: Json<PatchBlob>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     Ok(HttpResponse::Ok().json(
         svc.patch_blob_for_user(&perms, &id, payload.into_inner())
             .await?,
@@ -218,10 +219,10 @@ async fn patch_blob(
     ),
     responses(
         (status = 204, description = "Blob deleted"),
-        (status = 400, description = "Invalid blob identifier", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 404, description = "Blob not found", body = ErrorResponse),
-        (status = 500, description = "Failed to delete blob", body = ErrorResponse)
+        (status = 400, description = "Invalid blob identifier", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 404, description = "Blob not found", body = ProblemDetails),
+        (status = 500, description = "Failed to delete blob", body = ProblemDetails)
     ),
     tag = "Blobs",
     security(
@@ -235,7 +236,7 @@ async fn delete_blob(
     user: ReqData<User>,
     id: PathParam<String>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     svc.delete_blob_for_user(&perms, &id).await?;
     Ok(HttpResponse::NoContent().finish())
 }
@@ -254,10 +255,10 @@ async fn delete_blob(
             content_type = "image/*",
             body = Vec<u8>
         ),
-        (status = 400, description = "Invalid blob identifier", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 404, description = "Blob not found", body = ErrorResponse),
-        (status = 500, description = "Failed to download blob", body = ErrorResponse)
+        (status = 400, description = "Invalid blob identifier", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 404, description = "Blob not found", body = ProblemDetails),
+        (status = 500, description = "Failed to download blob", body = ProblemDetails)
     ),
     tag = "Blobs",
     security(
@@ -272,7 +273,7 @@ async fn download_blob_image(
     user: ReqData<User>,
     id: PathParam<String>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     let id = id.into_inner();
     let (blob, file) = svc.open_blob_data_file_for_user(&perms, &id).await?;
     let filename = blob
@@ -307,11 +308,11 @@ async fn download_blob_image(
     ),
     responses(
         (status = 204, description = "Blob content uploaded successfully"),
-        (status = 400, description = "Invalid blob identifier", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 404, description = "Blob not found or write access denied", body = ErrorResponse),
-        (status = 413, description = "Payload too large", body = ErrorResponse),
-        (status = 500, description = "Failed to store blob content", body = ErrorResponse)
+        (status = 400, description = "Invalid blob identifier", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 404, description = "Blob not found or write access denied", body = ProblemDetails),
+        (status = 413, description = "Payload too large", body = ProblemDetails),
+        (status = 500, description = "Failed to store blob content", body = ProblemDetails)
     ),
     tag = "Blobs",
     security(
@@ -326,7 +327,7 @@ async fn upload_blob_data(
     id: PathParam<String>,
     body: Bytes,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     svc.upload_blob_data_for_user(&perms, &id, &body).await?;
     Ok(HttpResponse::NoContent().finish())
 }

--- a/backend/src/resources/blob/service.rs
+++ b/backend/src/resources/blob/service.rs
@@ -18,12 +18,12 @@ use super::surreal_repo::SurrealBlobRepo;
 #[derive(Clone)]
 pub struct BlobService<R, T, S> {
     pub repo: R,
-    pub teams: T,
+    pub teams: Arc<T>,
     pub storage: S,
 }
 
 impl<R, T, S> BlobService<R, T, S> {
-    pub fn new(repo: R, teams: T, storage: S) -> Self {
+    pub fn new(repo: R, teams: Arc<T>, storage: S) -> Self {
         Self {
             repo,
             teams,
@@ -35,7 +35,7 @@ impl<R, T, S> BlobService<R, T, S> {
 impl<R: BlobRepository, T: TeamResolver, S: BlobStorage> BlobService<R, T, S> {
     pub async fn list_blobs_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         pagination: ListQuery,
     ) -> Result<Vec<Blob>, AppError> {
         let read_teams = perms.read_teams().await?;
@@ -44,15 +44,16 @@ impl<R: BlobRepository, T: TeamResolver, S: BlobStorage> BlobService<R, T, S> {
 
     pub async fn count_blobs_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
+        pagination: &ListQuery,
     ) -> Result<u64, AppError> {
         let read_teams = perms.read_teams().await?;
-        self.repo.count_blobs(read_teams).await
+        self.repo.count_blobs(read_teams, pagination).await
     }
 
     pub async fn get_blob_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
     ) -> Result<Blob, AppError> {
         let read_teams = perms.read_teams().await?;
@@ -61,7 +62,7 @@ impl<R: BlobRepository, T: TeamResolver, S: BlobStorage> BlobService<R, T, S> {
 
     pub async fn create_blob_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         blob: CreateBlob,
     ) -> Result<Blob, AppError> {
         let created = self.repo.create_blob(&perms.user().id, blob).await?;
@@ -71,7 +72,7 @@ impl<R: BlobRepository, T: TeamResolver, S: BlobStorage> BlobService<R, T, S> {
 
     pub async fn update_blob_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
         blob: CreateBlob,
     ) -> Result<Blob, AppError> {
@@ -83,7 +84,7 @@ impl<R: BlobRepository, T: TeamResolver, S: BlobStorage> BlobService<R, T, S> {
 
     pub async fn patch_blob_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
         patch: PatchBlob,
     ) -> Result<Blob, AppError> {
@@ -99,7 +100,7 @@ impl<R: BlobRepository, T: TeamResolver, S: BlobStorage> BlobService<R, T, S> {
 
     pub async fn delete_blob_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
     ) -> Result<Blob, AppError> {
         let write_teams = perms.write_teams().await?;
@@ -110,7 +111,7 @@ impl<R: BlobRepository, T: TeamResolver, S: BlobStorage> BlobService<R, T, S> {
 
     pub async fn upload_blob_data_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
         data: &[u8],
     ) -> Result<(), AppError> {
@@ -127,7 +128,7 @@ impl<R: BlobRepository, T: TeamResolver, S: BlobStorage> BlobService<R, T, S> {
 
     pub async fn open_blob_data_file_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
     ) -> Result<(Blob, NamedFile), AppError> {
         let read_teams = perms.read_teams().await?;
@@ -143,9 +144,21 @@ pub type BlobServiceHandle =
 
 impl BlobServiceHandle {
     pub fn build(db: Arc<Database>, blob_dir: String) -> Self {
+        Self::build_with_team_resolver(
+            db.clone(),
+            blob_dir,
+            Arc::new(crate::resources::team::SurrealTeamResolver::new(db.clone())),
+        )
+    }
+
+    pub fn build_with_team_resolver(
+        db: Arc<Database>,
+        blob_dir: String,
+        teams: Arc<crate::resources::team::SurrealTeamResolver>,
+    ) -> Self {
         BlobService::new(
             SurrealBlobRepo::new(db.clone()),
-            crate::resources::team::SurrealTeamResolver::new(db.clone()),
+            teams,
             FsBlobStorage::new(blob_dir),
         )
     }
@@ -153,6 +166,8 @@ impl BlobServiceHandle {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use async_trait::async_trait;
     use surrealdb::sql::Thing;
 
@@ -181,7 +196,11 @@ mod tests {
             Ok(self.blobs.clone())
         }
 
-        async fn count_blobs(&self, _read_teams: &[Thing]) -> Result<u64, AppError> {
+        async fn count_blobs(
+            &self,
+            _read_teams: &[Thing],
+            _pagination: &ListQuery,
+        ) -> Result<u64, AppError> {
             Ok(self.blobs.len() as u64)
         }
 
@@ -260,8 +279,12 @@ mod tests {
     #[tokio::test]
     async fn get_returns_not_found_when_empty() {
         let user = test_user();
-        let svc = BlobService::new(MockBlobRepo { blobs: vec![] }, MockTeams, NullStorage);
-        let perms = UserPermissions::new(&user, &svc.teams);
+        let svc = BlobService::new(
+            MockBlobRepo { blobs: vec![] },
+            Arc::new(MockTeams),
+            NullStorage,
+        );
+        let perms = UserPermissions::from_ref(&user, &svc.teams);
         let r = svc.get_blob_for_user(&perms, "b1").await;
         assert!(matches!(r, Err(AppError::NotFound(_))));
     }
@@ -269,8 +292,12 @@ mod tests {
     #[tokio::test]
     async fn create_calls_storage_write() {
         let user = test_user();
-        let svc = BlobService::new(MockBlobRepo { blobs: vec![] }, MockTeams, NullStorage);
-        let perms = UserPermissions::new(&user, &svc.teams);
+        let svc = BlobService::new(
+            MockBlobRepo { blobs: vec![] },
+            Arc::new(MockTeams),
+            NullStorage,
+        );
+        let perms = UserPermissions::from_ref(&user, &svc.teams);
         let r = svc
             .create_blob_for_user(
                 &perms,
@@ -288,8 +315,12 @@ mod tests {
     #[tokio::test]
     async fn delete_not_found_propagates() {
         let user = test_user();
-        let svc = BlobService::new(MockBlobRepo { blobs: vec![] }, MockTeams, NullStorage);
-        let perms = UserPermissions::new(&user, &svc.teams);
+        let svc = BlobService::new(
+            MockBlobRepo { blobs: vec![] },
+            Arc::new(MockTeams),
+            NullStorage,
+        );
+        let perms = UserPermissions::from_ref(&user, &svc.teams);
         let r = svc.delete_blob_for_user(&perms, "missing").await;
         assert!(matches!(r, Err(AppError::NotFound(_))));
     }
@@ -318,8 +349,8 @@ mod tests {
         .await
         .expect("acl");
 
-        let owner_perms = UserPermissions::new(&owner, &svc.teams);
-        let other_perms = UserPermissions::new(&other, &svc.teams);
+        let owner_perms = UserPermissions::from_ref(&owner, &svc.teams);
+        let other_perms = UserPermissions::from_ref(&other, &svc.teams);
 
         let b = svc
             .create_blob_for_user(
@@ -402,8 +433,8 @@ mod tests {
         let (db, owner, _cm, _guest, non_member, _tid) = four_user_blob_fixture().await;
         let svc =
             crate::test_helpers::blob_service(&db, blob_dir.path().to_string_lossy().into_owned());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
-        let nm_p = UserPermissions::new(&non_member, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
+        let nm_p = UserPermissions::from_ref(&non_member, &svc.teams);
         let b = svc
             .create_blob_for_user(
                 &owner_p,
@@ -427,8 +458,8 @@ mod tests {
         let (db, owner, cm, _guest, _nm, _tid) = four_user_blob_fixture().await;
         let svc =
             crate::test_helpers::blob_service(&db, blob_dir.path().to_string_lossy().into_owned());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
-        let cm_p = UserPermissions::new(&cm, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
+        let cm_p = UserPermissions::from_ref(&cm, &svc.teams);
         let b = svc
             .create_blob_for_user(
                 &owner_p,
@@ -462,8 +493,8 @@ mod tests {
         let (db, owner, _cm, guest, _nm, _tid) = four_user_blob_fixture().await;
         let svc =
             crate::test_helpers::blob_service(&db, blob_dir.path().to_string_lossy().into_owned());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
-        let guest_p = UserPermissions::new(&guest, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
+        let guest_p = UserPermissions::from_ref(&guest, &svc.teams);
         let b = svc
             .create_blob_for_user(
                 &owner_p,
@@ -498,8 +529,8 @@ mod tests {
         let (db, owner, _cm, guest, _nm, _tid) = four_user_blob_fixture().await;
         let svc =
             crate::test_helpers::blob_service(&db, blob_dir.path().to_string_lossy().into_owned());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
-        let guest_p = UserPermissions::new(&guest, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
+        let guest_p = UserPermissions::from_ref(&guest, &svc.teams);
         let b = svc
             .create_blob_for_user(
                 &owner_p,
@@ -523,7 +554,7 @@ mod tests {
         let (db, owner, _cm, _guest, _nm, _tid) = four_user_blob_fixture().await;
         let svc =
             crate::test_helpers::blob_service(&db, blob_dir.path().to_string_lossy().into_owned());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
         let b = svc
             .create_blob_for_user(
                 &owner_p,
@@ -557,7 +588,7 @@ mod tests {
         let (db, owner, _cm, _guest, _nm, tid) = four_user_blob_fixture().await;
         let svc =
             crate::test_helpers::blob_service(&db, blob_dir.path().to_string_lossy().into_owned());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
         let b = svc
             .create_blob_for_user(
                 &owner_p,
@@ -594,7 +625,7 @@ mod tests {
         let (db, owner, _cm, _guest, _nm, _tid) = four_user_blob_fixture().await;
         let svc =
             crate::test_helpers::blob_service(&db, blob_dir.path().to_string_lossy().into_owned());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
         let b = svc
             .create_blob_for_user(
                 &owner_p,
@@ -617,7 +648,7 @@ mod tests {
         let (db, owner, _cm, _guest, _nm, _tid) = four_user_blob_fixture().await;
         let svc =
             crate::test_helpers::blob_service(&db, blob_dir.path().to_string_lossy().into_owned());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
         let b = svc
             .create_blob_for_user(
                 &owner_p,
@@ -640,7 +671,7 @@ mod tests {
         let (db, owner, _cm, _guest, _nm, _tid) = four_user_blob_fixture().await;
         let svc =
             crate::test_helpers::blob_service(&db, blob_dir.path().to_string_lossy().into_owned());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
         let b = svc
             .create_blob_for_user(
                 &owner_p,
@@ -664,8 +695,8 @@ mod tests {
         let (db, owner, _cm, _guest, non_member, _tid) = four_user_blob_fixture().await;
         let svc =
             crate::test_helpers::blob_service(&db, blob_dir.path().to_string_lossy().into_owned());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
-        let nm_p = UserPermissions::new(&non_member, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
+        let nm_p = UserPermissions::from_ref(&non_member, &svc.teams);
         let b = svc
             .create_blob_for_user(
                 &owner_p,
@@ -710,7 +741,7 @@ mod tests {
             .await
             .expect("acl");
 
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
         let blob = svc
             .create_blob_for_user(
                 &owner_p,
@@ -753,8 +784,12 @@ mod tests {
         use shared::blob::PatchBlob;
 
         let user = test_user();
-        let svc = BlobService::new(MockBlobRepo { blobs: vec![] }, MockTeams, NullStorage);
-        let perms = UserPermissions::new(&user, &svc.teams);
+        let svc = BlobService::new(
+            MockBlobRepo { blobs: vec![] },
+            Arc::new(MockTeams),
+            NullStorage,
+        );
+        let perms = UserPermissions::from_ref(&user, &svc.teams);
         let r = svc
             .patch_blob_for_user(
                 &perms,
@@ -781,7 +816,7 @@ mod tests {
         let owner = create_user(&db, "blob-patch-combos@test.local")
             .await
             .expect("owner");
-        let perms = UserPermissions::new(&owner, &svc.teams);
+        let perms = UserPermissions::from_ref(&owner, &svc.teams);
 
         for mask in 0u8..16 {
             let include_file_type = (mask & 0b0001) != 0;

--- a/backend/src/resources/blob/surreal_repo.rs
+++ b/backend/src/resources/blob/surreal_repo.rs
@@ -31,6 +31,17 @@ impl SurrealBlobRepo {
     }
 }
 
+fn blob_list_q_needle(q: &ListQuery) -> Option<String> {
+    q.q.as_ref().and_then(|s| {
+        let t = s.trim();
+        if t.is_empty() {
+            None
+        } else {
+            Some(t.to_lowercase())
+        }
+    })
+}
+
 #[async_trait]
 impl BlobRepository for SurrealBlobRepo {
     async fn get_blobs(
@@ -40,17 +51,29 @@ impl BlobRepository for SurrealBlobRepo {
     ) -> Result<Vec<Blob>, AppError> {
         let db = self.inner();
         let (offset, limit) = pagination.effective_offset_limit();
-        let query =
-            String::from("SELECT * FROM blob WHERE owner IN $teams LIMIT $limit START $start");
+        let needle = blob_list_q_needle(&pagination);
 
-        let mut response = db
-            .db
-            .query(query)
-            .bind(("teams", read_teams.to_vec()))
-            .bind(("limit", limit))
-            .bind(("start", offset))
-            .await
-            .map_err(AppError::database)?;
+        let mut response = if let Some(needle) = needle {
+            db.db
+                .query(
+                    "SELECT * FROM blob WHERE owner IN $teams AND \
+                     string::contains(string::lowercase(ocr), $needle) LIMIT $limit START $start",
+                )
+                .bind(("teams", read_teams.to_vec()))
+                .bind(("needle", needle))
+                .bind(("limit", limit))
+                .bind(("start", offset))
+                .await
+                .map_err(AppError::database)?
+        } else {
+            db.db
+                .query("SELECT * FROM blob WHERE owner IN $teams LIMIT $limit START $start")
+                .bind(("teams", read_teams.to_vec()))
+                .bind(("limit", limit))
+                .bind(("start", offset))
+                .await
+                .map_err(AppError::database)?
+        };
 
         Ok(response
             .take::<Vec<BlobRecord>>(0)?
@@ -59,17 +82,33 @@ impl BlobRepository for SurrealBlobRepo {
             .collect())
     }
 
-    async fn count_blobs(&self, read_teams: &[Thing]) -> Result<u64, AppError> {
+    async fn count_blobs(
+        &self,
+        read_teams: &[Thing],
+        pagination: &ListQuery,
+    ) -> Result<u64, AppError> {
         #[derive(Deserialize)]
         struct CountResult {
             count: u64,
         }
-        let mut response = self
-            .inner()
-            .db
-            .query("SELECT count() FROM blob WHERE owner IN $teams GROUP ALL")
-            .bind(("teams", read_teams.to_vec()))
-            .await?;
+        let needle = blob_list_q_needle(pagination);
+        let mut response = if let Some(needle) = needle {
+            self.inner()
+                .db
+                .query(
+                    "SELECT count() FROM blob WHERE owner IN $teams AND \
+                     string::contains(string::lowercase(ocr), $needle) GROUP ALL",
+                )
+                .bind(("teams", read_teams.to_vec()))
+                .bind(("needle", needle))
+                .await?
+        } else {
+            self.inner()
+                .db
+                .query("SELECT count() FROM blob WHERE owner IN $teams GROUP ALL")
+                .bind(("teams", read_teams.to_vec()))
+                .await?
+        };
         Ok(response
             .take::<Vec<CountResult>>(0)?
             .into_iter()

--- a/backend/src/resources/collection/rest.rs
+++ b/backend/src/resources/collection/rest.rs
@@ -6,7 +6,7 @@ use actix_web::{
 
 use crate::accept::accepts_worship_player_json;
 #[allow(unused_imports)]
-use crate::docs::{ErrorResponse, ProblemDetails};
+use crate::docs::ProblemDetails;
 use crate::error::AppError;
 use crate::http_cache::{if_none_match_matches, weak_etag_json};
 use crate::resources::User;
@@ -38,15 +38,15 @@ pub fn scope() -> Scope {
     get,
     path = "/api/v1/collections",
     params(
-        ("page" = Option<u32>, Query, description = "Page index, zero-based. Defaults to 0."),
-        ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50."),
+        ("page" = Option<u32>, Query, description = "Zero-based page (default 0). `X-Total-Count` = filtered total before pagination; last page when `items.len() < page_size` or empty (`list-pagination.md`)."),
+        ("page_size" = Option<u32>, Query, description = "Page size 1–500 (default 50)."),
         ("q" = Option<String>, Query, description = "Full-text search query (title); uses text_search analyzer (stemming)")
     ),
     responses(
         (status = 200, description = "Return all collections. `X-Total-Count` header contains the total number of matching collections.", body = [Collection]),
-        (status = 400, description = "Invalid pagination parameters", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 500, description = "Failed to fetch collections", body = ErrorResponse)
+        (status = 400, description = "Invalid pagination parameters", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 500, description = "Failed to fetch collections", body = ProblemDetails)
     ),
     tag = "Collections",
     security(
@@ -64,7 +64,7 @@ async fn get_collections(
         .into_inner()
         .validate()
         .map_err(AppError::invalid_request)?;
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     let q_ref = query.q.clone();
     let collections = svc.list_collections_for_user(&perms, query).await?;
     let total = svc
@@ -87,10 +87,10 @@ async fn get_collections(
     responses(
         (status = 200, description = "Return a single collection (weak `ETag`; `If-None-Match` supported)", body = Collection),
         (status = 304, description = "Not modified"),
-        (status = 400, description = "Invalid collection identifier", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 404, description = "Collection not found", body = ErrorResponse),
-        (status = 500, description = "Failed to fetch collection", body = ErrorResponse)
+        (status = 400, description = "Invalid collection identifier", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 404, description = "Collection not found", body = ProblemDetails),
+        (status = 500, description = "Failed to fetch collection", body = ProblemDetails)
     ),
     tag = "Collections",
     security(
@@ -105,7 +105,7 @@ async fn get_collection(
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     let collection = svc.get_collection_for_user(&perms, &id).await?;
     let etag = weak_etag_json(&collection).map_err(|e| AppError::Internal(e.to_string()))?;
     if if_none_match_matches(&req, &etag) {
@@ -150,7 +150,7 @@ async fn get_collection_player(
             "supported Accept values include application/json, application/vnd.worship.player+json, and */*",
         ));
     }
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     Ok(HttpResponse::Ok().json(svc.collection_player_for_user(&perms, &id).await?))
 }
 
@@ -165,10 +165,10 @@ async fn get_collection_player(
     ),
     responses(
         (status = 200, description = "Return the songs for a collection. `X-Total-Count` is the total before paging.", body = [Song]),
-        (status = 400, description = "Invalid collection identifier or pagination", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 404, description = "Collection not found", body = ErrorResponse),
-        (status = 500, description = "Failed to fetch collection songs", body = ErrorResponse)
+        (status = 400, description = "Invalid collection identifier or pagination", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 404, description = "Collection not found", body = ProblemDetails),
+        (status = 500, description = "Failed to fetch collection songs", body = ProblemDetails)
     ),
     tag = "Collections",
     security(
@@ -187,7 +187,7 @@ async fn get_collection_songs(
         .into_inner()
         .validate()
         .map_err(AppError::invalid_request)?;
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     let (songs, total) = svc.collection_songs_for_user(&perms, &id, query).await?;
     Ok(HttpResponse::Ok()
         .insert_header((
@@ -203,9 +203,9 @@ async fn get_collection_songs(
     request_body = CreateCollection,
     responses(
         (status = 201, description = "Create a new collection", body = Collection),
-        (status = 400, description = "Invalid collection payload", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 500, description = "Failed to create collection", body = ErrorResponse)
+        (status = 400, description = "Invalid collection payload", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 500, description = "Failed to create collection", body = ProblemDetails)
     ),
     tag = "Collections",
     security(
@@ -219,7 +219,7 @@ async fn create_collection(
     user: ReqData<User>,
     payload: Json<CreateCollection>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     Ok(HttpResponse::Created().json(
         svc.create_collection_for_user(&perms, payload.into_inner())
             .await?,
@@ -235,10 +235,10 @@ async fn create_collection(
     request_body = CreateCollection,
     responses(
         (status = 200, description = "Update an existing collection", body = Collection),
-        (status = 400, description = "Invalid collection identifier", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 404, description = "Collection not found", body = ErrorResponse),
-        (status = 500, description = "Failed to update collection", body = ErrorResponse)
+        (status = 400, description = "Invalid collection identifier", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 404, description = "Collection not found", body = ProblemDetails),
+        (status = 500, description = "Failed to update collection", body = ProblemDetails)
     ),
     tag = "Collections",
     security(
@@ -253,7 +253,7 @@ async fn update_collection(
     id: Path<String>,
     payload: Json<CreateCollection>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     Ok(HttpResponse::Ok().json(
         svc.update_collection_for_user(&perms, &id, payload.into_inner())
             .await?,
@@ -269,10 +269,10 @@ async fn update_collection(
     request_body = PatchCollection,
     responses(
         (status = 200, description = "Partially update an existing collection", body = Collection),
-        (status = 400, description = "Invalid collection identifier or payload", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 404, description = "Collection not found", body = ErrorResponse),
-        (status = 500, description = "Failed to patch collection", body = ErrorResponse)
+        (status = 400, description = "Invalid collection identifier or payload", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 404, description = "Collection not found", body = ProblemDetails),
+        (status = 500, description = "Failed to patch collection", body = ProblemDetails)
     ),
     tag = "Collections",
     security(
@@ -287,7 +287,7 @@ async fn patch_collection(
     id: Path<String>,
     payload: Json<PatchCollection>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     Ok(HttpResponse::Ok().json(
         svc.patch_collection_for_user(&perms, &id, payload.into_inner())
             .await?,
@@ -302,10 +302,10 @@ async fn patch_collection(
     ),
     responses(
         (status = 204, description = "Collection deleted"),
-        (status = 400, description = "Invalid collection identifier", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 404, description = "Collection not found", body = ErrorResponse),
-        (status = 500, description = "Failed to delete collection", body = ErrorResponse)
+        (status = 400, description = "Invalid collection identifier", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 404, description = "Collection not found", body = ProblemDetails),
+        (status = 500, description = "Failed to delete collection", body = ProblemDetails)
     ),
     tag = "Collections",
     security(
@@ -319,7 +319,7 @@ async fn delete_collection(
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     svc.delete_collection_for_user(&perms, &id).await?;
     Ok(HttpResponse::NoContent().finish())
 }

--- a/backend/src/resources/collection/service.rs
+++ b/backend/src/resources/collection/service.rs
@@ -18,12 +18,12 @@ use super::surreal_repo::SurrealCollectionRepo;
 #[derive(Clone)]
 pub struct CollectionService<R, T, L> {
     pub repo: R,
-    pub teams: T,
+    pub teams: Arc<T>,
     pub likes: L,
 }
 
 impl<R, T, L> CollectionService<R, T, L> {
-    pub fn new(repo: R, teams: T, likes: L) -> Self {
+    pub fn new(repo: R, teams: Arc<T>, likes: L) -> Self {
         Self { repo, teams, likes }
     }
 }
@@ -31,7 +31,7 @@ impl<R, T, L> CollectionService<R, T, L> {
 impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionService<R, T, L> {
     pub async fn list_collections_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         pagination: ListQuery,
     ) -> Result<Vec<Collection>, AppError> {
         let read_teams = perms.read_teams().await?;
@@ -40,7 +40,7 @@ impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionServic
 
     pub async fn count_collections_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         q: Option<&str>,
     ) -> Result<u64, AppError> {
         let read_teams = perms.read_teams().await?;
@@ -49,7 +49,7 @@ impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionServic
 
     pub async fn get_collection_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
     ) -> Result<Collection, AppError> {
         let read_teams = perms.read_teams().await?;
@@ -58,7 +58,7 @@ impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionServic
 
     pub async fn collection_player_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
     ) -> Result<Player, AppError> {
         let user_id = perms.user().id.clone();
@@ -70,7 +70,7 @@ impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionServic
 
     pub async fn collection_songs_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
         pagination: ListQuery,
     ) -> Result<(Vec<Song>, u64), AppError> {
@@ -95,7 +95,7 @@ impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionServic
 
     pub async fn create_collection_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         collection: CreateCollection,
     ) -> Result<Collection, AppError> {
         self.repo
@@ -105,7 +105,7 @@ impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionServic
 
     pub async fn update_collection_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
         collection: CreateCollection,
     ) -> Result<Collection, AppError> {
@@ -117,7 +117,7 @@ impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionServic
 
     pub async fn patch_collection_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
         patch: PatchCollection,
     ) -> Result<Collection, AppError> {
@@ -132,7 +132,7 @@ impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionServic
 
     pub async fn delete_collection_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
     ) -> Result<Collection, AppError> {
         let write_teams = perms.write_teams().await?;
@@ -149,11 +149,17 @@ pub type CollectionServiceHandle = CollectionService<
 
 impl CollectionServiceHandle {
     pub fn build(db: Arc<Database>) -> Self {
-        CollectionService::new(
-            SurrealCollectionRepo::new(db.clone()),
-            crate::resources::team::SurrealTeamResolver::new(db.clone()),
+        Self::build_with_team_resolver(
             db.clone(),
+            Arc::new(crate::resources::team::SurrealTeamResolver::new(db.clone())),
         )
+    }
+
+    pub fn build_with_team_resolver(
+        db: Arc<Database>,
+        teams: Arc<crate::resources::team::SurrealTeamResolver>,
+    ) -> Self {
+        CollectionService::new(SurrealCollectionRepo::new(db.clone()), teams, db.clone())
     }
 }
 
@@ -194,8 +200,8 @@ mod tests {
             .await
             .expect("song");
 
-        let owner_perms = UserPermissions::new(&owner, &svc.teams);
-        let guest_perms = UserPermissions::new(&guest, &svc.teams);
+        let owner_perms = UserPermissions::from_ref(&owner, &svc.teams);
+        let guest_perms = UserPermissions::from_ref(&guest, &svc.teams);
 
         let col = svc
             .create_collection_for_user(
@@ -311,8 +317,8 @@ mod tests {
     async fn blc_coll_002_non_member_read_not_found() {
         let (db, owner, _cm, _guest, nm, _tid) = four_user_coll_fixture().await;
         let svc = CollectionServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
-        let nm_p = UserPermissions::new(&nm, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
+        let nm_p = UserPermissions::from_ref(&nm, &svc.teams);
         let col = svc
             .create_collection_for_user(&owner_p, make_collection("NMTest"))
             .await
@@ -326,8 +332,8 @@ mod tests {
     async fn blc_coll_002_guest_can_read() {
         let (db, owner, _cm, guest, _nm, _tid) = four_user_coll_fixture().await;
         let svc = CollectionServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
-        let guest_p = UserPermissions::new(&guest, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
+        let guest_p = UserPermissions::from_ref(&guest, &svc.teams);
         let col = svc
             .create_collection_for_user(&owner_p, make_collection("GuestTest"))
             .await
@@ -342,8 +348,8 @@ mod tests {
     async fn blc_coll_002_content_maintainer_can_update() {
         let (db, owner, cm, _guest, _nm, _tid) = four_user_coll_fixture().await;
         let svc = CollectionServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
-        let cm_p = UserPermissions::new(&cm, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
+        let cm_p = UserPermissions::from_ref(&cm, &svc.teams);
         let col = svc
             .create_collection_for_user(&owner_p, make_collection("CMTest"))
             .await
@@ -358,7 +364,7 @@ mod tests {
     async fn blc_coll_007_guest_cannot_create() {
         let (db, _owner, _cm, guest, _nm, _tid) = four_user_coll_fixture().await;
         let svc = CollectionServiceHandle::build(db.clone());
-        let guest_p = UserPermissions::new(&guest, &svc.teams);
+        let guest_p = UserPermissions::from_ref(&guest, &svc.teams);
         // The collection would be owned by the guest's personal team, which the guest can write.
         // But test: guest on owner's team cannot write to owner's collections.
         // Actually, create always goes to caller's personal team, so guest creates on their own
@@ -367,7 +373,7 @@ mod tests {
         let owner_2 = crate::test_helpers::create_user(&db, "c3g-owner2@test.local")
             .await
             .expect("o2");
-        let owner2_p = UserPermissions::new(&owner_2, &svc.teams);
+        let owner2_p = UserPermissions::from_ref(&owner_2, &svc.teams);
         let col = svc
             .create_collection_for_user(&owner2_p, make_collection("O2Coll"))
             .await
@@ -383,8 +389,8 @@ mod tests {
     async fn blc_coll_007_guest_cannot_delete() {
         let (db, owner, _cm, guest, _nm, _tid) = four_user_coll_fixture().await;
         let svc = CollectionServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
-        let guest_p = UserPermissions::new(&guest, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
+        let guest_p = UserPermissions::from_ref(&guest, &svc.teams);
         let col = svc
             .create_collection_for_user(&owner_p, make_collection("GuestDel"))
             .await
@@ -398,7 +404,7 @@ mod tests {
     async fn blc_coll_003_put_does_not_change_owner() {
         let (db, owner, _cm, _guest, _nm, tid) = four_user_coll_fixture().await;
         let svc = CollectionServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
         let col = svc
             .create_collection_for_user(&owner_p, make_collection("OwnerTest"))
             .await
@@ -416,7 +422,7 @@ mod tests {
     async fn blc_coll_004_post_accepts_nonexistent_song_ids() {
         let (db, owner, _cm, _guest, _nm, _tid) = four_user_coll_fixture().await;
         let svc = CollectionServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
         let col = svc
             .create_collection_for_user(
                 &owner_p,
@@ -440,7 +446,7 @@ mod tests {
     async fn blc_coll_005_list_with_q_filter() {
         let (db, owner, _cm, _guest, _nm, _tid) = four_user_coll_fixture().await;
         let svc = CollectionServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
         svc.create_collection_for_user(&owner_p, make_collection("Hallelujah"))
             .await
             .expect("c1");
@@ -460,7 +466,7 @@ mod tests {
     async fn blc_coll_005_list_pagination() {
         let (db, owner, _cm, _guest, _nm, _tid) = four_user_coll_fixture().await;
         let svc = CollectionServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
         for i in 0..3u32 {
             svc.create_collection_for_user(&owner_p, make_collection(&format!("Coll{i}")))
                 .await
@@ -490,7 +496,7 @@ mod tests {
         use crate::test_helpers::create_song_with_title;
         let (db, owner, _cm, _guest, _nm, _tid) = four_user_coll_fixture().await;
         let svc = CollectionServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
         let song = create_song_with_title(&db, &owner, "CollSongSub")
             .await
             .expect("song");
@@ -522,7 +528,7 @@ mod tests {
         use shared::collection::PatchCollection;
         let (db, owner, _cm, _guest, _nm, _tid) = four_user_coll_fixture().await;
         let svc = CollectionServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
 
         let col = svc
             .create_collection_for_user(&owner_p, make_collection("Old Title"))
@@ -557,7 +563,7 @@ mod tests {
         use shared::collection::PatchCollection;
         let (db, owner, _cm, _guest, _nm, _tid) = four_user_coll_fixture().await;
         let svc = CollectionServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
 
         let col = svc
             .create_collection_for_user(&owner_p, make_collection("Title"))
@@ -587,7 +593,7 @@ mod tests {
         use shared::collection::PatchCollection;
         let (db, owner, _cm, _guest, _nm, _tid) = four_user_coll_fixture().await;
         let svc = CollectionServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
         let r = svc
             .patch_collection_for_user(
                 &owner_p,
@@ -608,7 +614,7 @@ mod tests {
 
         let (db, owner, _cm, _guest, _nm, _tid) = four_user_coll_fixture().await;
         let svc = CollectionServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
         let s1 = create_song_with_title(&db, &owner, "Song One")
             .await
             .expect("s1");
@@ -688,8 +694,8 @@ mod tests {
     async fn blc_coll_011_songs_sub_route_unauthorized() {
         let (db, owner, _cm, _guest, nm, _tid) = four_user_coll_fixture().await;
         let svc = CollectionServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
-        let nm_p = UserPermissions::new(&nm, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
+        let nm_p = UserPermissions::from_ref(&nm, &svc.teams);
         let col = svc
             .create_collection_for_user(&owner_p, make_collection("SecretColl"))
             .await

--- a/backend/src/resources/setlist/model.rs
+++ b/backend/src/resources/setlist/model.rs
@@ -102,11 +102,11 @@ mod tests {
         let db = test_db().await.expect("test db");
         let svc = SetlistService::new(
             SurrealSetlistRepo::new(db.clone()),
-            SurrealTeamResolver::new(db.clone()),
+            std::sync::Arc::new(SurrealTeamResolver::new(db.clone())),
             db.clone(),
         );
         let user = seed_user(&db).await.expect("seed user");
-        let perms = UserPermissions::new(&user, &svc.teams);
+        let perms = UserPermissions::from_ref(&user, &svc.teams);
         let created = svc
             .create_setlist_for_user(
                 &perms,

--- a/backend/src/resources/setlist/rest.rs
+++ b/backend/src/resources/setlist/rest.rs
@@ -6,7 +6,7 @@ use actix_web::{
 
 use crate::accept::accepts_worship_player_json;
 #[allow(unused_imports)]
-use crate::docs::{ErrorResponse, ProblemDetails};
+use crate::docs::ProblemDetails;
 use crate::error::AppError;
 use crate::http_cache::{if_none_match_matches, weak_etag_json};
 use crate::resources::User;
@@ -38,15 +38,15 @@ pub fn scope() -> Scope {
     get,
     path = "/api/v1/setlists",
     params(
-        ("page" = Option<u32>, Query, description = "Page index, zero-based. Defaults to 0."),
-        ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50."),
+        ("page" = Option<u32>, Query, description = "Zero-based page (default 0). `X-Total-Count` = filtered total before pagination; last page when `items.len() < page_size` or empty (`list-pagination.md`)."),
+        ("page_size" = Option<u32>, Query, description = "Page size 1–500 (default 50)."),
         ("q" = Option<String>, Query, description = "Full-text search query (title); uses text_search analyzer (stemming)")
     ),
     responses(
         (status = 200, description = "Return all setlists. `X-Total-Count` header contains the total number of matching setlists.", body = [Setlist]),
-        (status = 400, description = "Invalid pagination parameters", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 500, description = "Failed to fetch setlists", body = ErrorResponse)
+        (status = 400, description = "Invalid pagination parameters", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 500, description = "Failed to fetch setlists", body = ProblemDetails)
     ),
     tag = "Setlists",
     security(
@@ -64,7 +64,7 @@ async fn get_setlists(
         .into_inner()
         .validate()
         .map_err(AppError::invalid_request)?;
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     let q_ref = query.q.clone();
     let setlists = svc.list_setlists_for_user(&perms, query).await?;
     let total = svc
@@ -87,10 +87,10 @@ async fn get_setlists(
     responses(
         (status = 200, description = "Return a single setlist (weak `ETag`; `If-None-Match` supported)", body = Setlist),
         (status = 304, description = "Not modified"),
-        (status = 400, description = "Invalid setlist identifier", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 404, description = "Setlist not found", body = ErrorResponse),
-        (status = 500, description = "Failed to fetch setlist", body = ErrorResponse)
+        (status = 400, description = "Invalid setlist identifier", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 404, description = "Setlist not found", body = ProblemDetails),
+        (status = 500, description = "Failed to fetch setlist", body = ProblemDetails)
     ),
     tag = "Setlists",
     security(
@@ -105,7 +105,7 @@ async fn get_setlist(
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     let setlist = svc.get_setlist_for_user(&perms, &id).await?;
     let etag = weak_etag_json(&setlist).map_err(|e| AppError::Internal(e.to_string()))?;
     if if_none_match_matches(&req, &etag) {
@@ -150,7 +150,7 @@ async fn get_setlist_player(
             "supported Accept values include application/json, application/vnd.worship.player+json, and */*",
         ));
     }
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     Ok(HttpResponse::Ok().json(svc.setlist_player_for_user(&perms, &id).await?))
 }
 
@@ -165,10 +165,10 @@ async fn get_setlist_player(
     ),
     responses(
         (status = 200, description = "Return the songs for a setlist. `X-Total-Count` is the total before paging.", body = [Song]),
-        (status = 400, description = "Invalid setlist identifier or pagination", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 404, description = "Setlist not found", body = ErrorResponse),
-        (status = 500, description = "Failed to fetch setlist songs", body = ErrorResponse)
+        (status = 400, description = "Invalid setlist identifier or pagination", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 404, description = "Setlist not found", body = ProblemDetails),
+        (status = 500, description = "Failed to fetch setlist songs", body = ProblemDetails)
     ),
     tag = "Setlists",
     security(
@@ -187,7 +187,7 @@ async fn get_setlist_songs(
         .into_inner()
         .validate()
         .map_err(AppError::invalid_request)?;
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     let (songs, total) = svc.setlist_songs_for_user(&perms, &id, query).await?;
     Ok(HttpResponse::Ok()
         .insert_header((
@@ -203,9 +203,9 @@ async fn get_setlist_songs(
     request_body = CreateSetlist,
     responses(
         (status = 201, description = "Create a new setlist", body = Setlist),
-        (status = 400, description = "Invalid setlist payload", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 500, description = "Failed to create setlist", body = ErrorResponse)
+        (status = 400, description = "Invalid setlist payload", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 500, description = "Failed to create setlist", body = ProblemDetails)
     ),
     tag = "Setlists",
     security(
@@ -219,7 +219,7 @@ async fn create_setlist(
     user: ReqData<User>,
     payload: Json<CreateSetlist>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     Ok(HttpResponse::Created().json(
         svc.create_setlist_for_user(&perms, payload.into_inner())
             .await?,
@@ -235,9 +235,10 @@ async fn create_setlist(
     request_body = CreateSetlist,
     responses(
         (status = 200, description = "Update an existing setlist", body = Setlist),
-        (status = 400, description = "Invalid setlist identifier", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 500, description = "Failed to update setlist", body = ErrorResponse)
+        (status = 400, description = "Invalid setlist identifier", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 404, description = "Setlist not found", body = ProblemDetails),
+        (status = 500, description = "Failed to update setlist", body = ProblemDetails)
     ),
     tag = "Setlists",
     security(
@@ -252,7 +253,7 @@ async fn update_setlist(
     id: Path<String>,
     payload: Json<CreateSetlist>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     Ok(HttpResponse::Ok().json(
         svc.update_setlist_for_user(&perms, &id, payload.into_inner())
             .await?,
@@ -268,10 +269,10 @@ async fn update_setlist(
     request_body = PatchSetlist,
     responses(
         (status = 200, description = "Partially update an existing setlist", body = Setlist),
-        (status = 400, description = "Invalid setlist identifier or payload", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 404, description = "Setlist not found", body = ErrorResponse),
-        (status = 500, description = "Failed to patch setlist", body = ErrorResponse)
+        (status = 400, description = "Invalid setlist identifier or payload", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 404, description = "Setlist not found", body = ProblemDetails),
+        (status = 500, description = "Failed to patch setlist", body = ProblemDetails)
     ),
     tag = "Setlists",
     security(
@@ -286,7 +287,7 @@ async fn patch_setlist(
     id: Path<String>,
     payload: Json<PatchSetlist>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     Ok(HttpResponse::Ok().json(
         svc.patch_setlist_for_user(&perms, &id, payload.into_inner())
             .await?,
@@ -301,10 +302,10 @@ async fn patch_setlist(
     ),
     responses(
         (status = 204, description = "Setlist deleted"),
-        (status = 400, description = "Invalid setlist identifier", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 404, description = "Setlist not found", body = ErrorResponse),
-        (status = 500, description = "Failed to delete setlist", body = ErrorResponse)
+        (status = 400, description = "Invalid setlist identifier", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 404, description = "Setlist not found", body = ProblemDetails),
+        (status = 500, description = "Failed to delete setlist", body = ProblemDetails)
     ),
     tag = "Setlists",
     security(
@@ -318,7 +319,7 @@ async fn delete_setlist(
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     svc.delete_setlist_for_user(&perms, &id).await?;
     Ok(HttpResponse::NoContent().finish())
 }

--- a/backend/src/resources/setlist/service.rs
+++ b/backend/src/resources/setlist/service.rs
@@ -16,12 +16,12 @@ use crate::resources::common::player_from_song_links;
 #[derive(Clone)]
 pub struct SetlistService<R, T, L> {
     pub repo: R,
-    pub teams: T,
+    pub teams: Arc<T>,
     pub likes: L,
 }
 
 impl<R, T, L> SetlistService<R, T, L> {
-    pub fn new(repo: R, teams: T, likes: L) -> Self {
+    pub fn new(repo: R, teams: Arc<T>, likes: L) -> Self {
         Self { repo, teams, likes }
     }
 }
@@ -29,7 +29,7 @@ impl<R, T, L> SetlistService<R, T, L> {
 impl<R: SetlistRepository, T: TeamResolver, L: LikedSongIds> SetlistService<R, T, L> {
     pub async fn list_setlists_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         pagination: ListQuery,
     ) -> Result<Vec<Setlist>, AppError> {
         let read_teams = perms.read_teams().await?;
@@ -38,7 +38,7 @@ impl<R: SetlistRepository, T: TeamResolver, L: LikedSongIds> SetlistService<R, T
 
     pub async fn count_setlists_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         q: Option<&str>,
     ) -> Result<u64, AppError> {
         let read_teams = perms.read_teams().await?;
@@ -47,7 +47,7 @@ impl<R: SetlistRepository, T: TeamResolver, L: LikedSongIds> SetlistService<R, T
 
     pub async fn get_setlist_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
     ) -> Result<Setlist, AppError> {
         let read_teams = perms.read_teams().await?;
@@ -56,7 +56,7 @@ impl<R: SetlistRepository, T: TeamResolver, L: LikedSongIds> SetlistService<R, T
 
     pub async fn setlist_player_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
     ) -> Result<Player, AppError> {
         let user_id = perms.user().id.clone();
@@ -68,7 +68,7 @@ impl<R: SetlistRepository, T: TeamResolver, L: LikedSongIds> SetlistService<R, T
 
     pub async fn setlist_songs_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
         pagination: ListQuery,
     ) -> Result<(Vec<Song>, u64), AppError> {
@@ -93,7 +93,7 @@ impl<R: SetlistRepository, T: TeamResolver, L: LikedSongIds> SetlistService<R, T
 
     pub async fn create_setlist_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         setlist: CreateSetlist,
     ) -> Result<Setlist, AppError> {
         self.repo.create_setlist(&perms.user().id, setlist).await
@@ -101,7 +101,7 @@ impl<R: SetlistRepository, T: TeamResolver, L: LikedSongIds> SetlistService<R, T
 
     pub async fn update_setlist_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
         setlist: CreateSetlist,
     ) -> Result<Setlist, AppError> {
@@ -111,7 +111,7 @@ impl<R: SetlistRepository, T: TeamResolver, L: LikedSongIds> SetlistService<R, T
 
     pub async fn patch_setlist_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
         patch: PatchSetlist,
     ) -> Result<Setlist, AppError> {
@@ -125,7 +125,7 @@ impl<R: SetlistRepository, T: TeamResolver, L: LikedSongIds> SetlistService<R, T
 
     pub async fn delete_setlist_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
     ) -> Result<Setlist, AppError> {
         let write_teams = perms.write_teams().await?;
@@ -323,15 +323,15 @@ mod tests {
                 get_returns: None,
                 update_ok: false,
             },
-            MockTeams {
+            Arc::new(MockTeams {
                 read: vec![team_a()],
                 write: vec![],
-            },
+            }),
             MockLikes {
                 ids: HashSet::new(),
             },
         );
-        let perms = UserPermissions::new(&user, &svc.teams);
+        let perms = UserPermissions::from_ref(&user, &svc.teams);
         let r = svc.get_setlist_for_user(&perms, "nope").await;
         assert!(matches!(r, Err(AppError::NotFound(_))));
     }
@@ -346,15 +346,15 @@ mod tests {
                 get_returns: None,
                 update_ok: false,
             },
-            MockTeams {
+            Arc::new(MockTeams {
                 read: vec![team_a()],
                 write: vec![team_b()],
-            },
+            }),
             MockLikes {
                 ids: HashSet::new(),
             },
         );
-        let perms = UserPermissions::new(&user, &svc.teams);
+        let perms = UserPermissions::from_ref(&user, &svc.teams);
         let r = svc
             .update_setlist_for_user(
                 &perms,
@@ -378,15 +378,15 @@ mod tests {
                 get_returns: None,
                 update_ok: true,
             },
-            MockTeams {
+            Arc::new(MockTeams {
                 read: vec![team_a()],
                 write: vec![team_a()],
-            },
+            }),
             MockLikes {
                 ids: HashSet::new(),
             },
         );
-        let perms = UserPermissions::new(&user, &svc.teams);
+        let perms = UserPermissions::from_ref(&user, &svc.teams);
         let r = svc
             .update_setlist_for_user(
                 &perms,
@@ -418,7 +418,7 @@ mod tests {
         let s2 = create_song_with_title(&db, &owner, "Song Two")
             .await
             .expect("s2");
-        let owner_p = UserPermissions::new(&owner, &sl.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &sl.teams);
 
         let created = sl
             .create_setlist_for_user(
@@ -445,9 +445,9 @@ mod tests {
         let s1 = create_song_with_title(&db, &owner, "Song One")
             .await
             .expect("s1");
-        let owner_p = UserPermissions::new(&owner, &sl.teams);
-        let read_p = UserPermissions::new(&read_u, &sl.teams);
-        let noperm_p = UserPermissions::new(&noperm, &sl.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &sl.teams);
+        let read_p = UserPermissions::from_ref(&read_u, &sl.teams);
+        let noperm_p = UserPermissions::from_ref(&noperm, &sl.teams);
 
         sl.create_setlist_for_user(
             &owner_p,
@@ -503,7 +503,7 @@ mod tests {
         let s1 = create_song_with_title(&db, &owner, "Song")
             .await
             .expect("s");
-        let owner_p = UserPermissions::new(&owner, &sl.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &sl.teams);
 
         sl.create_setlist_for_user(&owner_p, setlist_with_songs("A", &[(s1.id.as_str(), None)]))
             .await
@@ -544,7 +544,7 @@ mod tests {
         let s1 = create_song_with_title(&db, &owner, "Song")
             .await
             .expect("s");
-        let owner_p = UserPermissions::new(&owner, &sl.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &sl.teams);
 
         let sunday = sl
             .create_setlist_for_user(
@@ -608,9 +608,9 @@ mod tests {
         let s2 = create_song_with_title(&db, &owner, "Song Two")
             .await
             .expect("s2");
-        let owner_p = UserPermissions::new(&owner, &sl.teams);
-        let read_p = UserPermissions::new(&read_u, &sl.teams);
-        let noperm_p = UserPermissions::new(&noperm, &sl.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &sl.teams);
+        let read_p = UserPermissions::from_ref(&read_u, &sl.teams);
+        let noperm_p = UserPermissions::from_ref(&noperm, &sl.teams);
 
         let created = sl
             .create_setlist_for_user(
@@ -657,9 +657,9 @@ mod tests {
         let s2 = create_song_with_title(&db, &owner, "Song Two")
             .await
             .expect("s2");
-        let owner_p = UserPermissions::new(&owner, &sl.teams);
-        let read_p = UserPermissions::new(&read_u, &sl.teams);
-        let noperm_p = UserPermissions::new(&noperm, &sl.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &sl.teams);
+        let read_p = UserPermissions::from_ref(&read_u, &sl.teams);
+        let noperm_p = UserPermissions::from_ref(&noperm, &sl.teams);
 
         let created = sl
             .create_setlist_for_user(
@@ -712,9 +712,9 @@ mod tests {
         let s2 = create_song_with_title(&db, &owner, "Song Two")
             .await
             .expect("s2");
-        let owner_p = UserPermissions::new(&owner, &sl.teams);
-        let read_p = UserPermissions::new(&read_u, &sl.teams);
-        let noperm_p = UserPermissions::new(&noperm, &sl.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &sl.teams);
+        let read_p = UserPermissions::from_ref(&read_u, &sl.teams);
+        let noperm_p = UserPermissions::from_ref(&noperm, &sl.teams);
 
         let created = sl
             .create_setlist_for_user(
@@ -763,10 +763,10 @@ mod tests {
         let s2 = create_song_with_title(&db, &owner, "Song Two")
             .await
             .expect("s2");
-        let owner_p = UserPermissions::new(&owner, &sl.teams);
-        let read_p = UserPermissions::new(&read_u, &sl.teams);
-        let write_p = UserPermissions::new(&write_u, &sl.teams);
-        let noperm_p = UserPermissions::new(&noperm, &sl.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &sl.teams);
+        let read_p = UserPermissions::from_ref(&read_u, &sl.teams);
+        let write_p = UserPermissions::from_ref(&write_u, &sl.teams);
+        let noperm_p = UserPermissions::from_ref(&noperm, &sl.teams);
 
         let created = sl
             .create_setlist_for_user(
@@ -857,7 +857,7 @@ mod tests {
         let s1 = create_song_with_title(&db, &owner, "Song One")
             .await
             .expect("s1");
-        let owner_p = UserPermissions::new(&owner, &sl.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &sl.teams);
 
         let created = sl
             .create_setlist_for_user(
@@ -893,7 +893,7 @@ mod tests {
         use shared::setlist::PatchSetlist;
         let (db, owner, _read_u, _write_u, _noperm, _team_id) = four_user_setlist_fixture().await;
         let sl = setlist_service(&db);
-        let owner_p = UserPermissions::new(&owner, &sl.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &sl.teams);
         let r = sl
             .patch_setlist_for_user(
                 &owner_p,
@@ -916,8 +916,8 @@ mod tests {
         let s1 = create_song_with_title(&db, &owner, "Song")
             .await
             .expect("s");
-        let owner_p = UserPermissions::new(&owner, &sl.teams);
-        let read_p = UserPermissions::new(&read_u, &sl.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &sl.teams);
+        let read_p = UserPermissions::from_ref(&read_u, &sl.teams);
         let created = sl
             .create_setlist_for_user(
                 &owner_p,
@@ -950,7 +950,7 @@ mod tests {
         let s2 = create_song_with_title(&db, &owner, "Song Two")
             .await
             .expect("s2");
-        let owner_p = UserPermissions::new(&owner, &sl.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &sl.teams);
 
         for mask in 0u8..4 {
             let created = sl
@@ -1013,9 +1013,9 @@ mod tests {
         let s1 = create_song_with_title(&db, &owner, "Song")
             .await
             .expect("s");
-        let owner_p = UserPermissions::new(&owner, &sl.teams);
-        let write_p = UserPermissions::new(&write_u, &sl.teams);
-        let noperm_p = UserPermissions::new(&noperm, &sl.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &sl.teams);
+        let write_p = UserPermissions::from_ref(&write_u, &sl.teams);
+        let noperm_p = UserPermissions::from_ref(&noperm, &sl.teams);
 
         let owner_setlist = sl
             .create_setlist_for_user(

--- a/backend/src/resources/song/mod.rs
+++ b/backend/src/resources/song/mod.rs
@@ -8,7 +8,7 @@ mod surreal_repo;
 
 pub use liked::LikedSongIds;
 pub use model::SongRecord;
-pub use repository::SongRepository;
+pub use repository::{SongRepository, SongUpsertOutcome};
 pub use service::{SongService, SongServiceHandle};
 pub use surreal_repo::SurrealSongRepo;
 

--- a/backend/src/resources/song/repository.rs
+++ b/backend/src/resources/song/repository.rs
@@ -8,6 +8,21 @@ use shared::song::{CreateSong, Song};
 
 use crate::error::AppError;
 
+/// Result of [`SongRepository::update_song`] (PUT upsert).
+#[derive(Debug)]
+pub enum SongUpsertOutcome {
+    Created(Song),
+    Updated(Song),
+}
+
+impl SongUpsertOutcome {
+    pub fn into_song(self) -> Song {
+        match self {
+            SongUpsertOutcome::Created(s) | SongUpsertOutcome::Updated(s) => s,
+        }
+    }
+}
+
 /// Pure song data access (no user ACL — callers pass pre-resolved team [`Thing`]s).
 #[async_trait]
 pub trait SongRepository: Send + Sync {
@@ -38,7 +53,7 @@ pub trait SongRepository: Send + Sync {
         actor_user_id: &str,
         id: &str,
         song: CreateSong,
-    ) -> Result<Song, AppError>;
+    ) -> Result<SongUpsertOutcome, AppError>;
 
     async fn delete_song(&self, write_teams: &[Thing], id: &str) -> Result<Song, AppError>;
 

--- a/backend/src/resources/song/rest.rs
+++ b/backend/src/resources/song/rest.rs
@@ -14,6 +14,7 @@ use crate::resources::song::CreateSong;
 use crate::resources::song::PatchSong;
 #[allow(unused_imports)]
 use crate::resources::song::Song;
+use crate::resources::song::SongUpsertOutcome;
 use crate::resources::song::service::SongServiceHandle;
 use crate::resources::team::UserPermissions;
 use shared::api::SongListQuery;
@@ -38,8 +39,8 @@ pub fn scope() -> Scope {
     get,
     path = "/api/v1/songs",
     params(
-        ("page" = Option<u32>, Query, description = "Page index, zero-based. Defaults to 0."),
-        ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50."),
+        ("page" = Option<u32>, Query, description = "Zero-based page index (default 0). `X-Total-Count` is the total before pagination; the last page is when `items.len() < page_size` or the list is empty (see `docs/business-logic-constraints/list-pagination.md`)."),
+        ("page_size" = Option<u32>, Query, description = "Page size 1–500 (default 50)."),
         ("q" = Option<String>, Query, description = "Full-text search query (titles, artists, line lyrics); uses text_search analyzer (stemming)"),
         ("sort" = Option<String>, Query, description = "Sort: `id_desc` (default without q), `id_asc`, `title_asc`, `title_desc`, `relevance` (default with q; requires q when set explicitly)"),
         ("lang" = Option<String>, Query, description = "Filter: song must list this language in `data.languages`."),
@@ -67,7 +68,7 @@ async fn get_songs(
         .into_inner()
         .validate()
         .map_err(AppError::invalid_request)?;
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     let songs = svc.list_songs_for_user(&perms, query.clone()).await?;
     let total = svc.count_songs_for_user(&perms, &query).await?;
     Ok(HttpResponse::Ok()
@@ -105,7 +106,7 @@ async fn get_song(
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     let song = svc.get_song_for_user(&perms, &id).await?;
     let etag = weak_etag_json(&song).map_err(|e| AppError::Internal(e.to_string()))?;
     if if_none_match_matches(&req, &etag) {
@@ -150,7 +151,7 @@ async fn get_song_player(
             "supported Accept values include application/json, application/vnd.worship.player+json, and */*",
         ));
     }
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     Ok(HttpResponse::Ok().json(svc.song_player_for_user(&perms, &id).await?))
 }
 
@@ -176,11 +177,10 @@ async fn create_song(
     user: ReqData<User>,
     payload: Json<CreateSong>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
-    Ok(HttpResponse::Created().json(
-        svc.create_song_for_user(&perms, payload.into_inner())
-            .await?,
-    ))
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
+    let payload = payload.into_inner();
+    payload.validate().map_err(AppError::invalid_request)?;
+    Ok(HttpResponse::Created().json(svc.create_song_for_user(&perms, payload).await?))
 }
 
 #[utoipa::path(
@@ -191,7 +191,8 @@ async fn create_song(
     ),
     request_body = CreateSong,
     responses(
-        (status = 200, description = "Update an existing song, or upsert: if the id does not exist, creates the song (same as POST) on the caller's writable context (BLC upsert tests).", body = Song),
+        (status = 200, description = "Updated an existing song.", body = Song),
+        (status = 201, description = "Created the song via PUT upsert (new id). Response includes `Location: /api/v1/songs/{id}`.", body = Song),
         (status = 400, description = "Invalid song identifier", body = ProblemDetails),
         (status = 401, description = "Authentication required", body = ProblemDetails),
         (status = 404, description = "Song not found", body = ProblemDetails),
@@ -210,11 +211,15 @@ async fn update_song(
     id: Path<String>,
     payload: Json<CreateSong>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
-    Ok(HttpResponse::Ok().json(
-        svc.update_song_for_user(&perms, &id, payload.into_inner())
-            .await?,
-    ))
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
+    let payload = payload.into_inner();
+    payload.validate().map_err(AppError::invalid_request)?;
+    match svc.update_song_for_user(&perms, &id, payload).await? {
+        SongUpsertOutcome::Created(song) => Ok(HttpResponse::Created()
+            .insert_header((header::LOCATION, format!("/api/v1/songs/{}", song.id)))
+            .json(song)),
+        SongUpsertOutcome::Updated(song) => Ok(HttpResponse::Ok().json(song)),
+    }
 }
 
 #[utoipa::path(
@@ -244,7 +249,7 @@ async fn patch_song(
     id: Path<String>,
     payload: Json<PatchSong>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     Ok(HttpResponse::Ok().json(
         svc.patch_song_for_user(&perms, &id, payload.into_inner())
             .await?,
@@ -276,7 +281,7 @@ async fn delete_song(
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     svc.delete_song_for_user(&perms, &id).await?;
     Ok(HttpResponse::NoContent().finish())
 }
@@ -306,7 +311,7 @@ async fn get_song_like_status(
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     Ok(HttpResponse::Ok().json(svc.song_like_status_for_user(&perms, &id).await?))
 }
 
@@ -335,7 +340,7 @@ async fn put_song_like(
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     svc.set_song_like_status_for_user(&perms, &id, true).await?;
     Ok(HttpResponse::NoContent().finish())
 }
@@ -365,7 +370,7 @@ async fn delete_song_like(
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    let perms = UserPermissions::new(&user, &svc.teams);
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
     svc.set_song_like_status_for_user(&perms, &id, false)
         .await?;
     Ok(HttpResponse::NoContent().finish())

--- a/backend/src/resources/song/service.rs
+++ b/backend/src/resources/song/service.rs
@@ -20,7 +20,7 @@ use crate::resources::user::UserRepository;
 use shared::collection::CreateCollection;
 
 use super::liked::LikedSongIds;
-use super::repository::SongRepository;
+use super::repository::{SongRepository, SongUpsertOutcome};
 use super::surreal_repo::SurrealSongRepo;
 
 /// Abstraction over updating a user's default collection reference.
@@ -31,6 +31,8 @@ pub trait UserCollectionUpdater: Send + Sync {
         user_id: &str,
         collection_id: &str,
     ) -> Result<(), AppError>;
+
+    async fn clear_default_collection(&self, user_id: &str) -> Result<(), AppError>;
 }
 
 #[async_trait]
@@ -44,20 +46,24 @@ impl UserCollectionUpdater for Arc<SurrealUserRepo> {
             .set_default_collection(user_id, collection_id)
             .await
     }
+
+    async fn clear_default_collection(&self, user_id: &str) -> Result<(), AppError> {
+        (**self).clear_default_collection(user_id).await
+    }
 }
 
 /// Application service: team resolution, authorization, and orchestration for songs.
 #[derive(Clone)]
 pub struct SongService<R, T, L, C, U> {
     pub repo: R,
-    pub teams: T,
+    pub teams: Arc<T>,
     pub likes: L,
     pub collections: C,
     pub user_updater: U,
 }
 
 impl<R, T, L, C, U> SongService<R, T, L, C, U> {
-    pub fn new(repo: R, teams: T, likes: L, collections: C, user_updater: U) -> Self {
+    pub fn new(repo: R, teams: Arc<T>, likes: L, collections: C, user_updater: U) -> Self {
         Self {
             repo,
             teams,
@@ -125,7 +131,7 @@ impl<
 
     pub async fn list_songs_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         query: SongListQuery,
     ) -> Result<Vec<Song>, AppError> {
         let user_id = perms.user().id.clone();
@@ -145,7 +151,7 @@ impl<
 
     pub async fn count_songs_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         query: &SongListQuery,
     ) -> Result<u64, AppError> {
         let read_teams = perms.read_teams().await?;
@@ -154,7 +160,7 @@ impl<
 
     pub async fn get_song_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
     ) -> Result<Song, AppError> {
         let user_id = perms.user().id.clone();
@@ -167,7 +173,7 @@ impl<
 
     pub async fn song_player_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
     ) -> Result<Player, AppError> {
         let read_teams = perms.read_teams().await?;
@@ -184,43 +190,58 @@ impl<
 
     pub async fn create_song_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         song: CreateSong,
     ) -> Result<Song, AppError> {
         let created = self.repo.create_song(&perms.user().id, song).await?;
+        let mut default_id = perms.user().default_collection.clone();
 
-        if let Some(collection_id) = perms.user().default_collection.as_ref() {
+        loop {
             let write_teams = perms.write_teams().await?;
-            self.collections
-                .add_song_to_collection(
-                    write_teams,
-                    collection_id,
-                    SongLink {
-                        id: created.id.clone(),
-                        nr: None,
-                        key: None,
-                    },
-                )
-                .await?;
-        } else {
-            let collection = self
-                .collections
-                .create_collection(
-                    &perms.user().id,
-                    CreateCollection {
-                        title: "Default".to_string(),
-                        cover: "mysongs".to_string(),
-                        songs: vec![SongLink {
+            if let Some(collection_id) = default_id.as_ref() {
+                match self
+                    .collections
+                    .add_song_to_collection(
+                        write_teams,
+                        collection_id,
+                        SongLink {
                             id: created.id.clone(),
                             nr: None,
                             key: None,
-                        }],
-                    },
-                )
-                .await?;
-            self.user_updater
-                .set_default_collection(&perms.user().id, &collection.id)
-                .await?;
+                        },
+                    )
+                    .await
+                {
+                    Ok(()) => break,
+                    Err(e) if matches!(&e, AppError::NotFound(_) | AppError::Conflict(_)) => {
+                        self.user_updater
+                            .clear_default_collection(&perms.user().id)
+                            .await?;
+                        default_id = None;
+                    }
+                    Err(e) => return Err(e),
+                }
+            } else {
+                let collection = self
+                    .collections
+                    .create_collection(
+                        &perms.user().id,
+                        CreateCollection {
+                            title: "Default".to_string(),
+                            cover: "mysongs".to_string(),
+                            songs: vec![SongLink {
+                                id: created.id.clone(),
+                                nr: None,
+                                key: None,
+                            }],
+                        },
+                    )
+                    .await?;
+                self.user_updater
+                    .set_default_collection(&perms.user().id, &collection.id)
+                    .await?;
+                break;
+            }
         }
 
         Ok(created)
@@ -228,10 +249,10 @@ impl<
 
     pub async fn update_song_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
         song: CreateSong,
-    ) -> Result<Song, AppError> {
+    ) -> Result<SongUpsertOutcome, AppError> {
         let write_teams = perms.write_teams().await?;
         self.repo
             .update_song(write_teams, &perms.user().id, id, song)
@@ -240,7 +261,7 @@ impl<
 
     pub async fn patch_song_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
         patch: PatchSong,
     ) -> Result<Song, AppError> {
@@ -253,12 +274,14 @@ impl<
                 .map(|song_data_patch| Self::merge_song_data(current.data.clone(), song_data_patch))
                 .unwrap_or(current.data),
         };
-        self.update_song_for_user(perms, id, merged).await
+        self.update_song_for_user(perms, id, merged)
+            .await
+            .map(SongUpsertOutcome::into_song)
     }
 
     pub async fn delete_song_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
     ) -> Result<Song, AppError> {
         let write_teams = perms.write_teams().await?;
@@ -267,7 +290,7 @@ impl<
 
     pub async fn song_like_status_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
     ) -> Result<LikeStatus, AppError> {
         let read_teams = perms.read_teams().await?;
@@ -280,7 +303,7 @@ impl<
 
     pub async fn set_song_like_status_for_user(
         &self,
-        perms: &UserPermissions<'_, T>,
+        perms: &UserPermissions<T>,
         id: &str,
         liked: bool,
     ) -> Result<LikeStatus, AppError> {
@@ -304,9 +327,19 @@ pub type SongServiceHandle = SongService<
 
 impl SongServiceHandle {
     pub fn build(db: Arc<Database>) -> Self {
+        Self::build_with_team_resolver(
+            db.clone(),
+            Arc::new(crate::resources::team::SurrealTeamResolver::new(db.clone())),
+        )
+    }
+
+    pub fn build_with_team_resolver(
+        db: Arc<Database>,
+        teams: Arc<crate::resources::team::SurrealTeamResolver>,
+    ) -> Self {
         SongService::new(
             SurrealSongRepo::new(db.clone()),
-            crate::resources::team::SurrealTeamResolver::new(db.clone()),
+            teams,
             db.clone(),
             crate::resources::collection::SurrealCollectionRepo::new(db.clone()),
             Arc::new(SurrealUserRepo::new(db.clone())),
@@ -350,8 +383,8 @@ mod tests {
             .await
             .expect("s2");
 
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
-        let other_p = UserPermissions::new(&other, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
+        let other_p = UserPermissions::from_ref(&other, &svc.teams);
 
         let list = svc
             .list_songs_for_user(&owner_p, ListQuery::default().into())
@@ -430,8 +463,8 @@ mod tests {
     async fn blc_song_002_non_member_read_not_found() {
         let (db, owner, _cm, _guest, nm, _tid) = four_user_song_fixture().await;
         let svc = SongServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
-        let nm_p = UserPermissions::new(&nm, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
+        let nm_p = UserPermissions::from_ref(&nm, &svc.teams);
         let song = create_song_with_title(&db, &owner, "NMSong")
             .await
             .expect("song");
@@ -449,8 +482,8 @@ mod tests {
         use shared::song::CreateSong;
         let (db, owner, _cm, guest_u, _nm, _tid) = four_user_song_fixture().await;
         let svc = SongServiceHandle::build(db.clone());
-        let _owner_p = UserPermissions::new(&owner, &svc.teams);
-        let guest_p = UserPermissions::new(&guest_u, &svc.teams);
+        let _owner_p = UserPermissions::from_ref(&owner, &svc.teams);
+        let guest_p = UserPermissions::from_ref(&guest_u, &svc.teams);
         let song = create_song_with_title(&db, &owner, "GuestPUTSong")
             .await
             .expect("song");
@@ -468,8 +501,8 @@ mod tests {
     async fn blc_song_007_guest_cannot_delete() {
         let (db, owner, _cm, guest_u, _nm, _tid) = four_user_song_fixture().await;
         let svc = SongServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
-        let guest_p = UserPermissions::new(&guest_u, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
+        let guest_p = UserPermissions::from_ref(&guest_u, &svc.teams);
         let song = create_song_with_title(&db, &owner, "GuestDELSong")
             .await
             .expect("song");
@@ -487,8 +520,8 @@ mod tests {
         use shared::song::CreateSong;
         let (db, owner, cm, _guest, _nm, _tid) = four_user_song_fixture().await;
         let svc = SongServiceHandle::build(db.clone());
-        let _owner_p = UserPermissions::new(&owner, &svc.teams);
-        let cm_p = UserPermissions::new(&cm, &svc.teams);
+        let _owner_p = UserPermissions::from_ref(&owner, &svc.teams);
+        let cm_p = UserPermissions::from_ref(&cm, &svc.teams);
         let song = create_song_with_title(&db, &owner, "CMUpdateSong")
             .await
             .expect("song");
@@ -501,7 +534,8 @@ mod tests {
         };
         svc.update_song_for_user(&cm_p, &song.id, create)
             .await
-            .expect("cm update");
+            .expect("cm update")
+            .into_song();
     }
 
     /// BLC-SONG-003: PUT does not change the song's owner.
@@ -510,7 +544,7 @@ mod tests {
         use shared::song::CreateSong;
         let (db, owner, _cm, _guest, _nm, tid) = four_user_song_fixture().await;
         let svc = SongServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
         let song = create_song_with_title(&db, &owner, "OwnerSong")
             .await
             .expect("song");
@@ -524,7 +558,8 @@ mod tests {
         let updated = svc
             .update_song_for_user(&owner_p, &song.id, create)
             .await
-            .expect("update");
+            .expect("update")
+            .into_song();
         assert_eq!(updated.owner, tid, "owner must not change on PUT");
     }
 
@@ -534,7 +569,7 @@ mod tests {
         use shared::api::ListQuery;
         let (db, owner, _cm, _guest, _nm, _tid) = four_user_song_fixture().await;
         let svc = SongServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
 
         let mut data_with_artist = crate::test_helpers::minimal_song_data();
         data_with_artist.titles = vec!["SongByArtist".into()];
@@ -572,7 +607,7 @@ mod tests {
     async fn blc_song_012_liked_true_when_liked() {
         let (db, owner, _cm, _guest, _nm, _tid) = four_user_song_fixture().await;
         let svc = SongServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
         let song = create_song_with_title(&db, &owner, "LikeSong")
             .await
             .expect("song");
@@ -591,7 +626,7 @@ mod tests {
     async fn blc_song_012_liked_false_when_not_liked() {
         let (db, owner, _cm, _guest, _nm, _tid) = four_user_song_fixture().await;
         let svc = SongServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
         let song = create_song_with_title(&db, &owner, "UnlikedSong")
             .await
             .expect("song");
@@ -607,8 +642,8 @@ mod tests {
     async fn blc_song_004_like_state_independent_per_user() {
         let (db, owner, _cm, guest_u, _nm, _tid) = four_user_song_fixture().await;
         let svc = SongServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
-        let guest_p = UserPermissions::new(&guest_u, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
+        let guest_p = UserPermissions::from_ref(&guest_u, &svc.teams);
         let song = create_song_with_title(&db, &owner, "IndependentLike")
             .await
             .expect("song");
@@ -635,8 +670,8 @@ mod tests {
     async fn blc_song_004_like_unreadable_song_not_found() {
         let (db, owner, _cm, _guest, nm, _tid) = four_user_song_fixture().await;
         let svc = SongServiceHandle::build(db.clone());
-        let _owner_p = UserPermissions::new(&owner, &svc.teams);
-        let nm_p = UserPermissions::new(&nm, &svc.teams);
+        let _owner_p = UserPermissions::from_ref(&owner, &svc.teams);
+        let nm_p = UserPermissions::from_ref(&nm, &svc.teams);
         let song = create_song_with_title(&db, &owner, "SecretLikeSong")
             .await
             .expect("song");
@@ -652,7 +687,7 @@ mod tests {
         use shared::song::CreateSong;
         let (db, owner, _cm, _guest, _nm, _tid) = four_user_song_fixture().await;
         let svc = SongServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
         let data = crate::test_helpers::minimal_song_data();
         let create = CreateSong {
             not_a_song: false,
@@ -674,7 +709,7 @@ mod tests {
         use shared::song::PatchSong;
         let (db, owner, _cm, _guest, _nm, _tid) = four_user_song_fixture().await;
         let svc = SongServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
 
         let song = create_song_with_title(&db, &owner, "OriginalTitle")
             .await
@@ -710,7 +745,7 @@ mod tests {
         use shared::song::PatchSong;
         let (db, owner, _cm, guest_u, _nm, _tid) = four_user_song_fixture().await;
         let svc = SongServiceHandle::build(db.clone());
-        let guest_p = UserPermissions::new(&guest_u, &svc.teams);
+        let guest_p = UserPermissions::from_ref(&guest_u, &svc.teams);
         let song = create_song_with_title(&db, &owner, "GuestPatchSong")
             .await
             .expect("song");
@@ -734,7 +769,7 @@ mod tests {
         use shared::song::PatchSong;
         let (db, owner, _cm, _guest, _nm, _tid) = four_user_song_fixture().await;
         let svc = SongServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
         let r = svc
             .patch_song_for_user(
                 &owner_p,
@@ -755,7 +790,7 @@ mod tests {
         use shared::song::PatchSong;
         let (db, owner, _cm, _guest, _nm, _tid) = four_user_song_fixture().await;
         let svc = SongServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
         let song = create_song_with_title(&db, &owner, "NoopSong")
             .await
             .expect("song");
@@ -781,7 +816,7 @@ mod tests {
 
         let (db, owner, _cm, _guest, _nm, _tid) = four_user_song_fixture().await;
         let svc = SongServiceHandle::build(db.clone());
-        let owner_p = UserPermissions::new(&owner, &svc.teams);
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
 
         let mut base_data = crate::test_helpers::minimal_song_data();
         base_data.titles = vec!["BaseTitle".into()];
@@ -1046,7 +1081,7 @@ mod tests {
         use shared::song::CreateSong;
         let (db, _owner, _cm, guest_u, _nm, _tid) = four_user_song_fixture().await;
         let svc = SongServiceHandle::build(db.clone());
-        let guest_p = UserPermissions::new(&guest_u, &svc.teams);
+        let guest_p = UserPermissions::from_ref(&guest_u, &svc.teams);
         let data = crate::test_helpers::minimal_song_data();
         let create = CreateSong {
             not_a_song: false,
@@ -1057,7 +1092,8 @@ mod tests {
         let result = svc
             .update_song_for_user(&guest_p, "brand-new-guest-created-id", create)
             .await
-            .expect("guest can upsert to own personal team");
+            .expect("guest can upsert to own personal team")
+            .into_song();
         let guest_pt = personal_team_id(&db, &guest_u).await.expect("guest pt");
         assert_eq!(
             result.owner, guest_pt,
@@ -1076,7 +1112,7 @@ mod tests {
             "new user must have no default_collection"
         );
         let svc = SongServiceHandle::build(db.clone());
-        let perms = UserPermissions::new(&u, &svc.teams);
+        let perms = UserPermissions::from_ref(&u, &svc.teams);
         let song = svc
             .create_song_for_user(
                 &perms,
@@ -1091,7 +1127,7 @@ mod tests {
 
         // A "Default" collection must have been created.
         let coll_svc = crate::test_helpers::collection_service(&db);
-        let fresh_perms = UserPermissions::new(&u, &coll_svc.teams);
+        let fresh_perms = UserPermissions::from_ref(&u, &coll_svc.teams);
         let collections = coll_svc
             .list_collections_for_user(&fresh_perms, ListQuery::default())
             .await
@@ -1133,7 +1169,7 @@ mod tests {
             .await
             .expect("u");
         let svc = SongServiceHandle::build(db.clone());
-        let perms = UserPermissions::new(&u, &svc.teams);
+        let perms = UserPermissions::from_ref(&u, &svc.teams);
         let song1 = svc
             .create_song_for_user(
                 &perms,
@@ -1160,7 +1196,7 @@ mod tests {
 
         // Create a second song using the updated user (whose default_collection is set).
         let svc2 = SongServiceHandle::build(db.clone());
-        let perms2 = UserPermissions::new(&updated_u, &svc2.teams);
+        let perms2 = UserPermissions::from_ref(&updated_u, &svc2.teams);
         let song2 = svc2
             .create_song_for_user(
                 &perms2,
@@ -1178,7 +1214,7 @@ mod tests {
             .expect("song2");
 
         let coll_svc = crate::test_helpers::collection_service(&db);
-        let fresh_perms = UserPermissions::new(&updated_u, &coll_svc.teams);
+        let fresh_perms = UserPermissions::from_ref(&updated_u, &coll_svc.teams);
         let collections = coll_svc
             .list_collections_for_user(&fresh_perms, ListQuery::default())
             .await
@@ -1213,7 +1249,7 @@ mod tests {
             .await
             .expect("song");
         let sl_svc = setlist_service(&db);
-        let u_p = UserPermissions::new(&u, &sl_svc.teams);
+        let u_p = UserPermissions::from_ref(&u, &sl_svc.teams);
         let sl = sl_svc
             .create_setlist_for_user(
                 &u_p,
@@ -1221,12 +1257,12 @@ mod tests {
             )
             .await
             .expect("setlist");
-        let song_p = UserPermissions::new(&u, &svc.teams);
+        let song_p = UserPermissions::from_ref(&u, &svc.teams);
         svc.delete_song_for_user(&song_p, &song.id)
             .await
             .expect("del song");
         let sl_svc2 = setlist_service(&db);
-        let u_p2 = UserPermissions::new(&u, &sl_svc2.teams);
+        let u_p2 = UserPermissions::from_ref(&u, &sl_svc2.teams);
         let g = sl_svc2
             .get_setlist_for_user(&u_p2, &sl.id)
             .await

--- a/backend/src/resources/song/surreal_repo.rs
+++ b/backend/src/resources/song/surreal_repo.rs
@@ -15,7 +15,7 @@ use crate::error::AppError;
 use crate::resources::common::{belongs_to, blob_thing, resource_id};
 
 use super::model::{LikeRecord, SongRecord, search_content_from_song_data};
-use super::repository::SongRepository;
+use super::repository::{SongRepository, SongUpsertOutcome};
 
 fn owner_thing(user_id: &str) -> Thing {
     Thing::from(("user".to_owned(), user_id.to_owned()))
@@ -195,7 +195,7 @@ impl SongRepository for SurrealSongRepo {
         actor_user_id: &str,
         id: &str,
         song: CreateSong,
-    ) -> Result<Song, AppError> {
+    ) -> Result<SongUpsertOutcome, AppError> {
         let db = self.inner();
         let resource = resource_id("song", id)?;
         let (tb, sid) = resource.clone();
@@ -219,7 +219,7 @@ impl SongRepository for SurrealSongRepo {
 
         let rows: Vec<SongRecord> = response.take(0)?;
         if let Some(updated) = rows.into_iter().next() {
-            return Ok(updated.into_song());
+            return Ok(SongUpsertOutcome::Updated(updated.into_song()));
         }
 
         let existing: Option<SongRecord> = db.db.select(resource.clone()).await?;
@@ -233,12 +233,14 @@ impl SongRepository for SurrealSongRepo {
         }
         let record_id = Thing::from(resource.clone());
         let record = SongRecord::from_payload(Some(record_id), Some(personal), song);
-        db.db
+        let created = db
+            .db
             .create(resource)
             .content(record)
             .await?
             .map(SongRecord::into_song)
-            .ok_or_else(|| AppError::database("failed to upsert song"))
+            .ok_or_else(|| AppError::database("failed to upsert song"))?;
+        Ok(SongUpsertOutcome::Created(created))
     }
 
     async fn delete_song(&self, write_teams: &[Thing], id: &str) -> Result<Song, AppError> {

--- a/backend/src/resources/team/invitation/rest.rs
+++ b/backend/src/resources/team/invitation/rest.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use crate::docs::ErrorResponse;
+use crate::docs::ProblemDetails;
 use crate::error::AppError;
 use crate::resources::User;
 use actix_web::http::header;
@@ -36,11 +36,11 @@ pub fn invitations_accept_scope() -> Scope {
     ),
     responses(
         (status = 201, description = "Invitation created", body = TeamInvitation),
-        (status = 400, description = "Team is not shared", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 403, description = "Not a team admin", body = ErrorResponse),
-        (status = 404, description = "Team not found", body = ErrorResponse),
-        (status = 500, description = "Database error", body = ErrorResponse)
+        (status = 400, description = "Team is not shared", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 403, description = "Not a team admin", body = ProblemDetails),
+        (status = 404, description = "Team not found", body = ProblemDetails),
+        (status = 500, description = "Database error", body = ProblemDetails)
     ),
     tag = "Teams",
     security(
@@ -71,11 +71,11 @@ async fn create_team_invitation(
     ),
     responses(
         (status = 200, description = "Invitations for the team. `X-Total-Count` is the total before paging.", body = [TeamInvitation]),
-        (status = 400, description = "Invalid pagination parameters", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 403, description = "Not a team admin", body = ErrorResponse),
-        (status = 404, description = "Team not found", body = ErrorResponse),
-        (status = 500, description = "Database error", body = ErrorResponse)
+        (status = 400, description = "Invalid pagination parameters", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 403, description = "Not a team admin", body = ProblemDetails),
+        (status = 404, description = "Team not found", body = ProblemDetails),
+        (status = 500, description = "Database error", body = ProblemDetails)
     ),
     tag = "Teams",
     security(
@@ -114,10 +114,10 @@ async fn list_team_invitations(
     ),
     responses(
         (status = 200, description = "Invitation details", body = TeamInvitation),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 403, description = "Not a team admin", body = ErrorResponse),
-        (status = 404, description = "Team or invitation not found", body = ErrorResponse),
-        (status = 500, description = "Database error", body = ErrorResponse)
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 403, description = "Not a team admin", body = ProblemDetails),
+        (status = 404, description = "Team or invitation not found", body = ProblemDetails),
+        (status = 500, description = "Database error", body = ProblemDetails)
     ),
     tag = "Teams",
     security(
@@ -147,10 +147,10 @@ async fn get_team_invitation(
     ),
     responses(
         (status = 204, description = "Invitation removed"),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 403, description = "Not a team admin", body = ErrorResponse),
-        (status = 404, description = "Team or invitation not found", body = ErrorResponse),
-        (status = 500, description = "Database error", body = ErrorResponse)
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 403, description = "Not a team admin", body = ProblemDetails),
+        (status = 404, description = "Team or invitation not found", body = ProblemDetails),
+        (status = 500, description = "Database error", body = ProblemDetails)
     ),
     tag = "Teams",
     security(
@@ -178,9 +178,9 @@ async fn delete_team_invitation(
     ),
     responses(
         (status = 200, description = "Current user is on the team (added as guest if needed)", body = Team),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 404, description = "Invitation not found or not usable", body = ErrorResponse),
-        (status = 500, description = "Database error", body = ErrorResponse)
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 404, description = "Invitation not found or not usable", body = ProblemDetails),
+        (status = 500, description = "Database error", body = ProblemDetails)
     ),
     tag = "Teams",
     security(

--- a/backend/src/resources/team/resolver.rs
+++ b/backend/src/resources/team/resolver.rs
@@ -30,18 +30,18 @@ pub trait TeamResolver: Send + Sync {
 /// Per-request caching wrapper around a [`User`] and a [`TeamResolver`].
 ///
 /// Team lists are resolved lazily on first access and cached for the lifetime of
-/// this struct. Construct one at the start of a request handler and pass it into
-/// service methods instead of a bare `&User`.
-pub struct UserPermissions<'a, T: TeamResolver> {
-    user: &'a User,
-    resolver: &'a T,
+/// this struct. Construct with [`UserPermissions::from_ref`](UserPermissions::from_ref)
+/// (or [`UserPermissions::new`](UserPermissions::new) with `Arc`s) at the start of a handler.
+pub struct UserPermissions<T: TeamResolver> {
+    user: Arc<User>,
+    resolver: Arc<T>,
     read_teams: OnceCell<Vec<Thing>>,
     write_teams: OnceCell<Vec<Thing>>,
     personal_team: OnceCell<Thing>,
 }
 
-impl<'a, T: TeamResolver> UserPermissions<'a, T> {
-    pub fn new(user: &'a User, resolver: &'a T) -> Self {
+impl<T: TeamResolver> UserPermissions<T> {
+    pub fn new(user: Arc<User>, resolver: Arc<T>) -> Self {
         Self {
             user,
             resolver,
@@ -51,26 +51,31 @@ impl<'a, T: TeamResolver> UserPermissions<'a, T> {
         }
     }
 
+    /// Convenience for handlers and tests: clone `user` into an [`Arc`] and share `resolver`.
+    pub fn from_ref(user: &User, resolver: &Arc<T>) -> Self {
+        Self::new(Arc::new(user.clone()), Arc::clone(resolver))
+    }
+
     pub fn user(&self) -> &User {
-        self.user
+        self.user.as_ref()
     }
 
     /// Teams whose content the user may read. Resolved once; subsequent calls return the cached slice.
     pub async fn read_teams(&self) -> Result<&[Thing], AppError> {
-        let user = self.user;
-        let resolver = self.resolver;
+        let user = Arc::clone(&self.user);
+        let resolver = Arc::clone(&self.resolver);
         self.read_teams
-            .get_or_try_init(|| async move { resolver.content_read_teams(user).await })
+            .get_or_try_init(|| async move { resolver.content_read_teams(user.as_ref()).await })
             .await
             .map(Vec::as_slice)
     }
 
     /// Teams whose content the user may write. Resolved once; subsequent calls return the cached slice.
     pub async fn write_teams(&self) -> Result<&[Thing], AppError> {
-        let user = self.user;
-        let resolver = self.resolver;
+        let user = Arc::clone(&self.user);
+        let resolver = Arc::clone(&self.resolver);
         self.write_teams
-            .get_or_try_init(|| async move { resolver.content_write_teams(user).await })
+            .get_or_try_init(|| async move { resolver.content_write_teams(user.as_ref()).await })
             .await
             .map(Vec::as_slice)
     }
@@ -78,11 +83,26 @@ impl<'a, T: TeamResolver> UserPermissions<'a, T> {
     /// The user's personal team. Resolved once; subsequent calls return a clone.
     pub async fn personal_team(&self) -> Result<Thing, AppError> {
         let user_id = self.user.id.clone();
-        let resolver = self.resolver;
+        let resolver = Arc::clone(&self.resolver);
         self.personal_team
             .get_or_try_init(|| async move { resolver.personal_team(&user_id).await })
             .await
             .cloned()
+    }
+}
+
+#[async_trait]
+impl<T: TeamResolver + Send + Sync> TeamResolver for Arc<T> {
+    async fn content_read_teams(&self, user: &User) -> Result<Vec<Thing>, AppError> {
+        self.as_ref().content_read_teams(user).await
+    }
+
+    async fn content_write_teams(&self, user: &User) -> Result<Vec<Thing>, AppError> {
+        self.as_ref().content_write_teams(user).await
+    }
+
+    async fn personal_team(&self, user_id: &str) -> Result<Thing, AppError> {
+        self.as_ref().personal_team(user_id).await
     }
 }
 

--- a/backend/src/resources/team/rest.rs
+++ b/backend/src/resources/team/rest.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use crate::docs::ErrorResponse;
+use crate::docs::ProblemDetails;
 use crate::error::AppError;
 use crate::resources::User;
 use actix_web::http::header;
@@ -36,9 +36,9 @@ pub fn scope() -> Scope {
     ),
     responses(
         (status = 200, description = "Teams readable by the current user; platform admins receive all teams (except internal public). `X-Total-Count` is the total before paging.", body = [Team]),
-        (status = 400, description = "Invalid pagination parameters", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 500, description = "Failed to list teams", body = ErrorResponse)
+        (status = 400, description = "Invalid pagination parameters", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 500, description = "Failed to list teams", body = ProblemDetails)
     ),
     tag = "Teams",
     security(
@@ -75,9 +75,9 @@ async fn get_teams(
     ),
     responses(
         (status = 200, description = "Team details; platform admins may read any team except internal public", body = Team),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 404, description = "Team not found", body = ErrorResponse),
-        (status = 500, description = "Failed to fetch team", body = ErrorResponse)
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 404, description = "Team not found", body = ProblemDetails),
+        (status = 500, description = "Failed to fetch team", body = ProblemDetails)
     ),
     tag = "Teams",
     security(
@@ -100,9 +100,9 @@ async fn get_team(
     request_body = CreateTeam,
     responses(
         (status = 201, description = "Shared team created", body = Team),
-        (status = 400, description = "Invalid request", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 500, description = "Failed to create team", body = ErrorResponse)
+        (status = 400, description = "Invalid request", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 500, description = "Failed to create team", body = ProblemDetails)
     ),
     tag = "Teams",
     security(
@@ -116,10 +116,9 @@ async fn create_team(
     user: ReqData<User>,
     payload: Json<CreateTeam>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Created().json(
-        svc.create_shared_team_for_user(&user, payload.into_inner())
-            .await?,
-    ))
+    let payload = payload.into_inner();
+    payload.validate().map_err(AppError::invalid_request)?;
+    Ok(HttpResponse::Created().json(svc.create_shared_team_for_user(&user, payload).await?))
 }
 
 #[utoipa::path(
@@ -131,12 +130,12 @@ async fn create_team(
     request_body = UpdateTeam,
     responses(
         (status = 200, description = "Team updated", body = Team),
-        (status = 400, description = "Invalid request", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 403, description = "Insufficient team role", body = ErrorResponse),
-        (status = 404, description = "Team not found", body = ErrorResponse),
-        (status = 409, description = "Sole admin cannot remove all admins", body = ErrorResponse),
-        (status = 500, description = "Failed to update team", body = ErrorResponse)
+        (status = 400, description = "Invalid request", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 403, description = "Insufficient team role", body = ProblemDetails),
+        (status = 404, description = "Team not found", body = ProblemDetails),
+        (status = 409, description = "Sole admin cannot remove all admins", body = ProblemDetails),
+        (status = 500, description = "Failed to update team", body = ProblemDetails)
     ),
     tag = "Teams",
     security(
@@ -151,10 +150,9 @@ async fn update_team(
     id: Path<String>,
     payload: Json<UpdateTeam>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Ok().json(
-        svc.update_team_for_user(&user, &id, payload.into_inner())
-            .await?,
-    ))
+    let payload = payload.into_inner();
+    payload.validate().map_err(AppError::invalid_request)?;
+    Ok(HttpResponse::Ok().json(svc.update_team_for_user(&user, &id, payload).await?))
 }
 
 #[utoipa::path(
@@ -166,12 +164,12 @@ async fn update_team(
     request_body = PatchTeam,
     responses(
         (status = 200, description = "Team partially updated", body = Team),
-        (status = 400, description = "Invalid request", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 403, description = "Insufficient team role", body = ErrorResponse),
-        (status = 404, description = "Team not found", body = ErrorResponse),
-        (status = 409, description = "Sole admin cannot remove all admins", body = ErrorResponse),
-        (status = 500, description = "Failed to update team", body = ErrorResponse)
+        (status = 400, description = "Invalid request", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 403, description = "Insufficient team role", body = ProblemDetails),
+        (status = 404, description = "Team not found", body = ProblemDetails),
+        (status = 409, description = "Sole admin cannot remove all admins", body = ProblemDetails),
+        (status = 500, description = "Failed to update team", body = ProblemDetails)
     ),
     tag = "Teams",
     security(
@@ -200,10 +198,10 @@ async fn patch_team(
     ),
     responses(
         (status = 204, description = "Team deleted"),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 403, description = "Cannot delete personal team or insufficient role", body = ErrorResponse),
-        (status = 404, description = "Team not found", body = ErrorResponse),
-        (status = 500, description = "Failed to delete team", body = ErrorResponse)
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 403, description = "Cannot delete personal team or insufficient role", body = ProblemDetails),
+        (status = 404, description = "Team not found", body = ProblemDetails),
+        (status = 500, description = "Failed to delete team", body = ProblemDetails)
     ),
     tag = "Teams",
     security(

--- a/backend/src/resources/team/service.rs
+++ b/backend/src/resources/team/service.rs
@@ -23,11 +23,11 @@ use super::surreal_repo::SurrealTeamRepo;
 #[derive(Clone)]
 pub struct TeamService<R, TR> {
     pub repo: R,
-    pub resolver: TR,
+    pub resolver: Arc<TR>,
 }
 
 impl<R, TR> TeamService<R, TR> {
-    pub fn new(repo: R, resolver: TR) -> Self {
+    pub fn new(repo: R, resolver: Arc<TR>) -> Self {
         Self { repo, resolver }
     }
 }
@@ -193,7 +193,7 @@ impl<R: TeamRepository, TR: TeamResolver> TeamService<R, TR> {
     }
 
     pub async fn delete_team_for_user(&self, user: &User, id: &str) -> Result<Team, AppError> {
-        let perms = UserPermissions::new(user, &self.resolver);
+        let perms = UserPermissions::from_ref(user, &self.resolver);
         let resource = team_resource_or_reject_public(id)?;
 
         let row = self
@@ -225,10 +225,17 @@ pub type TeamServiceHandle = TeamService<SurrealTeamRepo, super::resolver::Surre
 
 impl TeamServiceHandle {
     pub fn build(db: Arc<Database>) -> Self {
-        TeamService::new(
-            SurrealTeamRepo::new(db.clone()),
-            super::resolver::SurrealTeamResolver::new(db.clone()),
+        Self::build_with_team_resolver(
+            db.clone(),
+            Arc::new(super::resolver::SurrealTeamResolver::new(db.clone())),
         )
+    }
+
+    pub fn build_with_team_resolver(
+        db: Arc<Database>,
+        resolver: Arc<super::resolver::SurrealTeamResolver>,
+    ) -> Self {
+        TeamService::new(SurrealTeamRepo::new(db.clone()), resolver)
     }
 }
 
@@ -728,7 +735,7 @@ mod tests {
 
         // admin_user's personal team now owns the song.
         let admin_personal = personal_team_id(&db, &fx.admin_user).await.expect("pt");
-        let song_perms = UserPermissions::new(&fx.admin_user, &song_svc.teams);
+        let song_perms = UserPermissions::from_ref(&fx.admin_user, &song_svc.teams);
         let fetched = song_svc
             .get_song_for_user(&song_perms, &song.id)
             .await
@@ -748,7 +755,7 @@ mod tests {
         let coll_svc = collection_service(&db);
 
         // admin_user creates a collection (owned by their personal team).
-        let admin_perms_coll = UserPermissions::new(&fx.admin_user, &coll_svc.teams);
+        let admin_perms_coll = UserPermissions::from_ref(&fx.admin_user, &coll_svc.teams);
         let coll = coll_svc
             .create_collection_for_user(
                 &admin_perms_coll,

--- a/backend/src/resources/user/repository.rs
+++ b/backend/src/resources/user/repository.rs
@@ -9,8 +9,8 @@ use crate::error::AppError;
 #[async_trait]
 pub trait UserRepository: Send + Sync {
     async fn get_users(&self, pagination: ListQuery) -> Result<Vec<User>, AppError>;
-    /// Count all users in the system.
-    async fn count_users(&self) -> Result<u64, AppError>;
+    /// Count users matching the same optional `q` filter as [`get_users`](Self::get_users) (ignores page).
+    async fn count_users(&self, query: ListQuery) -> Result<u64, AppError>;
     async fn get_user(&self, id: &str) -> Result<User, AppError>;
     async fn get_user_by_email(&self, email: &str) -> Result<Option<User>, AppError>;
     /// Insert a user record. Does NOT create a personal team — service layer handles that.

--- a/backend/src/resources/user/rest.rs
+++ b/backend/src/resources/user/rest.rs
@@ -1,7 +1,7 @@
 use super::{CreateUserRequest, User, session};
 use crate::auth::middleware::RequireAdmin;
 #[allow(unused_imports)]
-use crate::docs::ErrorResponse;
+use crate::docs::ProblemDetails;
 use crate::error::AppError;
 use crate::resources::user::service::UserServiceHandle;
 use actix_web::http::header;
@@ -36,8 +36,8 @@ pub fn scope() -> Scope {
     path = "/api/v1/users/me",
     responses(
         (status = 200, description = "Returns the currently authenticated user", body = User),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 500, description = "Failed to load user session", body = ErrorResponse)
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 500, description = "Failed to load user session", body = ProblemDetails)
     ),
     tag = "Users",
     security(
@@ -58,10 +58,10 @@ async fn get_users_me(user: ReqData<User>) -> HttpResponse {
     ),
     responses(
         (status = 200, description = "Returns the user matching the provided id", body = User),
-        (status = 400, description = "Invalid user identifier", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 403, description = "Admin role required", body = ErrorResponse),
-        (status = 500, description = "Failed to fetch user", body = ErrorResponse)
+        (status = 400, description = "Invalid user identifier", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 403, description = "Admin role required", body = ProblemDetails),
+        (status = 500, description = "Failed to fetch user", body = ProblemDetails)
     ),
     tag = "Users",
     security(
@@ -81,15 +81,16 @@ async fn get_user(
     get,
     path = "/api/v1/users",
     params(
-        ("page" = Option<u32>, Query, description = "Page index, zero-based. Defaults to 0."),
-        ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50.")
+        ("page" = Option<u32>, Query, description = "Page index, zero-based. Defaults to 0. See `docs/business-logic-constraints/list-pagination.md` (Track A: `X-Total-Count` is pre-pagination total; last page when `items.len() < page_size` or empty)."),
+        ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50."),
+        ("q" = Option<String>, Query, description = "Optional case-insensitive email substring filter. Whitespace-only is treated as absent.")
     ),
     responses(
-        (status = 200, description = "Returns list of all users. `X-Total-Count` header contains the total user count.", body = [User]),
-        (status = 400, description = "Invalid pagination parameters", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 403, description = "Admin role required", body = ErrorResponse),
-        (status = 500, description = "Failed to list users", body = ErrorResponse)
+        (status = 200, description = "Returns list of all users. `X-Total-Count` header contains the total matching user count (before pagination).", body = [User]),
+        (status = 400, description = "Invalid pagination parameters", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 403, description = "Admin role required", body = ProblemDetails),
+        (status = 500, description = "Failed to list users", body = ProblemDetails)
     ),
     tag = "Users",
     security(
@@ -106,8 +107,8 @@ async fn get_users(
         .into_inner()
         .validate()
         .map_err(AppError::invalid_request)?;
-    let users = svc.get_users(query).await?;
-    let total = svc.count_users().await?;
+    let users = svc.get_users(query.clone()).await?;
+    let total = svc.count_users(query).await?;
     Ok(HttpResponse::Ok()
         .insert_header((
             header::HeaderName::from_static("x-total-count"),
@@ -122,11 +123,11 @@ async fn get_users(
     request_body = CreateUserRequest,
     responses(
         (status = 201, description = "Creates a new user", body = User),
-        (status = 400, description = "Invalid request payload", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 403, description = "Admin role required", body = ErrorResponse),
-        (status = 409, description = "User with that email already exists", body = ErrorResponse),
-        (status = 500, description = "Failed to create user", body = ErrorResponse)
+        (status = 400, description = "Invalid request payload", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 403, description = "Admin role required", body = ProblemDetails),
+        (status = 409, description = "User with that email already exists", body = ProblemDetails),
+        (status = 500, description = "Failed to create user", body = ProblemDetails)
     ),
     tag = "Users",
     security(
@@ -150,10 +151,10 @@ async fn create_user(
     ),
     responses(
         (status = 204, description = "User deleted"),
-        (status = 400, description = "Invalid user identifier", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 403, description = "Admin role required", body = ErrorResponse),
-        (status = 500, description = "Failed to delete user", body = ErrorResponse)
+        (status = 400, description = "Invalid user identifier", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 403, description = "Admin role required", body = ProblemDetails),
+        (status = 500, description = "Failed to delete user", body = ProblemDetails)
     ),
     tag = "Users",
     security(

--- a/backend/src/resources/user/service.rs
+++ b/backend/src/resources/user/service.rs
@@ -29,8 +29,8 @@ impl<R: UserRepository, T: TeamRepository> UserService<R, T> {
         self.repo.get_users(pagination).await
     }
 
-    pub async fn count_users(&self) -> Result<u64, AppError> {
-        self.repo.count_users().await
+    pub async fn count_users(&self, query: ListQuery) -> Result<u64, AppError> {
+        self.repo.count_users(query).await
     }
 
     pub async fn get_user(&self, id: &str) -> Result<User, AppError> {
@@ -158,7 +158,7 @@ mod tests {
             unreachable!("not used in these tests")
         }
 
-        async fn count_users(&self) -> Result<u64, AppError> {
+        async fn count_users(&self, _query: ListQuery) -> Result<u64, AppError> {
             unreachable!("not used in these tests")
         }
 

--- a/backend/src/resources/user/session/rest.rs
+++ b/backend/src/resources/user/session/rest.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use shared::api::ListQuery;
 
 #[allow(unused_imports)]
-use crate::docs::ErrorResponse;
+use crate::docs::ProblemDetails;
 use crate::error::AppError;
 use crate::resources::User;
 use crate::settings::CookieConfig;
@@ -19,15 +19,15 @@ use super::service::SessionServiceHandle;
     get,
     path = "/api/v1/users/me/sessions",
     params(
-        ("page" = Option<u32>, Query, description = "Page index, zero-based. Omit with `page_size` for full list."),
+        ("page" = Option<u32>, Query, description = "Zero-based page. With `page_size`, `X-Total-Count` is pre-pagination total (`list-pagination.md`)."),
         ("page_size" = Option<u32>, Query, description = "Items per page (1–500). Omit with `page` for full list."),
         ("q" = Option<String>, Query, description = "Reserved.")
     ),
     responses(
         (status = 200, description = "Returns active sessions for the current user. `X-Total-Count` is the total before paging.", body = [Session]),
-        (status = 400, description = "Invalid pagination parameters", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 500, description = "Failed to list sessions for current user", body = ErrorResponse)
+        (status = 400, description = "Invalid pagination parameters", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 500, description = "Failed to list sessions for current user", body = ProblemDetails)
     ),
     tag = "Users",
     security(
@@ -63,9 +63,9 @@ pub async fn get_sessions_for_current_user(
     ),
     responses(
         (status = 200, description = "Returns a session for the current user", body = Session),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 404, description = "Session not found for current user", body = ErrorResponse),
-        (status = 500, description = "Failed to fetch session", body = ErrorResponse)
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 404, description = "Session not found for current user", body = ProblemDetails),
+        (status = 500, description = "Failed to fetch session", body = ProblemDetails)
     ),
     tag = "Users",
     security(
@@ -90,9 +90,9 @@ pub async fn get_session_for_current_user(
     ),
     responses(
         (status = 204, description = "Session deleted"),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 404, description = "Session not found for current user", body = ErrorResponse),
-        (status = 500, description = "Failed to delete session", body = ErrorResponse)
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 404, description = "Session not found for current user", body = ProblemDetails),
+        (status = 500, description = "Failed to delete session", body = ProblemDetails)
     ),
     tag = "Users",
     security(
@@ -118,9 +118,9 @@ pub async fn delete_session_for_current_user(
     ),
     responses(
         (status = 201, description = "Creates a session for the specified user", body = Session),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 403, description = "Admin role required", body = ErrorResponse),
-        (status = 500, description = "Failed to create session", body = ErrorResponse)
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 403, description = "Admin role required", body = ProblemDetails),
+        (status = 500, description = "Failed to create session", body = ProblemDetails)
     ),
     tag = "Users",
     security(
@@ -146,16 +146,16 @@ pub async fn create_session_for_user(
     path = "/api/v1/users/{user_id}/sessions",
     params(
         ("user_id" = String, Path, description = "User identifier"),
-        ("page" = Option<u32>, Query, description = "Page index, zero-based. Omit with `page_size` for full list."),
+        ("page" = Option<u32>, Query, description = "Zero-based page. With `page_size`, `X-Total-Count` is pre-pagination total (`list-pagination.md`)."),
         ("page_size" = Option<u32>, Query, description = "Items per page (1–500). Omit with `page` for full list."),
         ("q" = Option<String>, Query, description = "Reserved.")
     ),
     responses(
         (status = 200, description = "Returns active sessions for the specified user. `X-Total-Count` is the total before paging.", body = [Session]),
-        (status = 400, description = "Invalid pagination parameters", body = ErrorResponse),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 403, description = "Admin role required", body = ErrorResponse),
-        (status = 500, description = "Failed to list sessions", body = ErrorResponse)
+        (status = 400, description = "Invalid pagination parameters", body = ProblemDetails),
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 403, description = "Admin role required", body = ProblemDetails),
+        (status = 500, description = "Failed to list sessions", body = ProblemDetails)
     ),
     tag = "Users",
     security(
@@ -192,10 +192,10 @@ pub async fn get_sessions_for_user(
     ),
     responses(
         (status = 200, description = "Returns a session for the specified user", body = Session),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 403, description = "Admin role required", body = ErrorResponse),
-        (status = 404, description = "Session not found for specified user", body = ErrorResponse),
-        (status = 500, description = "Failed to fetch session", body = ErrorResponse)
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 403, description = "Admin role required", body = ProblemDetails),
+        (status = 404, description = "Session not found for specified user", body = ProblemDetails),
+        (status = 500, description = "Failed to fetch session", body = ProblemDetails)
     ),
     tag = "Users",
     security(
@@ -220,10 +220,10 @@ pub async fn get_session_for_user(
     ),
     responses(
         (status = 204, description = "Session deleted"),
-        (status = 401, description = "Authentication required", body = ErrorResponse),
-        (status = 403, description = "Admin role required", body = ErrorResponse),
-        (status = 404, description = "Session not found for specified user", body = ErrorResponse),
-        (status = 500, description = "Failed to delete session", body = ErrorResponse)
+        (status = 401, description = "Authentication required", body = ProblemDetails),
+        (status = 403, description = "Admin role required", body = ProblemDetails),
+        (status = 404, description = "Session not found for specified user", body = ProblemDetails),
+        (status = 500, description = "Failed to delete session", body = ProblemDetails)
     ),
     tag = "Users",
     security(

--- a/backend/src/resources/user/session/service.rs
+++ b/backend/src/resources/user/session/service.rs
@@ -230,7 +230,7 @@ mod tests {
             unreachable!("not used in session tests")
         }
 
-        async fn count_users(&self) -> Result<u64, AppError> {
+        async fn count_users(&self, _query: ListQuery) -> Result<u64, AppError> {
             unreachable!("not used in session tests")
         }
 

--- a/backend/src/resources/user/surreal_repo.rs
+++ b/backend/src/resources/user/surreal_repo.rs
@@ -33,13 +33,33 @@ impl SurrealUserRepo {
 impl UserRepository for SurrealUserRepo {
     async fn get_users(&self, pagination: ListQuery) -> Result<Vec<User>, AppError> {
         let (offset, limit) = pagination.effective_offset_limit();
-        let mut response = self
-            .inner()
-            .db
-            .query("SELECT * FROM user LIMIT $limit START $start")
-            .bind(("limit", limit))
-            .bind(("start", offset))
-            .await?;
+        let needle = pagination.q.as_ref().and_then(|s| {
+            let t = s.trim();
+            if t.is_empty() {
+                None
+            } else {
+                Some(t.to_lowercase())
+            }
+        });
+        let mut response = if let Some(needle) = needle {
+            self.inner()
+                .db
+                .query(
+                    "SELECT * FROM user WHERE string::contains(string::lowercase(email), $needle) \
+                     LIMIT $limit START $start",
+                )
+                .bind(("needle", needle))
+                .bind(("limit", limit))
+                .bind(("start", offset))
+                .await?
+        } else {
+            self.inner()
+                .db
+                .query("SELECT * FROM user LIMIT $limit START $start")
+                .bind(("limit", limit))
+                .bind(("start", offset))
+                .await?
+        };
         Ok(response
             .take::<Vec<UserRecord>>(0)?
             .into_iter()
@@ -47,16 +67,33 @@ impl UserRepository for SurrealUserRepo {
             .collect())
     }
 
-    async fn count_users(&self) -> Result<u64, AppError> {
+    async fn count_users(&self, query: ListQuery) -> Result<u64, AppError> {
         #[derive(Deserialize)]
         struct CountResult {
             count: u64,
         }
-        let mut response = self
-            .inner()
-            .db
-            .query("SELECT count() FROM user GROUP ALL")
-            .await?;
+        let needle = query.q.as_ref().and_then(|s| {
+            let t = s.trim();
+            if t.is_empty() {
+                None
+            } else {
+                Some(t.to_lowercase())
+            }
+        });
+        let mut response = if let Some(needle) = needle {
+            self.inner()
+                .db
+                .query(
+                    "SELECT count() FROM user WHERE string::contains(string::lowercase(email), $needle) GROUP ALL",
+                )
+                .bind(("needle", needle))
+                .await?
+        } else {
+            self.inner()
+                .db
+                .query("SELECT count() FROM user GROUP ALL")
+                .await?
+        };
         Ok(response
             .take::<Vec<CountResult>>(0)?
             .into_iter()
@@ -118,6 +155,18 @@ impl UserRepository for SurrealUserRepo {
                 "collection",
                 Thing::from(("collection".to_owned(), collection_id.to_owned())),
             ))
+            .await?;
+        Ok(())
+    }
+}
+
+impl SurrealUserRepo {
+    pub async fn clear_default_collection(&self, user_id: &str) -> Result<(), AppError> {
+        let _ = self
+            .inner()
+            .db
+            .query("UPDATE $user SET default_collection = NONE")
+            .bind(("user", Thing::from(("user".to_owned(), user_id.to_owned()))))
             .await?;
         Ok(())
     }

--- a/backend/src/settings.rs
+++ b/backend/src/settings.rs
@@ -13,6 +13,8 @@ pub struct OtpConfig {
     pub ttl_seconds: u64,
     pub pepper: String,
     pub max_attempts: u32,
+    /// When false, OTP verify rejects unknown emails instead of creating a user.
+    pub allow_self_signup: bool,
 }
 
 #[derive(Deserialize, Debug)]
@@ -28,6 +30,9 @@ pub struct Settings {
     pub otp_ttl_seconds: u64,
     pub otp_pepper: String,
     pub otp_max_attempts: u32,
+    /// When false, `/auth/otp/verify` requires an existing user (no implicit signup). Default true.
+    #[serde(default = "default_otp_allow_self_signup")]
+    pub otp_allow_self_signup: bool,
 
     pub db_address: String,
     pub db_namespace: String,
@@ -83,6 +88,7 @@ impl Default for Settings {
             otp_ttl_seconds: 300,
             otp_pepper: "changeme".into(),
             otp_max_attempts: 5,
+            otp_allow_self_signup: true,
             db_address: "mem://".into(),
             db_namespace: "app".into(),
             db_database: "app".into(),
@@ -112,9 +118,18 @@ impl Default for Settings {
     }
 }
 
+fn default_otp_allow_self_signup() -> bool {
+    true
+}
+
 impl Settings {
     pub fn from_env() -> Result<Self, envy::Error> {
-        envy::from_env::<Self>()
+        let mut s = envy::from_env::<Self>()?;
+        if let Ok(v) = std::env::var("WORSHIP_OTP_ALLOW_SELF_SIGNUP") {
+            s.otp_allow_self_signup =
+                !(v == "0" || v.eq_ignore_ascii_case("false") || v.eq_ignore_ascii_case("no"));
+        }
+        Ok(s)
     }
 
     pub fn cookie_config(&self) -> CookieConfig {
@@ -131,6 +146,7 @@ impl Settings {
             ttl_seconds: self.otp_ttl_seconds,
             pepper: self.otp_pepper.clone(),
             max_attempts: self.otp_max_attempts,
+            allow_self_signup: self.otp_allow_self_signup,
         }
     }
 }

--- a/backend/src/test_helpers.rs
+++ b/backend/src/test_helpers.rs
@@ -62,7 +62,7 @@ pub async fn create_song_with_title(
         data,
     };
     let svc = song_service(db);
-    let perms = UserPermissions::new(user, &svc.teams);
+    let perms = UserPermissions::from_ref(user, &svc.teams);
     Ok(svc.create_song_for_user(&perms, create).await?)
 }
 
@@ -112,7 +112,7 @@ pub fn song_service(db: &Arc<Database>) -> SongServiceHandle {
 pub fn setlist_service(db: &Arc<Database>) -> SetlistServiceHandle {
     SetlistService::new(
         SurrealSetlistRepo::new(db.clone()),
-        SurrealTeamResolver::new(db.clone()),
+        Arc::new(SurrealTeamResolver::new(db.clone())),
         db.clone(),
     )
 }

--- a/backend/tests/4_songs.yml
+++ b/backend/tests/4_songs.yml
@@ -1319,7 +1319,7 @@ testcases:
             }
           }
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 201
 
   # BLC: BLC-SONG-006
   - name: put-song-no-permission
@@ -1383,7 +1383,7 @@ testcases:
             }
           }
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 201
           - result.bodyjson.id ShouldEqual "new-song-id"
           - result.bodyjson.data.titles ShouldHaveLength 1
           - result.bodyjson.data.titles.titles0 ShouldEqual "Created By PUT"
@@ -1408,7 +1408,7 @@ testcases:
             }
           }
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 201
           - result.bodyjson.id ShouldEqual "new-song-by-write-user"
           - result.bodyjson.data.titles ShouldHaveLength 1
           - result.bodyjson.data.titles.titles0 ShouldEqual "Created By Write User Via PUT"
@@ -1433,7 +1433,7 @@ testcases:
             }
           }
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 201
           - result.bodyjson.owner ShouldEqual "{{.get-no-permission-personal-team.noperm_personal_team_id}}"
 
   # DELETE /api/v1/songs/{id} tests
@@ -1621,7 +1621,7 @@ testcases:
             }
           }
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 201
           - result.bodyjson.id ShouldEqual "cascade-song-delete"
         vars:
           songid:
@@ -1735,7 +1735,7 @@ testcases:
             }
           }
         assertions:
-          - result.statuscode ShouldEqual 200
+          - result.statuscode ShouldEqual 201
           - result.bodyjson.id ShouldEqual "{{.put-song-cascade-target.songid}}"
 
   # BLC: BLC-SONG-004

--- a/docs/business-logic-constraints/authentication.md
+++ b/docs/business-logic-constraints/authentication.md
@@ -10,3 +10,9 @@ Applies to routes under **`/api/v1`** that require an authenticated user session
 ## Relation to sessions
 
 Session lifecycle and **404**/**403** on **`/users/.../sessions`** are in [session.md](./session.md). **BLC-AUTH-002** applies when the token never identifies a session at all; after **BLC-SESS-008**/**BLC-SESS-009**, a once-valid token MAY also yield **401** on subsequent calls.
+
+## Email OTP
+
+- **BLC-AUTH-OTP-001:** **`POST /auth/otp/request`** stores a short-lived hashed code and sends it out-of-band. Per-IP rate limits apply (see server **`auth_rate_limit_*`** settings).
+- **BLC-AUTH-OTP-002:** **`POST /auth/otp/verify`** validates the code; after too many failures the code is invalidated (**429** / request a new code — see server **`otp_max_attempts`**).
+- **BLC-AUTH-OTP-003:** When **`WORSHIP_OTP_ALLOW_SELF_SIGNUP`** is unset or true, a successful verify MAY create a user for a previously unknown email (same as historical behavior). When **`WORSHIP_OTP_ALLOW_SELF_SIGNUP`** is **`false`**/**`0`**, verify succeeds only if the user already exists; otherwise **400** with a stable message (`invalid_request` / no self-signup).

--- a/docs/business-logic-constraints/http-contract.md
+++ b/docs/business-logic-constraints/http-contract.md
@@ -6,6 +6,10 @@ Rules that apply across several **`/api/v1`** resources (path validation, idempo
 
 - **BLC-HTTP-001:** WHEN a path segment that MUST match the API’s resource **id** format IS syntactically invalid THEN the API responds **400** (same class of validation as list query integers in **BLC-LP-004**; see [list-pagination.md](./list-pagination.md)).
 
+## Validation status codes
+
+- **BLC-HTTP-003:** The API does **not** use **422 Unprocessable Entity**. Invalid JSON, unknown fields (`deny_unknown_fields`), and other request validation failures are **400 Bad Request** with `application/problem+json`.
+
 ## Idempotent DELETE
 
 - **BLC-HTTP-002:** WHEN **DELETE** on a resource succeeds and the client issues the same **DELETE** again for that **id** THEN the API responds **404** (same pattern as **BLC-USER-014** for users).

--- a/docs/business-logic-constraints/list-pagination.md
+++ b/docs/business-logic-constraints/list-pagination.md
@@ -6,7 +6,7 @@ Applies to **GET** list routes that support paging: **`/users`** (admin), **`/bl
 
 - **BLC-LP-001:** **`page`** — 0-based index of the page.
 - **BLC-LP-002:** **`page_size`** — maximum number of items per page.
-- **BLC-LP-003:** **`q`** — optional search filter on **`/songs`**, **`/collections`**, and **`/setlists`** only (not on **`/users`** or **`/blobs`**). Collection and setlist lists match **title**; song list also matches **artists** and lyric text per the product's list-search rules (including stemming where applicable).
+- **BLC-LP-003:** **`q`** — optional search filter: **`/songs`** (full-text: titles, artists, lyrics per analyzer rules), **`/collections`** and **`/setlists`** (**title**), **`/users`** (admin list: **email** substring, case-insensitive), **`/blobs`** (**OCR** substring, case-insensitive). Whitespace-only **`q`** is treated as absent everywhere.
 
 ## Validation
 
@@ -22,4 +22,4 @@ Applies to **GET** list routes that support paging: **`/users`** (admin), **`/bl
 - **BLC-LP-008:** WHEN **`page`** IS beyond the last page THEN the API responds **200** with an **empty array** (not **404**).
 - **BLC-LP-009:** WHEN **`q`** IS combined with **`page`** / **`page_size`** THEN filtering runs first, then pagination over those results.
 
-All list responses include an **`X-Total-Count`** response header containing the total number of matching records (before pagination), allowing clients to calculate the total number of pages.
+**Track A (current):** All list responses include an **`X-Total-Count`** header: the **total number of matching records after filters and before pagination**. Clients detect the last page when the returned **`items.len() < page_size`** or the page is **empty** (including “beyond last page” pages).

--- a/docs/rest-api-review-closing-gaps-action-plan.md
+++ b/docs/rest-api-review-closing-gaps-action-plan.md
@@ -1,0 +1,260 @@
+# REST API — closing gaps (action plan)
+
+Date: 2026-04-18  
+Baseline: [rest-api-review.md](./rest-api-review.md) and follow-up work through PRs **#78–#81** (P0–P3).
+
+This document turns the **remaining** findings in the review into an ordered, implementable backlog. Items are grouped by theme, with **goal**, **scope**, **concrete steps**, **acceptance criteria**, and **primary touchpoints**.
+
+---
+
+## 0. Keep the review doc honest
+
+**Goal:** [rest-api-review.md](./rest-api-review.md) should not read like open P0/P1 bugs when those are fixed.
+
+**Steps**
+
+1. Add a short **“Status (2026-04)”** section at the top listing what #78–#81 resolved (IDOR, admin session scoping, Bearer-only auth, DELETE 204, pagination caps, Problem Details, etc.).
+2. Replace or annotate stale **code citations** (e.g. S1 snippet) with “fixed in #78” or point to current handlers.
+3. Refresh the **executive summary table (§1)** into “historical” vs “remaining” or move resolved rows to an appendix.
+
+**Acceptance:** A new reader can tell in one screen what is still actionable vs already shipped.
+
+---
+
+## 1. SPA fallback must not swallow API-shaped paths
+
+**Gap:** [rest-api-review.md §5.22](./rest-api-review.md) — unknown `GET` under the static scope can still return `index.html` for paths that look like API or auth URLs, depending on route registration order.
+
+**Goal:** Any request whose path starts with `/api/` or `/auth/` and is not handled by a dedicated route returns a **JSON 404** (or the appropriate API error shape), never the SPA shell.
+
+**Steps**
+
+1. In `backend/src/frontend.rs`, inside the `default_handler` / `spa_fallback` closure, inspect `http_req.path()` (or equivalent).
+2. If the path starts with `/api/` or `/auth/`, respond with `404` + `application/problem+json` (reuse `AppError::NotFound` or a small dedicated handler) instead of `index.html`.
+3. Add integration tests: e.g. `GET /api/v1/definitely/not/a/route` and `GET /auth/not-a-real-endpoint` expect JSON problem body, not HTML.
+
+**Acceptance:** No HTML `index.html` for those prefixes on unregistered paths; tests green.
+
+**Touchpoints:** `backend/src/frontend.rs`, `backend/src/http_tests.rs` or YAML HTTP tests.
+
+---
+
+## 2. Harmonize OpenAPI response matrices (403 / 422 / PATCH / PUT)
+
+**Gap:** [§4.3](./rest-api-review.md) — `PATCH`/`PUT` routes differ in documented status codes (`403`, `422`, `404`) across resources.
+
+**Goal:** One predictable matrix per method class (aligned with [§11](./rest-api-review.md)), reflected in `utoipa::path` for every `/api/v1` route.
+
+**Steps**
+
+1. Produce a **spreadsheet or table**: each route × documented statuses (401, 403, 404, 409, 422, 500, …).
+2. For each handler, compare **actual** `AppError` paths from the service layer with the OpenAPI block; add missing `(status = 403, …)` (and others) where the service can return them.
+3. Decide project-wide whether **422** is used for semantic validation failures vs **400**; if 422 is reserved for future use, document “not used” in BLCs and keep 400 only — but be **consistent**.
+4. Longer-term (optional in same epic): introduce a **`utoipa::Modify`** or small **macro** that injects common `(401, 403, 500)` + security for authenticated routes to avoid drift ([§5.12](./rest-api-review.md)).
+
+**Acceptance:** Swagger UI shows no route that can return `Forbidden` in code but omits 403 in the spec; PUT/PATCH matrices match §11 intent.
+
+**Touchpoints:** `backend/src/resources/**/rest.rs`, `backend/src/docs.rs`, relevant BLC markdown under `docs/business-logic-constraints/`.
+
+---
+
+## 3. PUT upsert: distinguish create vs update (201 vs 200)
+
+**Gap:** [§5.6 / S7](./rest-api-review.md) — `PUT` can create; OpenAPI and clients still see **200** only.
+
+**Goal:** When `update_song_for_user` (and any other upserting `PUT`) **creates** a resource, return **201 Created** with `Location` (or at least 201 without `Location` if Actix patterns make headers awkward); when updating, **200 OK**.
+
+**Steps**
+
+1. Audit all `PUT` handlers that delegate to “upsert” services (start with songs; repeat for collections/setlists/teams if applicable).
+2. Change service APIs to return an enum or `(Resource, UpsertOutcome)` so the REST layer can pick status.
+3. Update `utoipa::path` with `(status = 201, …)` and describe when it applies.
+4. Update HTTP tests and CLI/client expectations.
+
+**Acceptance:** BLC/tests that assert “PUT with new id creates” expect **201**; update paths expect **200**.
+
+**Touchpoints:** `backend/src/resources/song/service.rs`, `song/rest.rs`, parallel resources, `backend/tests/*.yml`, `shared/src/net/*`, `cli/`, `frontend/`.
+
+---
+
+## 4. Reduce handler boilerplate: `UserPermissions` extractor
+
+**Gap:** [§5.13](./rest-api-review.md) — every handler repeats `UserPermissions::new(&user, &svc.teams)`.
+
+**Goal:** A single `FromRequest` implementation (e.g. `ReqData<UserPerms>` or tuple extractor) used across resources.
+
+**Steps**
+
+1. Define an extractor type holding `User` + `UserPermissions` (or `&User` + `UserPermissions` with appropriate lifetimes — Actix typically uses owned `User` from `ReqData`).
+2. Implement `FromRequest` with the same error mapping as today (`401`/`403` as appropriate).
+3. Migrate handlers incrementally (one resource module per PR) to avoid a mega-diff.
+
+**Acceptance:** No new `UserPermissions::new` in migrated handlers; behavior unchanged in tests.
+
+**Touchpoints:** `backend/src/resources/common.rs` or new `backend/src/extractors.rs`, all `**/rest.rs` under `resources/`.
+
+---
+
+## 5. Input validation at the edge
+
+**Gap:** [§5.14](./rest-api-review.md) — DTOs lack max lengths, cardinality limits, and format checks until the database complains.
+
+**Goal:** Predictable **400** with stable problem codes for common violations (length, empty name, too many IDs in `CreateSong.blobs`, etc.).
+
+**Steps**
+
+1. Choose **one** approach: `validator` crate + `Validate` on DTOs, or hand-written `fn validate(&self) -> Result<(), AppError>` on request types.
+2. Start with high-risk fields called out in the review: team name (length already partially addressed), `CreateSong.blobs` max len, `UpdateTeam.members` max size, string trims.
+3. Centralize limits in constants shared with OpenAPI `description` text where useful.
+4. Add tests for oversize payloads and assert problem `code` / `detail` policy (human-readable but not leaky).
+
+**Acceptance:** Oversize/malformed bodies fail in the handler layer with **400** and never hit Surreal for trivial cases.
+
+**Touchpoints:** `shared/src/**` request DTOs, `backend/src/resources/**/rest.rs`, tests.
+
+---
+
+## 6. OpenAPI examples and discoverability
+
+**Gap:** [§9](./rest-api-review.md) — no examples; clients must guess shapes.
+
+**Goal:** At least **one request + one success response example** per major resource tag (`Songs`, `Collections`, …) in the generated OpenAPI.
+
+**Steps**
+
+1. Add `example` fields to key schemas in `backend/src/docs.rs` (or via `#[schema(example = …)]` on shared types).
+2. Use `utoipa` examples on `request_body` and primary `responses` for POST/PATCH where it matters most.
+3. Verify `openapi.json` validates in Swagger UI.
+
+**Acceptance:** Swagger UI shows copy-pastable examples for create song, patch song, list query, and one auth flow.
+
+**Touchpoints:** `backend/src/docs.rs`, selected `shared` types with `ToSchema`.
+
+---
+
+## 7. Conflict (`409`) and other messages — leak audit
+
+**Gap:** [§5.10](./rest-api-review.md) focused on Surreal **400** mapping; **`409 Conflict`** paths may still embed raw `dberr.to_string()` in some branches.
+
+**Goal:** Business conflicts return **safe, user-facing** `detail` strings; raw DB text only in logs.
+
+**Steps**
+
+1. Grep for `AppError::conflict`, `Conflict(`, and `409` paths; list all `detail` sources.
+2. Replace raw DB strings with short constants + log the full error server-side.
+3. Optionally add a dedicated problem `code` per conflict type (`duplicate_email`, `sole_admin`, …) if not already present.
+
+**Acceptance:** No conflict response includes table names, index names, or query fragments.
+
+**Touchpoints:** `backend/src/error.rs`, `From<surrealdb::Error>`, services returning `Conflict`.
+
+---
+
+## 8. Nested lists and pagination — polish
+
+**Status:** `X-Total-Count` and nested pagination landed in #80; [§4.6](./rest-api-review.md) still mentions **no JSON envelope** (`total`, `next` links).
+
+**Goal (choose one track):**
+
+- **Track A (minimal):** Document in OpenAPI that list endpoints use **`X-Total-Count`** and describe paging algebra; add BLC cross-links.
+- **Track B (richer):** Introduce a `Paginated<T> { items, total, page, page_size }` wrapper for selected list endpoints (breaking change — version or coordinate with clients).
+
+**Steps for Track A:** Update descriptions on all list operations; ensure CLI/frontend read `X-Total-Count` consistently.
+
+**Steps for Track B:** Design DTO in `shared`, migrate one resource, then roll out.
+
+**Acceptance:** No ambiguity for frontend authors on how to detect last page.
+
+**Touchpoints:** `shared/src/api/`, `backend/src/resources/**/rest.rs`, `frontend/`, `cli/`.
+
+---
+
+## 9. Downloads: `Content-Disposition` and export OpenAPI
+
+**Status:** Blob download gained `Content-Disposition` in #81; the review’s **export** routes (`pdf`/`zip`/…) may not exist in the current tree or may live outside the paths previously cited.
+
+**Goal:** Any byte-stream download (blob data, future exports) sets **`Content-Disposition: attachment`** where appropriate and documents **accurate** `content_type` in OpenAPI (not only `application/octet-stream` when the server sends `application/pdf`).
+
+**Steps**
+
+1. Inventory all handlers that return files or `Vec<u8>` bodies.
+2. For each, set response headers consistently and mirror them in `utoipa` (multiple `content` blocks or documented primary type).
+3. If export endpoints are **intentionally removed**, update BLCs and the review doc to say so.
+
+**Acceptance:** Swagger + real responses agree on content type for each format variant.
+
+**Touchpoints:** `backend/src/resources/blob/rest.rs`, any future export handlers, `docs.rs`.
+
+---
+
+## 10. OTP product semantics and documentation
+
+**Gap:** [§5.9 / S6](./rest-api-review.md) — lockout/rate limits improved in #78; **self-signup via OTP verify** and enumeration nuances may still need explicit product decisions.
+
+**Goal:** Behavior is **documented** in OpenAPI + user-facing docs: whether unknown emails can create users, whether OTP is login-only, etc.
+
+**Steps**
+
+1. Confirm intended product policy with stakeholders.
+2. If self-signup is unwanted, gate `get_user_by_email_or_create` behind config or separate “register” flow.
+3. Update `auth` OpenAPI descriptions and `docs/business-logic-constraints` for OTP.
+
+**Acceptance:** No “surprise” account creation paths; security review can sign off.
+
+**Touchpoints:** `backend/src/auth/otp/rest.rs`, user service, BLC auth/OTP docs.
+
+---
+
+## 11. Operational hardening (from §10)
+
+**Goal:** Close non-HTTP but API-adjacent gaps called out in the review.
+
+**Steps**
+
+1. **Logger redaction:** Ensure `Logger` middleware does not print raw `Cookie` or `Authorization` ([§10](./rest-api-review.md)). Custom format or `tracing-actix-web` config.
+2. **Static dir path:** Resolve `static_dir` to an absolute path at startup and log it once ([§10](./rest-api-review.md)).
+3. **`initial_admin_user_test_session`:** Consider failing fast in “production-like” settings instead of only logging ([§10](./rest-api-review.md)).
+
+**Acceptance:** Ops checklist ticked; no secrets in default access logs.
+
+**Touchpoints:** `backend/src/main.rs`, `backend/src/settings.rs`, logging config.
+
+---
+
+## 12. Nice-to-have backlog (P3 remainder)
+
+Schedule after the items above unless they unblock a consumer:
+
+| Item | Ref | Notes |
+|------|-----|--------|
+| Structured filters beyond songs | §8 | Owner/tag/language patterns for other list endpoints |
+| `q` on `/users` and `/blobs` | §4.4 | Search semantics + indexes |
+| Resource ID canonical form in logs only | §4.7 | Already reject `table:id` at edge; ensure docs/BLC say “plain id only” |
+| `default_collection` stale pointer | §5.24 | Heal on write or lazy repair in `create_song` |
+| RFC 7807 `instance` URL | §5.11 | Populate `instance` with path + query |
+| Rate-limit `429` in OpenAPI for all auth routes | §5.16 | Docs parity with middleware |
+| CSRF posture | §6.7 | Document + optional custom header for cookie-authenticated writes |
+
+---
+
+## Suggested implementation order
+
+1. **§0** (doc refresh) — cheap, avoids confusion.  
+2. **§1** SPA guard — correctness + security hygiene.  
+3. **§7** conflict leak audit — quick security win.  
+4. **§2** OpenAPI matrices — improves every client.  
+5. **§3** PUT 201 — behavioral + contract change; coordinate versioning.  
+6. **§5** validation + **§6** examples — developer experience.  
+7. **§4** extractor — refactor once contracts stable.  
+8. **§8–§12** as product/ops priority dictates.
+
+---
+
+## Verification checklist (per PR)
+
+- [ ] `cargo test` / HTTP integration suite for affected routes  
+- [ ] Regenerate or snapshot `openapi.json` diff reviewed  
+- [ ] Frontend + CLI updated if status codes or envelopes change  
+- [ ] BLC markdown updated when behavior or error codes change  
+
+This plan can be split into GitHub issues by section (one issue per numbered section, §3 and §5 possibly split by resource).

--- a/docs/rest-api-review.md
+++ b/docs/rest-api-review.md
@@ -1,6 +1,16 @@
 # REST API Review — `worship_viewer` backend
 
-Date: 2026-04-17
+## Status (2026-04)
+
+Shipped in **#78–#81** (and small follow-ups): session **IDOR fix** and admin **`user_id` scoping**; **sanitized** DB validation errors; **`Bearer`-only** `Authorization`; **204** on all `DELETE`s; OTP **lockout** + **auth rate limits**; **Problem Details** (`application/problem+json`); **plain resource ids** at the HTTP edge (reject `table:id`); **pagination** caps and **`X-Total-Count`**; **nested list** paging; **`/songs/{id}/like`** singleton; **ETags** / conditional GETs; **song list** filters; **blob** `PUT …/data` and download headers; shared **team resolver** / permissions refactor (see codebase).
+
+**Export** routes (`/songs|collections|setlists/.../export`) are **not** exposed on the current HTTP API — see appendix **Exports**.
+
+Further work is tracked in [rest-api-review-closing-gaps-action-plan.md](./rest-api-review-closing-gaps-action-plan.md).
+
+---
+
+Date: 2026-04-17  
 Scope: the HTTP surface exposed by the `backend` crate
 (`/auth`, `/api/v1/*`, `/api/docs/*`, SPA fallback), as defined in:
 
@@ -27,24 +37,23 @@ Authentication is cleanly expressed as two tiers of middleware
 (`RequireUser`, `RequireAdmin`) and the ACL model (team-based, with lazy,
 cached permission resolution via `UserPermissions`) is elegant.
 
-That said, the surface has **several concrete inconsistencies and a few real
-correctness/security smells** that deserve attention. The most important ones:
+The table below is **historical** (pre-#78). Most rows were **addressed** in #78–#81; see **Status** above. Remaining polish is in [rest-api-review-closing-gaps-action-plan.md](./rest-api-review-closing-gaps-action-plan.md).
 
-| # | Severity | Issue | Location |
-|---|---|---|---|
-| S1 | **Security (IDOR)** | `DELETE /api/v1/users/me/sessions/{id}` does not scope by caller — any authenticated user can delete any other user's session by id. | `backend/src/resources/user/session/rest.rs:82` |
-| S2 | Medium | Admin `GET /users/{user_id}/sessions/{id}` and `DELETE /users/{user_id}/sessions/{id}` ignore the `user_id` path segment. | same file, lines 168, 196 |
-| S3 | Medium | 400 responses may leak SurrealDB-internal field/index/query strings to clients (`AppError::InvalidRequest(dberr.to_string())`). | `backend/src/error.rs:65–77` |
-| S4 | Medium | `Authorization` header is accepted **both** as a raw session id and as `Bearer <id>` — ambiguous and non-standard. | `backend/src/auth/bearer.rs` (via `authorization_bearer`) |
-| S5 | Medium | DELETE semantics are inconsistent: most resources return **200 + deleted body**, `DELETE /teams/{id}/invitations/{id}` returns **204 No Content**. | see §5.1 |
-| S6 | Medium | `POST /auth/otp/request` returns `204` and `POST /auth/otp/verify` can therefore be used to probe whether an email exists (auto-creates on verify instead of request). Email enumeration surface. | `backend/src/auth/otp/rest.rs` |
-| S7 | Low | PUT on resources is **upsert** (creates with caller's personal team as owner when the id is new). Never documented in OpenAPI, tested but surprising for clients. | `SongService::update_song_for_user`, tests `blc_song_018_*` |
-| S8 | Low | `body = Vec<u8>, content_type = "application/octet-stream"` for `/songs|setlists|collections/{id}/export` is wrong for `pdf`/`zip`/`wp`/`cp`. | `*/rest.rs` export routes |
-| S9 | Low | Likes resource is a URL smell: `PUT /songs/{id}/likes` on a singleton with a `{ liked: bool }` body. Should be `PUT`/`DELETE /songs/{id}/like` or a proper collection. | `song/rest.rs:310–352` |
-| S10 | Low | `page_size=0` meaning "no cap" is non-standard and undiscoverable; `page` is 0-based but also undocumented outside of BLCs. | `shared/src/api/list_query.rs`, `BLC-LP-006` |
+| # | Severity | Issue | Location | Resolution (high level) |
+|---|---|---|---|---|
+| S1 | **Security (IDOR)** | `DELETE …/me/sessions/{id}` did not scope by caller. | `user/session/rest.rs` | **Fixed #78:** `delete_session_for_user` + 204. |
+| S2 | Medium | Admin session GET/DELETE ignored `user_id`. | same | **Fixed #78:** paths use `user_id`. |
+| S3 | Medium | 400 could leak Surreal strings. | `error.rs` | **Fixed #79:** sanitize + log. |
+| S4 | Medium | Raw session id in `Authorization`. | `bearer.rs` | **Fixed #79:** `Bearer` only. |
+| S5 | Medium | Mixed DELETE 200 vs 204. | §5.1 | **Fixed #79:** 204 everywhere. |
+| S6 | Medium | OTP / enumeration / auto-signup. | `otp/rest.rs` | **Partial #78:** lockout + limits; **config/docs** in closing-gaps. |
+| S7 | Low | PUT upsert undocumented / status. | songs | **Docs + 201 on create** (closing-gaps). |
+| S8 | Low | Export OpenAPI content types. | (no export routes) | **N/A** until exports exist; see appendix. |
+| S9 | Low | `/likes` URL smell. | `song/rest.rs` | **Fixed #80:** `/like`. |
+| S10 | Low | `page_size=0`, undocumented paging. | `list_query` | **Fixed #79–#80:** validate + headers + docs. |
 
 The rest of this document discusses what is good, then drills into each class
-of issue with concrete references and recommended fixes.
+of issue with concrete references. Treat detailed §4–§7 recommendations as **design history** unless marked still open in the action plan.
 
 ---
 
@@ -66,9 +75,9 @@ of issue with concrete references and recommended fixes.
     (wrapped by RequireAdmin)
     GET|POST|DELETE "" and "/{id}"         Admin user CRUD
     GET|POST|DELETE "/{user_id}/sessions{/id?}"
-  /songs                                   CRUD + /player, /export, /likes
-  /collections                             CRUD + /player, /export, /songs
-  /setlists                                CRUD + /player, /export, /songs
+  /songs                                   CRUD + /player, /like
+  /collections                             CRUD + /player, /songs
+  /setlists                                CRUD + /player, /songs
   /blobs                                   CRUD + /{id}/data (binary download)
   /teams                                   CRUD (+ /{team_id}/invitations)
   /invitations/{id}/accept  POST           Accept invite
@@ -96,9 +105,7 @@ Counts: **~55** documented operations across **7** resource tags.
 - **Middleware is composable.** `RequireUser` sits on `/api/v1` and
   `RequireAdmin` is scoped further on admin routes via a nested
   `web::scope("")`. Clear, no ambiguity.
-- **Resource IDs are validated.** `resource_id(table, id)` both accepts plain
-  ids and the Surreal `table:id` form while rejecting wrong-table prefixes
-  (`resources/common.rs`). Good BLC-HTTP-001 enforcement.
+- **Resource IDs are validated.** At the HTTP edge, paths use **plain ids**; `table:id` is rejected (**#79**). `resource_id` still parses ids for queries (`resources/common.rs`).
 
 ### 3.2 HTTP semantics that are correct
 
@@ -296,98 +303,29 @@ atypical enough to warrant `204` with no body, or to be renamed as `POST
 /api/v1/.../{id}:delete` if you really want a body back. BLC-HTTP-002 says
 a second DELETE returns 404 — that is orthogonal and good.
 
-### 5.2 `DELETE /api/v1/users/me/sessions/{id}` is an IDOR (S1)
+### 5.2 `DELETE …/me/sessions/{id}` IDOR (S1) — **fixed #78**
 
-```82:88:backend/src/resources/user/session/rest.rs
-#[delete("/me/sessions/{id}")]
-pub async fn delete_session_for_current_user(
-    svc: Data<SessionServiceHandle>,
-    path: Path<SessionPath>,
-) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Ok().json(svc.delete_session(&path.id).await?))
-}
-```
+**Historical:** The handler called `delete_session` without scoping to the caller.
 
-There is no `ReqData<User>` parameter and no ownership check. Any
-authenticated user can call `DELETE /api/v1/users/me/sessions/<any-session-id>`
-and terminate another user's session — the only thing stopping total
-account take-over is that session ids are unguessable. **This should be
-`svc.delete_session_for_user(&path.id, &user.id)`** (mirror
-`get_session_for_user`, which is correct), and return `404` if the session
-does not belong to the caller.
+**Current:** `delete_session_for_current_user` in `backend/src/resources/user/session/rest.rs` uses `ReqData<User>`, `delete_session_for_user(&path.id, &user.id)`, and **204**.
 
-Compare with the correct sibling directly above it:
+### 5.3 Admin session routes ignored `user_id` (S2) — **fixed #78**
 
-```55:62:backend/src/resources/user/session/rest.rs
-pub async fn get_session_for_current_user(
-    svc: Data<SessionServiceHandle>,
-    user: ReqData<User>,
-    path: Path<SessionPath>,
-) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Ok().json(svc.get_session_for_user(&path.id, &user.id).await?))
-}
-```
+**Historical:** Admin GET/DELETE called `get_session` / `delete_session` without `user_id`.
 
-That is doing the right thing. The delete sibling is not.
+**Current:** Handlers use `get_session_for_user` / `delete_session_for_user` with `path.user_id`.
 
-### 5.3 Admin session routes ignore `user_id` (S2)
+### 5.4 `/songs/{id}/likes` URL shape (S9) — **fixed #80**
 
-```167:173:backend/src/resources/user/session/rest.rs
-#[get("/{user_id}/sessions/{id}")]
-pub async fn get_session_for_user(
-    svc: Data<SessionServiceHandle>,
-    path: Path<UserSessionPath>,
-) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Ok().json(svc.get_session(&path.id).await?))
-}
-```
+**Historical:** `/likes` with `{ liked: bool }` body.
 
-`UserSessionPath.user_id` is extracted and then `#[allow(dead_code)]`-ed. The
-`DELETE` sibling is the same. Either honor `user_id` (check that the returned
-session's `user.id` matches, else `404`), or drop the `user_id` segment and
-use `/api/v1/sessions/{id}` for admins — but don't pretend to scope.
+**Current:** `GET`/`PUT`/`DELETE` `/api/v1/songs/{id}/like` (singleton); see `song/rest.rs`.
 
-### 5.4 `/songs/{id}/likes` is not a collection
+### 5.5 Export endpoint OpenAPI (S8) — **N/A on current API**
 
-```310:352:backend/src/resources/song/rest.rs
-#[get("/{id}/likes")]    // body: LikeStatus
-#[put("/{id}/likes")]    // body: LikeStatus { liked: bool }
-```
+**Historical:** Review assumed export routes on songs/collections/setlists.
 
-Semantically this is a **flag** ("does the caller like this song?"), not a
-collection. Two cleaner options:
-
-- **Toggle via PUT/DELETE on a singleton:**
-  - `PUT  /api/v1/songs/{id}/like` → 204 (liked)
-  - `DELETE /api/v1/songs/{id}/like` → 204 (unliked)
-  - `GET  /api/v1/songs/{id}/like` → 200 or 404
-- **Promote `likes` to a real collection:**
-  - `GET  /api/v1/songs/{id}/likes` → who liked it (admin/self)
-  - `PUT  /api/v1/songs/{id}/likes/me` / `DELETE .../likes/me`
-
-The current shape is neither — it's `/likes` (plural, which suggests a
-collection) with a body `{ liked: bool }` (which suggests a singleton). Pick
-one.
-
-### 5.5 Export endpoint OpenAPI content-type
-
-```132:139:backend/src/resources/song/rest.rs
-(
-    status = 200,
-    description = "Download exported song file",
-    body = Vec<u8>,
-    content_type = "application/octet-stream"
-)
-```
-
-Same block in `collection/rest.rs` and `setlist/rest.rs`. In reality
-`format=pdf` returns `application/pdf`, `format=zip` `application/zip`, and
-`wp`/`cp` are text. `application/octet-stream` is misleading in the spec and
-forces clients to ignore the declared content-type and sniff their own. Use
-`utoipa` content-per-format or a union of `responses((status=200, ...,
-content_type = ...))`. Also document the `Content-Disposition: attachment;
-filename="..."` header if the server sets it (and if it doesn't, it should,
-for any `format != wp|cp`).
+**Current:** No such HTTP routes; see **Appendix: Exports**. If exports return, fix per-format OpenAPI and `Content-Disposition`.
 
 ### 5.6 `PUT` is upsert, secretly (S7)
 
@@ -886,3 +824,10 @@ careful pass can close. None of them require architectural change.
 Fixing P0 + P1 alone would put this API in a very strong position for
 external consumers, and the architecture you already have makes those fixes
 cheap and mechanical.
+
+---
+
+## Appendix: Exports (S8)
+
+There are **no** HTTP routes in this repo for `GET …/export?format=…` on songs, collections, or setlists. OpenAPI/content-type issues from the original review apply only if those endpoints are (re)introduced.
+

--- a/docs/worshipviewer-api-review.md
+++ b/docs/worshipviewer-api-review.md
@@ -1,0 +1,696 @@
+# Worship Viewer REST API — Design Review
+
+**Source:** `https://app.worshipviewer.com/api/docs/openapi.json`
+**Spec version:** OpenAPI 3.0.3 · API `1.0.0`
+**Scope:** Design, consistency, and best-practice review of the public contract. No live server traffic was made; findings are derived strictly from the OpenAPI document.
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [Scorecard](#2-scorecard)
+3. [What's Working Well](#3-whats-working-well)
+4. [Findings by Topic](#4-findings-by-topic)
+   1. [Resource & URL Design](#41-resource--url-design)
+   2. [Identifier & Reference Style (the `blobs` question)](#42-identifier--reference-style-the-blobs-question)
+   3. [Naming Conventions](#43-naming-conventions)
+   4. [Enums & Value Casing](#44-enums--value-casing)
+   5. [Error Model](#45-error-model)
+   6. [HTTP Status Coverage](#46-http-status-coverage)
+   7. [Conditional Requests / Concurrency](#47-conditional-requests--concurrency)
+   8. [Pagination](#48-pagination)
+   9. [Sorting & Filtering](#49-sorting--filtering)
+   10. [PATCH & Partial Update Semantics](#410-patch--partial-update-semantics)
+   11. [PUT / Create / Update Shapes](#411-put--create--update-shapes)
+   12. [Polymorphism (`PlayerItem`)](#412-polymorphism-playeritem)
+   13. [Reference vs Expansion Strategy](#413-reference-vs-expansion-strategy)
+   14. [Binary / Blob Handling](#414-binary--blob-handling)
+   15. [Auth Endpoints](#415-auth-endpoints)
+   16. [Security, CSRF, Rate Limits](#416-security-csrf-rate-limits)
+   17. [Dates, Numbers, Constraints](#417-dates-numbers-constraints)
+   18. [Domain Fields Without Documentation](#418-domain-fields-without-documentation)
+   19. [OpenAPI Hygiene](#419-openapi-hygiene)
+   20. [Missing / Asymmetric Operations](#420-missing--asymmetric-operations)
+5. [Prioritized Action List](#5-prioritized-action-list)
+6. [Appendix A — Schema Diffs (Illustrative)](#6-appendix-a--schema-diffs-illustrative)
+7. [Appendix B — Checklist Against Common Standards](#7-appendix-b--checklist-against-common-standards)
+
+---
+
+## 1. Executive Summary
+
+The Worship Viewer API is a **well-structured, versioned REST API** with clear resource boundaries, good pagination basics, ETag support for reads, and an explicit auth story. The spec is detailed enough that it could drive usable client generation today.
+
+However, several **cross-cutting consistency issues** reduce client quality and make the API harder to evolve:
+
+- **Two competing error schemas** (`ErrorResponse` and `ProblemDetails`) are used on different routes for the same error class.
+- **Enum casing styles disagree** across the spec (UPPERCASE, PascalCase, snake_case, lowercase).
+- **Reference strategy is mixed**: some relations embed full objects, some use `{id, …}` links, some use bare ID strings.
+- **ETag is read-only**: no `If-Match` / `412 Precondition Failed` for writes, so optimistic concurrency is incomplete.
+- **Pagination rules differ by route** (defaults vs "omit for full list").
+- **Auth endpoint parameters look misdeclared** (`in: path` for `code`, `state`, `redirect_to`, `provider`).
+- **`PlayerItem` polymorphism** uses externally-tagged Rust-style JSON that is unfriendly for typical JSON consumers and OpenAPI codegen.
+
+None of these are fatal. Each has a conservative fix that can land in v1 without breaking clients, and a preferred fix that is best scheduled for v2.
+
+---
+
+## 2. Scorecard
+
+| Area | Grade | One-line summary |
+|------|:----:|------------------|
+| Resource modeling | B+ | Clear nouns, good sub-resources; a few asymmetric paths. |
+| Naming (keys) | B | Mostly snake_case; `PlayerItem` breaks it. |
+| Naming (enums) | C | Four different casing conventions coexist. |
+| Error model | C- | Two schemas, not actually served as `application/problem+json`. |
+| Status codes | B- | Good coverage, but 404/403/412 inconsistently declared. |
+| Pagination | B | Solid basics; semantics drift between endpoints. |
+| Filtering/Sorting | C | Only songs filter; custom sort tokens; no general pattern. |
+| Concurrency / ETag | C+ | Read-side only; no write-side `If-Match`. |
+| Polymorphism | C- | `oneOf` without discriminator; externally-tagged keys. |
+| Binary handling | B- | Two-step upload is fine; content types need tightening. |
+| Security scheme | B+ | Cookie + bearer declared; CSRF discussed. |
+| Docs quality | A- | Good prose intro; per-route descriptions are useful. |
+| Evolvability | B- | `additionalProperties: false` on inputs is good; some structural choices will bite v2. |
+
+---
+
+## 3. What's Working Well
+
+- **Versioned base path** (`/api/v1`) and explicit "auth lives at `/auth/*` and is unversioned" declaration. Removes a common source of ambiguity.
+- **Stable resource set** — `users`, `songs`, `collections`, `setlists`, `blobs`, `teams` — each with uniform CRUD.
+- **Conditional GET** via weak ETag + `If-None-Match` on singleton reads.
+- **Pagination skeleton**: `page`, `page_size`, `X-Total-Count` header — familiar, scales, avoids envelope churn.
+- **Security declaration** is explicit per-operation (cookie + bearer), and `CSRF` notes appear in the intro.
+- **`additionalProperties: false`** on all `Create*` / `Patch*` / `Update*` inputs — catches client typos at validation time, excellent choice.
+- **Documented three-state semantics** on `PatchSongData` (`Missing` / `Null` / `Value(v)`) — this is the single clearest piece of schema documentation in the spec, and it should be the template for the rest of the API.
+- **Separate input vs output types** for teams (`TeamUserRef` vs `TeamUser`, `TeamMemberInput` vs `TeamMember`) — correctly prevents clients from being forced to send server-owned fields.
+
+---
+
+## 4. Findings by Topic
+
+### 4.1 Resource & URL Design
+
+**Observations**
+
+- Plural nouns, `/collection/{id}/songs`, `/setlists/{id}/player`, `/songs/{id}/like` — standard REST.
+- Path parameter names drift: `{id}`, `{team_id}`, `{user_id}`, `{invitation_id}`. Functionally equivalent but inconsistent.
+- `/api/v1/invitations/{invitation_id}/accept` is a **top-level** invitation route, while invitations are otherwise modeled as a sub-resource of a team (`/teams/{team_id}/invitations/{invitation_id}`). The accept action therefore lives on a path the rest of the API does not otherwise expose.
+- `POST /api/v1/users/{user_id}/sessions` exists alongside `POST /auth/otp/verify` (which also creates a session). Two entry points for the same domain object.
+- `/users/me` and `/users/{id}` coexist — fine and idiomatic, though `/users/me/sessions` duplicates `/users/{user_id}/sessions` with a self shortcut.
+
+**Recommendations**
+
+- **Choose one path-parameter style**: either always `{id}` scoped by its position in the path, or always `{resource_id}`. The former is slightly more common in OpenAPI toolchains; the latter is friendlier when the same path has two IDs (see `/teams/{team_id}/invitations/{invitation_id}`).
+- **Make invitation acceptance symmetric** with the rest of invitations:
+  - Preferred: `POST /api/v1/teams/{team_id}/invitations/{invitation_id}/accept`.
+  - Or: introduce a top-level `/invitations/{id}` GET that returns the invitation resource so clients can fetch context before accepting.
+- Consider whether `POST /users/{user_id}/sessions` is still needed now that OTP is the documented flow; if it is admin impersonation, rename it explicitly (`/users/{user_id}/impersonation-sessions`).
+
+---
+
+### 4.2 Identifier & Reference Style (the `blobs` question)
+
+This is the specific question you raised: `Song.blobs: string[]` vs a nested object.
+
+**Today**
+
+- `Song.blobs: array<string>` — bare blob IDs.
+- `Collection.songs: array<SongLink>` where `SongLink = { id, key?, nr? }`.
+- `Setlist.songs: array<SongLink>`.
+- `Session.user: User` (full embed).
+- `Team.owner: TeamUser`, `Team.members: TeamMember[]` (partial embed).
+- `PlayerItem.Blob: string` (bare blob ID again, but PascalCase key).
+
+**Analysis — three options**
+
+| Option | Pros | Cons | When it's right |
+|--------|------|------|-----------------|
+| `string[]` of IDs | Smallest payload, cheapest encoding/decoding | Name doesn't signal "this is an ID", no room for per-link metadata, inconsistent with `SongLink` | Only when relation is **ordered list of pure foreign keys** and will stay that way |
+| `{ id: string }[]` (minimal ref object) | Matches `SongLink`; extensible without breaking change | Slightly more verbose JSON | When the relation **might** grow per-link attributes |
+| Full expanded `Blob[]` | Single round trip | Coupling: every song read fetches every blob metadata; write payloads get ambiguous | Only for small, read-heavy aggregates |
+
+**Recommendation**
+
+Pick one of the first two and **apply the same rule for every cross-resource reference**:
+
+- If you stay with bare IDs, **rename the property** so the contract is self-describing: `blob_ids: string[]`. Do the same for `PlayerItem`'s `Blob` variant (see §4.12).
+- If you want ever to attach per-blob metadata (page number, role, crop, alt text, display order, annotation overlay…), introduce **`BlobLink = { id: string }`** *now*. Adding `BlobLink.page` later is a non-breaking additive change; adding a field to a `string` is a breaking change.
+
+The larger point is **consistency of pattern**: today `Song → Blob` uses one shape and `Collection → Song` uses another. Clients and SDKs need one mental model ("every cross-resource link is an object with `id` plus optional link metadata") to generate clean code.
+
+A pragmatic resolution:
+
+- **v1 (additive):** keep `blobs: string[]`, rename the field in docs/schema to `blob_ids`, and ship a new `blob_links: BlobLink[]` as an optional, forward-compatible field.
+- **v2:** drop `blob_ids` in favor of `blob_links`.
+
+---
+
+### 4.3 Naming Conventions
+
+- JSON property names are **almost entirely snake_case** (`created_at`, `default_collection`, `not_a_song`, `file_type`) — this is the house style.
+- `PlayerItem` breaks the rule with **PascalCase** keys (`Blob`, `Chords`). This is the serialization signature of Rust `serde` externally-tagged enums; it should be translated at the API boundary.
+- `operationId`s are snake_case (`create_session_for_user`) — matches the rest.
+- Tag names are TitleCase (`Songs`, `Auth`) — also fine, tags are presentation-only.
+
+**Recommendation**
+
+Adopt one rule: *"All JSON object keys in request and response bodies are `snake_case`."* Encode it as a lint (Spectral's `oas3-schema` + a custom `camelCase`/`snake_case` rule) and run it in CI. `PlayerItem` is currently the only violator but future code gen will add more unless guarded.
+
+---
+
+### 4.4 Enums & Value Casing
+
+Current enum values:
+
+| Schema | Values | Style |
+|--------|--------|-------|
+| `FileType` | `PNG`, `JPEG`, `SVG` | UPPERCASE |
+| `Orientation` | `Portrait`, `Landscape` | PascalCase |
+| `ScrollType` | `OnePage`, `HalfPage`, `TwoPage`, `Book`, `TwoHalfPage` | PascalCase |
+| `Role` | `default`, `admin` | lowercase |
+| `TeamRole` | `guest`, `content_maintainer`, `admin` | snake_case |
+
+Four different conventions in one spec. Clients that want to model these as typed unions/enums must now codify five different formatters.
+
+**Recommendation**
+
+Standardize on **`lower_snake_case`** for enum values across the API (it matches JSON keys and is the least controversial choice). Examples:
+
+- `FileType`: `png`, `jpeg`, `svg`
+- `Orientation`: `portrait`, `landscape`
+- `ScrollType`: `one_page`, `half_page`, `two_page`, `book`, `two_half_page`
+
+If backward compatibility matters, accept both casings on input and emit the new casing on output, with a deprecation window.
+
+Bonus: `FileType` doubles as a MIME hint. Consider making it an actual MIME string (`image/png`, `image/jpeg`, `image/svg+xml`) — note the current `image/svg` is not a registered MIME type; the correct value is `image/svg+xml`.
+
+---
+
+### 4.5 Error Model
+
+The intro promises RFC 7807:
+
+> Error responses use `application/problem+json` (RFC 7807) with `type`, `title`, `status`, `detail`, and `code`.
+
+Reality in the spec:
+
+- Two schemas are defined:
+  - `ErrorResponse` — `{ code, error }` only.
+  - `ProblemDetails` — `{ type, title, status, detail, code, error, instance? }`.
+- **Most endpoints** (blobs, collections, setlists, teams, users, auth) declare `application/json` responses with `$ref: ErrorResponse`.
+- **Songs** and **player** endpoints declare `application/json` responses with `$ref: ProblemDetails`.
+- **No endpoint** declares `application/problem+json` as the response content type.
+
+Consequences:
+
+1. Clients cannot rely on a single decode path; SDKs end up modeling a union.
+2. Observability tooling that filters by MIME type sees everything as `application/json`, including problem documents — defeating one of RFC 7807's benefits.
+3. The `error` field in `ProblemDetails` is already marked "legacy alias" — shipping it in a fresh v1 locks in debt.
+
+**Recommendations**
+
+- **Single canonical error schema**: `ProblemDetails` (keep it), and drop `ErrorResponse` in favor of it. Or, if you truly want two shapes, define `ErrorResponse` as a strict projection and document precisely which routes use which.
+- **Serve problem documents as `application/problem+json`** on 4xx/5xx, and declare that content type in the spec.
+- **Registered `code` values**: expose an enum (or at minimum a documented list) of valid `code` strings so clients can switch on them safely.
+- Remove the `error` legacy alias or scope it to the one client that needs it with a sunset date.
+
+---
+
+### 4.6 HTTP Status Coverage
+
+**Representative gaps**
+
+- `PUT /api/v1/setlists/{id}` documents 200/400/401/500 but **not 404**, while the analogous collection and song endpoints do include 404.
+- Mutating endpoints (`PUT`, `PATCH`, `DELETE`) that touch resources owned by other users **should** document `403` (cross-user access denied). Many only have 401/404.
+- No endpoint documents `412 Precondition Failed`, despite ETag support (§4.7).
+- `POST` endpoints conflate schema-invalid bodies and domain-invalid bodies as `400`. Consider `422 Unprocessable Entity` for semantically valid JSON that violates business rules.
+- `500` is listed on almost every operation. That's realistic but noisy; some teams prefer to document it only on operations that can fail in a specific, actionable way.
+- `GET /api/v1/users/me` doesn't list `403` — fine — but it also doesn't list `404` for "no current user resource", which is technically possible for deleted-but-session-alive states.
+
+**Recommendation**
+
+Define a **response inclusion policy** and apply it uniformly:
+
+- Always list: `400` (or `422`), `401`, `403` (where the resource can be owned), `404` (where the resource is addressable), `409` (conflict / concurrency), `412` (if ETag-aware), `429` (if rate-limited).
+- `500` is optional but document it consistently (all or none).
+
+---
+
+### 4.7 Conditional Requests / Concurrency
+
+- Singleton `GET` operations document weak ETag + `If-None-Match` → 304. Good.
+- **No** write-side documentation of `If-Match` + `412 Precondition Failed`.
+
+Without `If-Match`, two clients editing the same song can silently clobber each other's changes (last-write-wins). For a collaborative worship tool where multiple team members may edit a setlist or song, this is worth closing.
+
+**Recommendation**
+
+- Document `If-Match` on `PUT`, `PATCH`, `DELETE` for all resources that expose an ETag.
+- Add `412 Precondition Failed` to those operations.
+- Add `428 Precondition Required` if you want to **enforce** clients to supply `If-Match` (optional, strict mode).
+- Strong or weak ETag is fine; be consistent.
+
+---
+
+### 4.8 Pagination
+
+- Common pattern: `page` (zero-based), `page_size` (1–500), `X-Total-Count` header.
+- **Inconsistency #1:** Some endpoints say "defaults to 0 / 50". Others say "omit `page` and `page_size` for full list". Those behaviors are fundamentally different and clients must choose which to assume.
+- **Inconsistency #2:** `page_size.minimum` is `0` in the schema but the description is `1–500`. Schema and prose disagree.
+- **Inconsistency #3:** Some list endpoints expose `q` as "Reserved; not used". Declaring unused parameters adds noise and tempts future undocumented behavior.
+- No `Link` header (RFC 5988) with `next`/`prev` URIs — clients must construct pages themselves.
+- No cursor pagination option — problematic for large exports or frequently mutated lists where offset pagination skips/duplicates rows.
+
+**Recommendations**
+
+- Pick one semantic: *"Pagination is always on; defaults are page=0, page_size=50."* Return a full list only via an explicit `all=true` or, better, never.
+- Fix `page_size.minimum` to `1` and add `maximum: 500`.
+- Remove `q` from endpoints that don't use it. Add it only when it does something.
+- Add `Link` headers (`rel="next"`, `rel="prev"`, `rel="first"`, `rel="last"`) — cheap to implement, standard to consume.
+- Consider cursor pagination (`cursor`, `next_cursor`) for `/songs` and `/setlists/{id}/songs`, which are the highest-cardinality lists.
+
+---
+
+### 4.9 Sorting & Filtering
+
+- Only `/api/v1/songs` supports `sort`, `lang`, `tag`.
+- `sort` uses custom tokens like `id_desc`, `title_asc`, `relevance`. Common alternatives:
+  - Single field with `-` prefix for descending: `sort=-id`, `sort=title`. (JSON:API flavor.)
+  - `sort` + `order`: `sort=id&order=desc`. (Classic.)
+  - Multi-field: `sort=-id,title`.
+- `tag` filter is documented as "case-insensitive substring match on stringified `data.tags`" — this **leaks the server's internal storage representation** into the public contract. If storage ever changes (say, `data.tags` becomes a typed object), this filter's behavior changes.
+- No sort/filter options on collections, setlists, teams, users.
+
+**Recommendations**
+
+- Define a single sort syntax for the whole API and apply it everywhere a list is sortable.
+- Rephrase `tag` filtering in terms of the domain, not the storage: e.g., "songs whose tag set contains a key/value where key equals `tag`".
+- Where filtering makes sense for other resources, add it (e.g., `collections?owner=<id>`, `setlists?owner=<id>`).
+
+---
+
+### 4.10 PATCH & Partial Update Semantics
+
+- `PatchSongData` documents the three-state merge semantics clearly — **this is excellent** and should be the model for every `Patch*`.
+- `PatchSong` itself has `required: ["data"]`. Forcing `data` to be present on a partial update is unusual — callers who only want to flip `not_a_song` must still include `data`.
+- The content type for PATCH is `application/json`, not `application/merge-patch+json` or `application/json-patch+json`. That is a valid choice, but it means the server is defining a custom merge format; document that format explicitly and link it from every `PATCH` route.
+
+**Recommendations**
+
+- Drop `required: ["data"]` from `PatchSong` (and audit the rest of the `Patch*` schemas for the same issue).
+- Either:
+  - Serve `application/merge-patch+json` and mention RFC 7396, or
+  - Keep `application/json` and publish one short section titled "How PATCH works" that defines: "fields absent → unchanged; fields set to `null` on nullable properties → cleared; all other fields → replaced wholesale".
+
+---
+
+### 4.11 PUT / Create / Update Shapes
+
+- Most resources reuse `Create<X>` for both `POST` (create) and `PUT` (replace). That's unusual but defensible if the two really are identical.
+- `Team` uses **three** types: `CreateTeam`, `UpdateTeam`, `PatchTeam`. Good when semantics differ; worth asking whether the gap is real.
+- `User` creation uses `CreateUserRequest` (suffix `Request`) — naming drift from every other `Create<X>`.
+- `PUT /api/v1/songs/{id}` documents upsert: *"if the id does not exist, creates the song"*. That is RFC-correct PUT behavior, but **no other resource documents this**, so clients cannot tell whether collections/setlists/blobs behave the same way.
+
+**Recommendations**
+
+- Rename `CreateUserRequest` → `CreateUser` for consistency.
+- Document upsert explicitly on every `PUT` that actually upserts, or explicitly deny upsert and return `404` when the `id` doesn't exist.
+- Consider whether `CreateTeam` and `UpdateTeam` can be unified; if not, add the same split to other resources whose create/update surface differs.
+
+---
+
+### 4.12 Polymorphism (`PlayerItem`)
+
+```json
+"PlayerItem": {
+  "oneOf": [
+    { "type": "object", "required": ["Blob"],   "properties": { "Blob":   { "type": "string" } } },
+    { "type": "object", "required": ["Chords"], "properties": { "Chords": { "$ref": "#/components/schemas/Song" } } }
+  ]
+}
+```
+
+Issues:
+
+1. **Externally-tagged** format — the variant name *is* the JSON key. This is Rust `serde` default; it's legal JSON but it means consumers have to probe for keys to discriminate.
+2. **PascalCase** keys break the rest of the API.
+3. **No `discriminator`** on the `oneOf` — OpenAPI code generators cannot produce clean typed unions.
+4. The `Blob` variant is a bare string — confusing because `Blob` is also a full schema elsewhere.
+
+**Recommended shape (internally-tagged with a discriminator):**
+
+```json
+"PlayerItem": {
+  "oneOf": [
+    { "$ref": "#/components/schemas/PlayerBlobItem" },
+    { "$ref": "#/components/schemas/PlayerChordsItem" }
+  ],
+  "discriminator": { "propertyName": "type", "mapping": {
+    "blob":   "#/components/schemas/PlayerBlobItem",
+    "chords": "#/components/schemas/PlayerChordsItem"
+  }}
+}
+
+"PlayerBlobItem":   { "type": "object", "required": ["type","blob_id"],
+                      "properties": { "type": { "const": "blob" }, "blob_id": { "type": "string" } } }
+"PlayerChordsItem": { "type": "object", "required": ["type","song"],
+                      "properties": { "type": { "const": "chords" }, "song":    { "$ref": "#/components/schemas/Song" } } }
+```
+
+This is a breaking change for existing clients; schedule for v2 or run both during a transition.
+
+---
+
+### 4.13 Reference vs Expansion Strategy
+
+The spec mixes four strategies for cross-resource relationships:
+
+| Relationship | Strategy today |
+|---|---|
+| `Song.blobs` | Bare ID strings |
+| `Collection.songs`, `Setlist.songs` | `SongLink = { id, key?, nr? }` |
+| `Team.owner`, `Team.members[].user` | Expanded `TeamUser` |
+| `Session.user` | Full `User` |
+| `TeamInvitation.created_by` | `TeamUser` |
+| `PlayerItem.Blob` | Bare ID string (in PascalCase) |
+
+There are legitimate reasons for each choice, but the design is undiscoverable: a client cannot predict the shape of a new relationship without reading the schema.
+
+**Recommendation**
+
+Adopt one of these documented policies:
+
+- **Always-reference policy:** every relation is `{ id, …link-metadata }`. Use a query parameter `?expand=owner,members.user` when the client wants the embedded object.
+- **Size-based policy:** relations with $\leq N$ fields embed, larger ones reference. Document the N and the list of embedded types.
+
+Then migrate gradually. An `?expand=` mechanism is ideal because it leaves today's responses compatible.
+
+---
+
+### 4.14 Binary / Blob Handling
+
+- Two-step create: `POST /blobs` (metadata) → `PUT /blobs/{id}/data` (bytes). Clean, idempotent, cacheable.
+- `GET /blobs/{id}/data` returns `image/*`. Stated variants: `image/png`, `image/jpeg`, `image/svg` — the last one should be **`image/svg+xml`**.
+- `413 Payload Too Large` documented on upload. Good.
+- No `ETag`/`Last-Modified`/`Cache-Control` documented on the binary route — typical CDN wins are left on the table.
+- No `Range` / `206 Partial Content` — fine for images, but worth noting if you ever store large assets (PDF, audio).
+- No `Content-Length` expectation documented; no checksum (`Content-Digest`, RFC 9530) support.
+
+**Recommendations**
+
+- Fix `image/svg` → `image/svg+xml`.
+- Add `ETag` and `Cache-Control: private, max-age=…` guidance to the binary GET.
+- For upload robustness, accept `Content-Digest: sha-256=:…:` optionally and reject mismatches with `400`.
+- Consider a single-step upload via `multipart/form-data` as a convenience alternative.
+
+---
+
+### 4.15 Auth Endpoints
+
+- `/auth/callback` declares `code` and `state` as `in: path`.
+- `/auth/login` declares `redirect_to` and `provider` as `in: path`.
+
+OIDC implementations almost universally pass these as **query parameters**, and inspecting the routing shape of `/auth/callback` (no path segments for them) confirms they cannot be path parameters. Either:
+
+- The OpenAPI generator output is wrong, or
+- The API is implemented unconventionally.
+
+If the former (most likely), this is a spec bug that makes generated clients and mock servers diverge from reality.
+
+**Recommendation**
+
+- Change `in: path` → `in: query` for `code`, `state`, `redirect_to`, `provider`.
+- Mark `provider` with an enum of supported providers.
+- Document `redirect_to` validation (allow-list) — open redirectors are a classic auth bug.
+
+Also: `/auth/otp/verify` returns `200` with `Session` and is then supposed to set a cookie. Document the `Set-Cookie` header in the response (`headers:` section) so SDKs can treat it correctly.
+
+---
+
+### 4.16 Security, CSRF, Rate Limits
+
+- `SessionCookie` (apiKey in cookie) and `SessionToken` (apiKey in `Authorization` header). The latter is effectively bearer-style; using **`type: http, scheme: bearer`** is slightly more semantic and unlocks OpenAPI tooling (Swagger UI "Authorize" UX).
+- CSRF is discussed in prose. Consider defining a `CsrfToken` security scheme or explicitly marking which operations require a CSRF header when cookie auth is used.
+- `429` is documented on `/auth/login` and `/auth/otp/request`, but **not on any `/api/v1/*` operation**. If the API is rate-limited (it almost certainly is), document that uniformly plus `Retry-After` and `X-RateLimit-*` response headers.
+
+---
+
+### 4.17 Dates, Numbers, Constraints
+
+- `date-time` used consistently. **Document the timezone policy** ("all timestamps are UTC, rendered with `Z` suffix") so clients don't guess.
+- IDs are `type: string` with no `format`/`pattern`. Pick one (`uuid`, `ulid`, or an opaque printable subset) and declare it: `{ type: string, format: uuid }`. Helps codegen, validation, and fuzzing.
+- `tempo`: integer, no unit. Document "BPM, integer".
+- `time`: `integer[]`, undocumented — presumably time signature `[numerator, denominator]`. Either document that or upgrade to `{ numerator, denominator }`.
+- `languages`: `string[]` — document whether these are **BCP 47**, **ISO 639-1**, or free-form. Add `pattern` or `enum`.
+- `SongLink.key`: musical key, undocumented format. Document the grammar ("note (`A`-`G`), optional accidental (`#`/`b`), optional mode (`m`/`maj`/`min`)").
+- No `maxLength` on free-text fields (`title`, `ocr`, `copyright`, `subtitle`). Add sane caps — helps validation and protects against DoS.
+- No `maxItems` on arrays (`blobs`, `songs`, `members`). Same reasoning.
+
+---
+
+### 4.18 Domain Fields Without Documentation
+
+Beyond §4.17, several fields carry product-specific meaning that the spec does not explain:
+
+- `Song.not_a_song: boolean` — the name reads like a hack; the docs don't explain why a `/songs` resource has a "this isn't a song" flag.
+- `Song.data: object` — untyped. `PatchSongData` has much more structure; expose it as `SongData` for GET/POST so generated clients aren't stuck with `unknown`.
+- `Song.user_specific_addons: { liked: bool }` — good pattern but the name `user_specific_addons` is awkward. Consider `personalization` or inlining `liked` at the top level.
+- `Collection.cover: string` — blob ID? URL? Tell the reader.
+- `Player.scroll_type_cache_other_orientation` — leaking an internal cache concept to the public API. Consider computing it server-side and exposing a cleaner derived property, or dropping it.
+- `Player.between_items: bool` — meaning not documented.
+- `Blob.ocr: string` — OCR'd text from the blob image, presumably. Document explicitly; also consider whether it should be `string | null` (empty string vs no OCR yet).
+- `TocItem.nr: string` — song number? chapter number? Document.
+- `TocItem.id: string | null` — nullable because…? Document when it's null.
+- `User.request_count: int64` — exposing a usage counter on the public user object is unusual. Intentional?
+
+---
+
+### 4.19 OpenAPI Hygiene
+
+- No `info.contact`, no `info.termsOfService`. Nice-to-have.
+- `servers` has only `/`. Add staging/production if both are real.
+- The intro says *"See schema example fields on core DTOs in the components section"*, but the component schemas don't carry `example` / `examples`. Either add them or remove the promise.
+- No `externalDocs` per operation or tag.
+- Descriptions are generally good; a few operations have only a title ("Creates a new user") — add the interesting details (side effects, emitted events, idempotency).
+- **Spectral** (the community OpenAPI linter) would catch most of the issues in this review automatically; adding it to CI prevents regression.
+
+---
+
+### 4.20 Missing / Asymmetric Operations
+
+- **Invitation decline**: there is `.../accept` but no `.../decline`. Clients have to `DELETE` via a different path.
+- **Song likes discoverability**: you can like/unlike a song and check like status, but there is no `GET /users/me/liked-songs`. For UX, that's usually important.
+- **Team membership**: `POST /teams` and `PATCH /teams/{id}` can change the full membership list, but there is no `POST /teams/{id}/members` / `DELETE /teams/{id}/members/{user_id}` for single-member moves. "Replace-all" and "per-member" endpoints typically coexist.
+- **Bulk operations**: no `POST /songs/batch` or equivalent. Fine if not in scope, but worth a note.
+- **Export / download**: no "export all my data" endpoint — worth considering for GDPR-like requests.
+- **Search**: `q` is declared "Reserved" on several sub-resources; if search will never live there, remove the parameter; if it will, schedule it.
+
+---
+
+## 5. Prioritized Action List
+
+### Ship now (spec-only, no server changes)
+
+1. **Unify error handling**: pick `ProblemDetails` as the one schema, reference it from every 4xx/5xx, and change the content type to `application/problem+json`. Drop or deprecate `ErrorResponse`.
+2. **Fix auth parameter locations**: `in: path` → `in: query` for `code`, `state`, `redirect_to`, `provider`.
+3. **Fix `page_size.minimum`**: `0` → `1`. Add `maximum: 500`.
+4. **Fix MIME**: `image/svg` → `image/svg+xml`.
+5. **Drop the `required: ["data"]`** on `PatchSong` (and audit sibling `Patch*`).
+6. **Add missing responses**: `404` on `PUT /setlists/{id}`; audit every mutating endpoint for `403`, `412`, `409`.
+7. **Rename `CreateUserRequest` → `CreateUser`**.
+8. **Document domain fields**: `not_a_song`, `Player.between_items`, `Player.scroll_type_cache_other_orientation`, `TocItem.nr`, `SongLink.key`, units for `tempo`, format for `languages`.
+9. **Remove unused `q` parameters** from sub-resources that say "Reserved".
+10. **Add timezone / ID format documentation** in the intro.
+
+### Ship this quarter (minor breaking but scoped)
+
+11. **Expose `SongData`** as a real schema instead of `object`.
+12. **Standardize enum casing** on `lower_snake_case`; accept both old and new values on input; emit new on output.
+13. **Define and implement `If-Match` / `412 Precondition Failed`** on all mutating endpoints that support ETag.
+14. **Add `Link` pagination headers**; keep `X-Total-Count`.
+15. **Define one `sort` syntax** (recommend `sort=-id,title` style) and apply it everywhere.
+16. **Make invitation acceptance symmetric** (`POST /teams/{team_id}/invitations/{invitation_id}/accept`).
+17. **Add rate-limit documentation** (`429`, `Retry-After`, `X-RateLimit-*`) to `/api/v1/*`.
+18. **Add `ETag`, `Cache-Control` on blob `GET … /data`**.
+
+### Schedule for v2 (breaking)
+
+19. **Redesign `PlayerItem`** using internally-tagged `{ type, … }` + a `discriminator`.
+20. **Unify reference shapes** across the API with `{ id, … }` links; add `?expand=` for optional embedding. Migrate `Song.blobs` to `BlobLink[]`.
+21. **Drop `error` legacy alias** from `ProblemDetails`.
+22. **Drop `PascalCase` from `PlayerItem` and any other key** that doesn't follow `snake_case`.
+23. **Consolidate create/update types** (rename `CreateUserRequest`, unify `Create*`/`Update*` where semantics match).
+
+---
+
+## 6. Appendix A — Schema Diffs (Illustrative)
+
+### 6.1 `Song.blobs` → `Song.blob_links`
+
+**Before**
+
+```json
+"Song": {
+  "required": ["id","owner","not_a_song","blobs","data","user_specific_addons"],
+  "properties": {
+    "blobs": { "type": "array", "items": { "type": "string" } }
+  }
+}
+```
+
+**After (non-breaking additive)**
+
+```json
+"Song": {
+  "required": ["id","owner","not_a_song","blobs","data","user_specific_addons"],
+  "properties": {
+    "blobs":      { "type": "array", "items": { "type": "string" },
+                    "deprecated": true,
+                    "description": "Deprecated; use blob_links. Will be removed in v2." },
+    "blob_links": { "type": "array", "items": { "$ref": "#/components/schemas/BlobLink" } }
+  }
+},
+"BlobLink": {
+  "type": "object",
+  "required": ["id"],
+  "additionalProperties": false,
+  "properties": { "id": { "type": "string" } }
+}
+```
+
+### 6.2 Error envelope
+
+**Before (split)**
+
+```json
+"ErrorResponse":   { "required": ["code","error"],                 "properties": { "code":{}, "error":{} } }
+"ProblemDetails":  { "required": ["type","title","status","detail","code","error"], ... }
+```
+
+**After (single)**
+
+```json
+"Problem": {
+  "type": "object",
+  "required": ["type","title","status","code"],
+  "properties": {
+    "type":     { "type": "string", "format": "uri" },
+    "title":    { "type": "string" },
+    "status":   { "type": "integer", "minimum": 400, "maximum": 599 },
+    "code":     { "type": "string", "description": "Stable machine-readable code" },
+    "detail":   { "type": "string" },
+    "instance": { "type": "string", "format": "uri" }
+  },
+  "additionalProperties": true
+}
+```
+
+All error responses:
+
+```json
+"400": {
+  "description": "Validation failure",
+  "content": { "application/problem+json": { "schema": { "$ref": "#/components/schemas/Problem" } } }
+}
+```
+
+### 6.3 `PlayerItem`
+
+**Before**
+
+```json
+"PlayerItem": {
+  "oneOf": [
+    { "type": "object", "required": ["Blob"],   "properties": { "Blob":   { "type": "string" } } },
+    { "type": "object", "required": ["Chords"], "properties": { "Chords": { "$ref": "#/components/schemas/Song" } } }
+  ]
+}
+```
+
+**After**
+
+```json
+"PlayerItem": {
+  "oneOf": [
+    { "$ref": "#/components/schemas/PlayerBlobItem" },
+    { "$ref": "#/components/schemas/PlayerChordsItem" }
+  ],
+  "discriminator": {
+    "propertyName": "type",
+    "mapping": {
+      "blob":   "#/components/schemas/PlayerBlobItem",
+      "chords": "#/components/schemas/PlayerChordsItem"
+    }
+  }
+},
+"PlayerBlobItem": {
+  "type": "object",
+  "required": ["type","blob_id"],
+  "additionalProperties": false,
+  "properties": {
+    "type":    { "type": "string", "enum": ["blob"] },
+    "blob_id": { "type": "string" }
+  }
+},
+"PlayerChordsItem": {
+  "type": "object",
+  "required": ["type","song"],
+  "additionalProperties": false,
+  "properties": {
+    "type": { "type": "string", "enum": ["chords"] },
+    "song": { "$ref": "#/components/schemas/Song" }
+  }
+}
+```
+
+### 6.4 `page_size`
+
+**Before**
+
+```json
+{ "name": "page_size", "schema": { "type": "integer", "nullable": true, "minimum": 0 } }
+```
+
+**After**
+
+```json
+{ "name": "page_size",
+  "description": "Items per page. Must be 1–500. Defaults to 50.",
+  "schema": { "type": "integer", "nullable": true, "minimum": 1, "maximum": 500, "default": 50 } }
+```
+
+---
+
+## 7. Appendix B — Checklist Against Common Standards
+
+| Standard / Guideline | Status |
+|---|---|
+| OpenAPI 3.0.3 validity | ✅ Valid |
+| Consistent JSON property casing | ⚠️ Mostly snake_case; `PlayerItem` breaks |
+| Consistent enum value casing | ❌ Four styles |
+| Single error model | ❌ Two schemas in use |
+| RFC 7807 media type (`application/problem+json`) | ❌ Not served |
+| Stable error code catalog | ⚠️ Promised, not listed |
+| ETag + `If-None-Match` (reads) | ✅ On singletons |
+| ETag + `If-Match` + 412 (writes) | ❌ Missing |
+| 422 vs 400 distinction | ❌ All collapsed to 400 |
+| Pagination `Link` header (RFC 5988) | ❌ Missing |
+| Pagination consistency | ⚠️ Two semantics coexist |
+| Rate-limit headers / 429 on API | ❌ Auth only |
+| `Set-Cookie` modeled in responses | ❌ Not declared |
+| Binary caching headers | ❌ Not declared |
+| Correct MIME for SVG | ❌ `image/svg` → should be `image/svg+xml` |
+| `discriminator` on polymorphic unions | ❌ Missing on `PlayerItem` |
+| `additionalProperties: false` on inputs | ✅ |
+| `format` on IDs | ❌ All untyped strings |
+| Timezone policy documented | ❌ |
+| CI linting (Spectral or equivalent) | ❓ Not visible; recommend adding |
+
+---
+
+### TL;DR on the blobs question
+
+Bare `string[]` of IDs **is fine** if the relation is pure foreign keys. What *isn't* fine is using bare strings for `Song → Blob` while using `SongLink` objects for `Collection → Song` and full objects for `Session → User`. Either rename the field to `blob_ids` and keep it, or ship a `BlobLink = { id }` alongside and migrate. The consistency is the win; the specific shape is secondary.

--- a/shared/src/api/song_list_query.rs
+++ b/shared/src/api/song_list_query.rs
@@ -1,11 +1,25 @@
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "backend")]
+#[allow(unused_imports)]
+use serde_json::json;
+
 use super::ListQuery;
 
 /// Query parameters for `GET /api/v1/songs`: pagination plus optional sort and filters.
 ///
 /// Pagination fields mirror [`ListQuery`] (they are not `flatten`ed so `actix_web::Query`
 /// deserializes reliably from `application/x-www-form-urlencoded` query strings).
+#[cfg_attr(feature = "backend", derive(utoipa::ToSchema))]
+#[cfg_attr(
+    feature = "backend",
+    schema(example = json!({
+        "page": 0,
+        "page_size": 50,
+        "q": "grace",
+        "sort": "relevance"
+    }))
+)]
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct SongListQuery {
     pub page: Option<u32>,

--- a/shared/src/auth/otp.rs
+++ b/shared/src/auth/otp.rs
@@ -1,6 +1,14 @@
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "backend")]
+#[allow(unused_imports)]
+use serde_json::json;
+
 #[cfg_attr(feature = "backend", derive(utoipa::ToSchema))]
+#[cfg_attr(
+    feature = "backend",
+    schema(example = json!({ "email": "singer@example.com" }))
+)]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OtpRequest {
@@ -8,6 +16,10 @@ pub struct OtpRequest {
 }
 
 #[cfg_attr(feature = "backend", derive(utoipa::ToSchema))]
+#[cfg_attr(
+    feature = "backend",
+    schema(example = json!({ "email": "singer@example.com", "code": "123456" }))
+)]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OtpVerify {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod auth;
 pub mod blob;
+pub mod validation_limits;
 pub use patch::Patch;
 pub mod collection;
 pub mod error;

--- a/shared/src/song/song.rs
+++ b/shared/src/song/song.rs
@@ -7,6 +7,9 @@ use std::collections::BTreeMap;
 use std::convert::TryFrom;
 
 #[cfg(feature = "backend")]
+#[allow(unused_imports)]
+use serde_json::json;
+#[cfg(feature = "backend")]
 use utoipa::ToSchema;
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone)]
@@ -30,6 +33,14 @@ pub struct Song {
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "backend", derive(ToSchema))]
+#[cfg_attr(
+    feature = "backend",
+    schema(example = json!({
+        "not_a_song": false,
+        "blobs": [],
+        "data": { "titles": ["Example Hymn"], "sections": [] }
+    }))
+)]
 pub struct CreateSong {
     pub not_a_song: bool,
     pub blobs: Vec<String>,
@@ -41,6 +52,10 @@ pub struct CreateSong {
 #[derive(Deserialize, Debug, Default, PartialEq, Clone)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "backend", derive(ToSchema))]
+#[cfg_attr(
+    feature = "backend",
+    schema(example = json!({ "not_a_song": false }))
+)]
 pub struct PatchSong {
     pub not_a_song: Option<bool>,
     pub blobs: Option<Vec<String>>,
@@ -122,6 +137,17 @@ impl CreateSong {
     ) -> (String, String) {
         (&self.data).format_html_page(key, representation, language, scale)
     }
+
+    /// Reject oversized blob reference lists before hitting the service layer.
+    pub fn validate(&self) -> Result<(), String> {
+        use crate::validation_limits::MAX_BLOBS_PER_SONG;
+        if self.blobs.len() > MAX_BLOBS_PER_SONG {
+            return Err(format!(
+                "too many blob references (max {MAX_BLOBS_PER_SONG})"
+            ));
+        }
+        Ok(())
+    }
 }
 
 impl Song {
@@ -180,5 +206,19 @@ mod tests {
         assert_eq!(s.data.title(), "Hello");
         assert_eq!(s.data.artist(), "A");
         assert_eq!(s.data.language(), "en");
+    }
+
+    #[test]
+    fn create_song_validate_rejects_too_many_blobs() {
+        use crate::validation_limits::MAX_BLOBS_PER_SONG;
+        let mut s = CreateSong {
+            not_a_song: false,
+            blobs: vec![],
+            data: chordlib::types::Song::default(),
+        };
+        s.blobs = (0..=MAX_BLOBS_PER_SONG).map(|i| format!("b{i}")).collect();
+        assert!(s.validate().is_err());
+        s.blobs.pop();
+        assert!(s.validate().is_ok());
     }
 }

--- a/shared/src/team/team.rs
+++ b/shared/src/team/team.rs
@@ -90,3 +90,78 @@ pub struct PatchTeam {
     #[cfg_attr(feature = "backend", schema(value_type = Option<Vec<TeamMemberInput>>))]
     pub members: Patch<Vec<TeamMemberInput>>,
 }
+
+impl CreateTeam {
+    pub fn validate(&self) -> Result<(), String> {
+        use crate::validation_limits::{MAX_TEAM_MEMBER_INPUTS, MAX_TEAM_NAME_LEN};
+        let name = self.name.trim();
+        if name.is_empty() {
+            return Err("team name must not be empty".into());
+        }
+        if name.len() > MAX_TEAM_NAME_LEN {
+            return Err(format!(
+                "team name is too long (max {MAX_TEAM_NAME_LEN} characters)"
+            ));
+        }
+        if self.members.len() > MAX_TEAM_MEMBER_INPUTS {
+            return Err(format!(
+                "too many members in request (max {MAX_TEAM_MEMBER_INPUTS})"
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl UpdateTeam {
+    pub fn validate(&self) -> Result<(), String> {
+        use crate::validation_limits::{MAX_TEAM_MEMBER_INPUTS, MAX_TEAM_NAME_LEN};
+        let name = self.name.trim();
+        if name.is_empty() {
+            return Err("team name must not be empty".into());
+        }
+        if name.len() > MAX_TEAM_NAME_LEN {
+            return Err(format!(
+                "team name is too long (max {MAX_TEAM_NAME_LEN} characters)"
+            ));
+        }
+        if let Some(members) = &self.members {
+            if members.len() > MAX_TEAM_MEMBER_INPUTS {
+                return Err(format!(
+                    "too many members in request (max {MAX_TEAM_MEMBER_INPUTS})"
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod validate_tests {
+    use super::*;
+
+    #[test]
+    fn create_team_whitespace_name_fails() {
+        let t = CreateTeam {
+            name: "   \t".into(),
+            members: vec![],
+        };
+        assert!(t.validate().is_err());
+    }
+
+    #[test]
+    fn create_team_too_many_members_fails() {
+        use crate::validation_limits::MAX_TEAM_MEMBER_INPUTS;
+        let t = CreateTeam {
+            name: "Ok".into(),
+            members: (0..=MAX_TEAM_MEMBER_INPUTS)
+                .map(|i| TeamMemberInput {
+                    user: TeamUserRef {
+                        id: format!("u{i}"),
+                    },
+                    role: TeamRole::Guest,
+                })
+                .collect(),
+        };
+        assert!(t.validate().is_err());
+    }
+}

--- a/shared/src/user/session.rs
+++ b/shared/src/user/session.rs
@@ -3,9 +3,30 @@ use chrono::Duration;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "backend")]
+#[allow(unused_imports)]
+use serde_json::json;
+
 use super::User;
 
 #[cfg_attr(feature = "backend", derive(utoipa::ToSchema))]
+#[cfg_attr(
+    feature = "backend",
+    schema(example = json!({
+        "id": "550e8400-e29b-41d4-a716-446655440000",
+        "user": {
+            "id": "user-1",
+            "email": "singer@example.com",
+            "role": "default",
+            "default_collection": null,
+            "created_at": "2024-01-01T12:00:00Z",
+            "last_login_at": null,
+            "request_count": 0
+        },
+        "created_at": "2024-01-01T12:00:00Z",
+        "expires_at": "2025-01-01T12:00:00Z"
+    }))
+)]
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
 pub struct Session {
     pub id: String,

--- a/shared/src/validation_limits.rs
+++ b/shared/src/validation_limits.rs
@@ -1,0 +1,10 @@
+//! Shared numeric limits for API request bodies (see BLC / validation in handlers).
+
+/// Maximum length of a shared team name (trimmed), aligned with persistence and OpenAPI docs.
+pub const MAX_TEAM_NAME_LEN: usize = 256;
+
+/// Maximum blob id references attached to a single song on create/update.
+pub const MAX_BLOBS_PER_SONG: usize = 64;
+
+/// Maximum additional member entries in create/update team payloads (excluding the creating user).
+pub const MAX_TEAM_MEMBER_INPUTS: usize = 500;


### PR DESCRIPTION
## Summary
- Hardens the backend REST layer and resource handlers (permissions, conflicts, song PUT upsert semantics, ops-related behavior).
- Adds shared validation limits and DTO validation wiring; updates Venom song suite where needed.
- Refreshes REST API / BLC documentation and adds review artifacts.

## Commits
- `feat(backend): harden REST layer and resource handlers`
- `feat(shared): validation limits and REST contract documentation`

Made with [Cursor](https://cursor.com)