### PR TITLE
feat(api): Phase 2 HTTP contract (§11–§18)

### DIFF
--- a/backend/src/docs.rs
+++ b/backend/src/docs.rs
@@ -10,12 +10,13 @@ use crate::resources::{
     Blob, Collection, CreateBlob, CreateCollection, CreateSetlist, CreateSong, CreateUser, Session,
     Setlist, Song, User,
 };
-use shared::api::{SongListQuery, SongSort};
+use shared::api::SongListQuery;
 use shared::auth::otp::{OtpRequest, OtpVerify};
 use shared::blob::FileType;
 pub use shared::error::{ErrorResponse, Problem, ProblemDetails};
 use shared::like::LikeStatus;
 use shared::player::{Orientation, Player, PlayerItem, ScrollType, TocItem};
+use shared::song::SongDataSchema;
 use shared::song::{Link as SongLink, SongUserSpecificAddons};
 use shared::team::{
     CreateTeam, PatchTeam, Team, TeamInvitation, TeamMember, TeamMemberInput, TeamRole, TeamUser,
@@ -40,8 +41,9 @@ pub mod rest {
             **Timestamps:** All timestamps are UTC and use RFC 3339 with a `Z` suffix (e.g. `2026-04-18T12:00:00Z`).\n\n\
             **Identifiers:** Resource IDs are opaque printable strings returned by the API; treat them as opaque and do not parse their internal structure.\n\n\
             **JSON naming:** Object keys use `snake_case`. Enum wire values use the casing shown in each schema (broader enum casing standardization is planned).\n\n\
-            **Pagination:** List endpoints accept `page` (0-based) and `page_size` (1–500, default 50). Responses include `X-Total-Count` with the total matching rows before pagination. RFC 5988 `Link` headers for first/prev/next/last are planned (not emitted yet).\n\n\
-            **Errors:** Failed requests return `Content-Type: application/problem+json` ([RFC 7807](https://www.rfc-editor.org/rfc/rfc7807)) with a `Problem` body. Stable machine-readable `code` values include: `unauthorized`, `forbidden`, `not_found`, `invalid_request`, `invalid_page_size`, `conflict`, `too_many_requests`, `not_acceptable`, `internal`. Legacy schemas `ErrorResponse` and `ProblemDetails` remain listed for one release but are deprecated in favor of `Problem`.\n\n\
+            **Pagination:** List endpoints accept `page` (0-based) and `page_size` (1–500, default 50). Responses include `X-Total-Count` with the total matching rows before pagination and RFC 5988 `Link` headers (relations: first, prev, next, last) where applicable.\n\n\
+            **Rate limiting:** Versioned `/api/v1/*` routes use token-bucket limits per client IP (`Retry-After`, `X-RateLimit-*` on **429**; configurable via server settings).\n\n\
+            **Errors:** Failed requests return `Content-Type: application/problem+json` ([RFC 7807](https://www.rfc-editor.org/rfc/rfc7807)) with a `Problem` body. Stable machine-readable `code` values include: `unauthorized`, `forbidden`, `not_found`, `invalid_request`, `invalid_page_size`, `conflict`, `too_many_requests`, `not_acceptable`, `precondition_failed`, `internal`. Legacy schemas `ErrorResponse` and `ProblemDetails` remain listed for one release but are deprecated in favor of `Problem`.\n\n\
             **CSRF:** Cookie sessions use `SameSite=Lax`; state-changing methods are `POST`/`PUT`/`PATCH`/`DELETE` (not `GET`). Cross-site simple requests cannot mutate state via cookies under typical browser rules. Browser `fetch` from the SPA should use `credentials: 'same-origin'` (or include cookies only on same-site requests). API clients using bearer tokens should still avoid exposing tokens to third-party origins.\n\n\
             **Examples:** See schema `example` fields on core DTOs in the components section.",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT")
@@ -112,6 +114,7 @@ pub mod rest {
         crate::resources::team::invitation::rest::list_team_invitations,
         crate::resources::team::invitation::rest::get_team_invitation,
         crate::resources::team::invitation::rest::delete_team_invitation,
+        crate::resources::team::invitation::rest::accept_team_invitation_under_team,
         crate::resources::team::invitation::rest::accept_team_invitation
     ),
     components(
@@ -123,7 +126,6 @@ pub mod rest {
             OtpRequest,
             OtpVerify,
             SongListQuery,
-            SongSort,
             Problem,
             ErrorResponse,
             ProblemDetails,
@@ -131,6 +133,7 @@ pub mod rest {
             CreateSong,
             PatchSong,
             PatchSongData,
+            SongDataSchema,
             SongUserSpecificAddons,
             Collection,
             CreateCollection,

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -24,6 +24,8 @@ pub enum AppError {
     TooManyRequests(String),
     #[error("not acceptable: {0}")]
     NotAcceptable(String),
+    #[error("precondition failed")]
+    PreconditionFailed,
     #[error("internal error: {0}")]
     Internal(String),
 }
@@ -101,6 +103,10 @@ impl AppError {
     pub fn too_many_requests<T: Into<String>>(msg: T) -> Self {
         Self::TooManyRequests(msg.into())
     }
+
+    pub fn precondition_failed() -> Self {
+        Self::PreconditionFailed
+    }
 }
 
 /// Map [`shared::api::ListQuery::validate`] / [`shared::api::SongListQuery::validate`] failures to the right `AppError` (`invalid_page_size` vs `invalid_request`).
@@ -175,6 +181,7 @@ impl AppError {
             AppError::Conflict(_) => "conflict",
             AppError::TooManyRequests(_) => "too_many_requests",
             AppError::NotAcceptable(_) => "not_acceptable",
+            AppError::PreconditionFailed => "precondition_failed",
             AppError::Internal(_) => "internal",
         }
     }
@@ -189,6 +196,9 @@ impl AppError {
         }
         match self {
             AppError::NotAcceptable(msg) => msg.clone(),
+            AppError::PreconditionFailed => {
+                "If-Match does not match the current resource representation".to_owned()
+            }
             _ => self.to_string(),
         }
     }
@@ -203,6 +213,7 @@ fn http_status_title(status: u16) -> &'static str {
         406 => "Not Acceptable",
         409 => "Conflict",
         429 => "Too Many Requests",
+        412 => "Precondition Failed",
         500 => "Internal Server Error",
         _ => "Error",
     }
@@ -218,6 +229,7 @@ impl ResponseError for AppError {
             AppError::Conflict(_) => StatusCode::CONFLICT,
             AppError::TooManyRequests(_) => StatusCode::TOO_MANY_REQUESTS,
             AppError::NotAcceptable(_) => StatusCode::NOT_ACCEPTABLE,
+            AppError::PreconditionFailed => StatusCode::PRECONDITION_FAILED,
             AppError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }

--- a/backend/src/governor_peer.rs
+++ b/backend/src/governor_peer.rs
@@ -1,0 +1,34 @@
+//! [`actix_governor`] key extractor: rate-limit by peer IP when present, otherwise
+//! `127.0.0.1`. Test harness requests often omit `peer_addr`; without a fallback the
+//! default [`PeerIpKeyExtractor`] returns 500.
+
+use std::net::{IpAddr, Ipv4Addr};
+
+use actix_governor::KeyExtractor;
+use actix_web::dev::ServiceRequest;
+
+/// Same IPv6 /56 normalization as [`actix_governor::PeerIpKeyExtractor`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PeerOrFallbackIpKeyExtractor;
+
+fn normalize_ip_key(mut ip: IpAddr) -> IpAddr {
+    if let IpAddr::V6(ipv6) = ip {
+        let mut octets = ipv6.octets();
+        octets[7..16].fill(0);
+        ip = IpAddr::V6(octets.into());
+    }
+    ip
+}
+
+impl KeyExtractor for PeerOrFallbackIpKeyExtractor {
+    type Key = IpAddr;
+    type KeyExtractionError = actix_governor::SimpleKeyExtractionError<&'static str>;
+
+    fn extract(&self, req: &ServiceRequest) -> Result<Self::Key, Self::KeyExtractionError> {
+        let ip = req
+            .peer_addr()
+            .map(|s| normalize_ip_key(s.ip()))
+            .unwrap_or_else(|| IpAddr::V4(Ipv4Addr::LOCALHOST));
+        Ok(ip)
+    }
+}

--- a/backend/src/http_cache.rs
+++ b/backend/src/http_cache.rs
@@ -1,8 +1,10 @@
 //! Weak ETags and conditional GET helpers (P2 REST review).
 
 use actix_web::HttpRequest;
-use actix_web::http::header::IF_NONE_MATCH;
+use actix_web::http::header::{IF_MATCH, IF_NONE_MATCH};
 use ring::digest::{SHA256, digest};
+
+use crate::error::AppError;
 
 pub fn weak_etag_from_bytes(bytes: &[u8]) -> String {
     let d = digest(&SHA256, bytes);
@@ -37,4 +39,79 @@ pub fn if_none_match_matches(req: &HttpRequest, etag: &str) -> bool {
         }
     }
     false
+}
+
+/// Returns true when the request's `If-Match` includes `*`, or any listed value that matches
+/// `current_weak_etag` after weak ETag normalization.
+pub fn if_match_matches(req: &HttpRequest, current_weak_etag: &str) -> bool {
+    let Some(hdr) = req.headers().get(IF_MATCH) else {
+        return false;
+    };
+    let Ok(raw) = hdr.to_str() else {
+        return false;
+    };
+    let server = normalize_etag(current_weak_etag);
+    for part in raw.split(',') {
+        let client = normalize_etag(part);
+        if client == "*" {
+            return true;
+        }
+        if client == server {
+            return true;
+        }
+    }
+    false
+}
+
+/// When `If-Match` is absent, allows the request. When present, it must match `current_weak_etag`
+/// (same value as [`weak_etag_json`] on the current GET body) or the handler returns **412**.
+pub fn check_if_match(req: &HttpRequest, current_weak_etag: &str) -> Result<(), AppError> {
+    if !req.headers().contains_key(IF_MATCH) {
+        return Ok(());
+    }
+    if if_match_matches(req, current_weak_etag) {
+        Ok(())
+    } else {
+        Err(AppError::precondition_failed())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::AppError;
+    use actix_web::http::header::IF_MATCH;
+    use actix_web::test::TestRequest;
+
+    #[test]
+    fn check_if_match_allows_when_header_absent() {
+        let req = TestRequest::default().to_http_request();
+        assert!(check_if_match(&req, r#"W/\"abc\""#).is_ok());
+    }
+
+    #[test]
+    fn check_if_match_accepts_normalized_match() {
+        let etag = r#"W/\"7f8e9a\""#;
+        let req = TestRequest::default()
+            .insert_header((IF_MATCH, etag))
+            .to_http_request();
+        assert!(check_if_match(&req, etag).is_ok());
+    }
+
+    #[test]
+    fn check_if_match_star_accepts() {
+        let req = TestRequest::default()
+            .insert_header((IF_MATCH, "*"))
+            .to_http_request();
+        assert!(check_if_match(&req, r#"W/\"anything\""#).is_ok());
+    }
+
+    #[test]
+    fn check_if_match_rejects_stale() {
+        let req = TestRequest::default()
+            .insert_header((IF_MATCH, r#"W/\"old\""#))
+            .to_http_request();
+        let r = check_if_match(&req, r#"W/\"new\""#);
+        assert!(matches!(r, Err(AppError::PreconditionFailed)));
+    }
 }

--- a/backend/src/http_tests.rs
+++ b/backend/src/http_tests.rs
@@ -83,7 +83,7 @@ fn build_app(
         .app_data(cookie_cfg)
         .app_data(crate::error::json_config())
         .service(docs::rest::scope())
-        .service(resources::rest::scope(20 * 1024 * 1024))
+        .service(resources::rest::scope(20 * 1024 * 1024, 50, 200))
 }
 
 /// Create a session for `user` and return its raw ID (used as Bearer token).
@@ -1120,6 +1120,70 @@ mod song_patch_http {
             body["data"]["titles"][0].as_str().unwrap(),
             orig_title.as_str()
         );
+    }
+
+    /// POST → GET → PATCH → GET preserves `data` fields (Phase 2 `SongData` contract).
+    #[actix_web::test]
+    async fn song_data_round_trips_through_post_get_patch_get() {
+        let db = test_db().await.unwrap();
+        let user = create_user(&db, "song-rt-phase2@test.local").await.unwrap();
+        let token = create_session_token(&db, user.clone()).await.unwrap();
+
+        let app = test::init_service(build_app(db.clone())).await;
+
+        let create_json = r#"{
+            "not_a_song": false,
+            "blobs": [],
+            "data": {
+                "titles": ["RoundTrip"],
+                "subtitle": "sub",
+                "sections": [],
+                "tags": {"hymn_type": "common"}
+            }
+        }"#;
+
+        let post = test::TestRequest::post()
+            .uri("/api/v1/songs")
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .insert_header(("Content-Type", "application/json"))
+            .set_payload(create_json)
+            .to_request();
+        let resp = test::call_service(&app, post).await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let created: serde_json::Value = test::read_body_json(resp).await;
+        let id = created["id"].as_str().unwrap();
+
+        let get1 = test::TestRequest::get()
+            .uri(&format!("/api/v1/songs/{id}"))
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .to_request();
+        let resp = test::call_service(&app, get1).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let g1: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(g1["data"]["titles"][0], "RoundTrip");
+        assert_eq!(g1["data"]["subtitle"], "sub");
+        assert_eq!(g1["data"]["tags"]["hymn_type"], "common");
+
+        let patch = test::TestRequest::patch()
+            .uri(&format!("/api/v1/songs/{id}"))
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .insert_header(("Content-Type", "application/json"))
+            .set_payload(r#"{"data":{"titles":["RoundTrip","Second"]}}"#)
+            .to_request();
+        let resp = test::call_service(&app, patch).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let get2 = test::TestRequest::get()
+            .uri(&format!("/api/v1/songs/{id}"))
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .to_request();
+        let resp = test::call_service(&app, get2).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let g2: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(g2["data"]["titles"][0], "RoundTrip");
+        assert_eq!(g2["data"]["titles"][1], "Second");
+        assert_eq!(g2["data"]["subtitle"], "sub");
+        assert_eq!(g2["data"]["tags"]["hymn_type"], "common");
     }
 }
 

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -6,9 +6,11 @@ pub mod database;
 pub mod docs;
 pub mod error;
 pub mod frontend;
+pub mod governor_peer;
 pub mod http_cache;
 pub mod mail;
 pub mod request_id;
+pub mod request_link;
 pub mod resources;
 pub mod settings;
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -186,7 +186,11 @@ async fn main() -> AnyResult<()> {
                 settings.auth_rate_limit_burst,
             ))
             .service(docs::rest::scope())
-            .service(resources::rest::scope(settings.blob_upload_max_bytes))
+            .service(resources::rest::scope(
+                settings.blob_upload_max_bytes,
+                settings.api_rate_limit_rps,
+                settings.api_rate_limit_burst,
+            ))
             .service(frontend::rest::scope(&static_dir))
     })
     .bind((settings.host.clone(), settings.port))?

--- a/backend/src/request_link.rs
+++ b/backend/src/request_link.rs
@@ -1,0 +1,30 @@
+//! RFC 5988 `Link` helpers for paginated JSON list responses.
+
+use actix_web::HttpRequest;
+use actix_web::http::header;
+
+use shared::api::pagination_link_header;
+
+pub fn request_origin(req: &HttpRequest) -> String {
+    let c = req.connection_info();
+    format!("{}://{}", c.scheme(), c.host())
+}
+
+/// Build a `Link` `HeaderValue` for the current path and pagination state.
+pub fn list_link_header(
+    req: &HttpRequest,
+    query_for_page: impl Fn(u32) -> String,
+    current_page: u32,
+    page_size: u32,
+    total: u64,
+) -> header::HeaderValue {
+    let v = pagination_link_header(
+        &request_origin(req),
+        req.path(),
+        query_for_page,
+        current_page,
+        page_size,
+        total,
+    );
+    header::HeaderValue::from_str(&v).expect("RFC 5988 Link header ASCII")
+}

--- a/backend/src/resources/blob/rest.rs
+++ b/backend/src/resources/blob/rest.rs
@@ -7,7 +7,9 @@ use actix_web::{
 #[allow(unused_imports)]
 use crate::docs::Problem;
 use crate::error::AppError;
-use crate::http_cache::{if_none_match_matches, weak_etag_json};
+use crate::http_cache::{
+    check_if_match, if_none_match_matches, weak_etag_from_bytes, weak_etag_json,
+};
 use crate::resources::User;
 #[allow(unused_imports)]
 use crate::resources::blob::Blob;
@@ -15,7 +17,7 @@ use crate::resources::blob::CreateBlob;
 use crate::resources::blob::PatchBlob;
 use crate::resources::blob::service::BlobServiceHandle;
 use crate::resources::team::UserPermissions;
-use shared::api::ListQuery;
+use shared::api::{ListQuery, PAGE_SIZE_DEFAULT};
 
 pub fn scope(blob_upload_max_bytes: usize) -> Scope {
     web::scope("/blobs")
@@ -45,6 +47,7 @@ pub fn scope(blob_upload_max_bytes: usize) -> Scope {
         (status = 200, description = "Return all blobs. `X-Total-Count` matches the filtered total.", body = [Blob]),
         (status = 400, description = "Invalid pagination parameters", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to fetch blobs", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Blobs",
@@ -55,6 +58,7 @@ pub fn scope(blob_upload_max_bytes: usize) -> Scope {
 )]
 #[get("")]
 async fn get_blobs(
+    req: HttpRequest,
     svc: Data<BlobServiceHandle>,
     user: ReqData<User>,
     query: Query<ListQuery>,
@@ -64,12 +68,25 @@ async fn get_blobs(
         .validate()
         .map_err(crate::error::map_list_query_error)?;
     let perms = UserPermissions::from_ref(&user, &svc.teams);
+    let q_link = query.clone();
+    let page = query.page.unwrap_or(0);
+    let page_size = query.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
     let blobs = svc.list_blobs_for_user(&perms, query.clone()).await?;
     let total = svc.count_blobs_for_user(&perms, &query).await?;
     Ok(HttpResponse::Ok()
         .insert_header((
             header::HeaderName::from_static("x-total-count"),
             total.to_string(),
+        ))
+        .insert_header((
+            header::LINK,
+            crate::request_link::list_link_header(
+                &req,
+                |p| q_link.query_string_for_page(p),
+                page,
+                page_size,
+                total,
+            ),
         ))
         .json(blobs))
 }
@@ -85,6 +102,7 @@ async fn get_blobs(
         (status = 304, description = "Not modified"),
         (status = 400, description = "Invalid blob identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Blob not found", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to fetch blob", body = Problem, content_type = "application/problem+json")
     ),
@@ -122,6 +140,7 @@ async fn get_blob(
         (status = 201, description = "Create a new blob", body = Blob),
         (status = 400, description = "Invalid blob payload", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to create blob", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Blobs",
@@ -154,7 +173,9 @@ async fn create_blob(
         (status = 200, description = "Update an existing blob", body = Blob),
         (status = 400, description = "Invalid blob identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Blob not found", body = Problem, content_type = "application/problem+json"),
+        (status = 412, description = "`If-Match` does not match current weak ETag on blob metadata", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to update blob", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Blobs",
@@ -165,12 +186,17 @@ async fn create_blob(
 )]
 #[put("/{id}")]
 async fn update_blob(
+    req: HttpRequest,
     svc: Data<BlobServiceHandle>,
     user: ReqData<User>,
     id: PathParam<String>,
     payload: Json<CreateBlob>,
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::from_ref(&user, &svc.teams);
+    let id = id.into_inner();
+    let blob = svc.get_blob_for_user(&perms, &id).await?;
+    let etag = weak_etag_json(&blob).map_err(|e| AppError::Internal(e.to_string()))?;
+    check_if_match(&req, &etag)?;
     Ok(HttpResponse::Ok().json(
         svc.update_blob_for_user(&perms, &id, payload.into_inner())
             .await?,
@@ -188,7 +214,9 @@ async fn update_blob(
         (status = 200, description = "Partially update an existing blob", body = Blob),
         (status = 400, description = "Invalid blob identifier or payload", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Blob not found", body = Problem, content_type = "application/problem+json"),
+        (status = 412, description = "`If-Match` does not match current weak ETag on blob metadata", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to patch blob", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Blobs",
@@ -199,12 +227,17 @@ async fn update_blob(
 )]
 #[patch("/{id}")]
 async fn patch_blob(
+    req: HttpRequest,
     svc: Data<BlobServiceHandle>,
     user: ReqData<User>,
     id: PathParam<String>,
     payload: Json<PatchBlob>,
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::from_ref(&user, &svc.teams);
+    let id = id.into_inner();
+    let blob = svc.get_blob_for_user(&perms, &id).await?;
+    let etag = weak_etag_json(&blob).map_err(|e| AppError::Internal(e.to_string()))?;
+    check_if_match(&req, &etag)?;
     Ok(HttpResponse::Ok().json(
         svc.patch_blob_for_user(&perms, &id, payload.into_inner())
             .await?,
@@ -221,7 +254,9 @@ async fn patch_blob(
         (status = 204, description = "Blob deleted"),
         (status = 400, description = "Invalid blob identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Blob not found", body = Problem, content_type = "application/problem+json"),
+        (status = 412, description = "`If-Match` does not match current weak ETag on blob metadata", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to delete blob", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Blobs",
@@ -232,11 +267,16 @@ async fn patch_blob(
 )]
 #[delete("/{id}")]
 async fn delete_blob(
+    req: HttpRequest,
     svc: Data<BlobServiceHandle>,
     user: ReqData<User>,
     id: PathParam<String>,
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::from_ref(&user, &svc.teams);
+    let id = id.into_inner();
+    let blob = svc.get_blob_for_user(&perms, &id).await?;
+    let etag = weak_etag_json(&blob).map_err(|e| AppError::Internal(e.to_string()))?;
+    check_if_match(&req, &etag)?;
     svc.delete_blob_for_user(&perms, &id).await?;
     Ok(HttpResponse::NoContent().finish())
 }
@@ -257,6 +297,8 @@ async fn delete_blob(
         ),
         (status = 400, description = "Invalid blob identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
+        (status = 304, description = "Not modified (`If-None-Match` matches weak ETag of bytes)"),
         (status = 404, description = "Blob not found", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to download blob", body = Problem, content_type = "application/problem+json")
     ),
@@ -279,24 +321,34 @@ async fn download_blob_image(
     let filename = blob
         .file_name()
         .unwrap_or_else(|| format!("blob-{}", blob.id));
-    let mut res = file.into_response(&req);
-    res.headers_mut().insert(
-        header::CONTENT_TYPE,
-        header::HeaderValue::from_static(blob.file_type.mime()),
-    );
-    res.headers_mut().insert(
-        header::CONTENT_DISPOSITION,
-        header::HeaderValue::from_str(&format!(
-            "attachment; filename=\"{}\"",
-            filename.replace('\\', "\\\\").replace('"', "\\\"")
+    let path = file.path().to_path_buf();
+    let bytes = std::fs::read(&path).map_err(|e| AppError::Internal(e.to_string()))?;
+    let etag = weak_etag_from_bytes(&bytes);
+    if if_none_match_matches(&req, &etag) {
+        return Ok(HttpResponse::NotModified()
+            .insert_header((header::ETAG, etag))
+            .insert_header((
+                header::CACHE_CONTROL,
+                header::HeaderValue::from_static("private, max-age=3600, immutable"),
+            ))
+            .finish());
+    }
+    let ct = header::HeaderValue::from_static(blob.file_type.mime());
+    let cd = header::HeaderValue::from_str(&format!(
+        "attachment; filename=\"{}\"",
+        filename.replace('\\', "\\\\").replace('"', "\\\"")
+    ))
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+    Ok(HttpResponse::Ok()
+        .insert_header((header::ETAG, etag))
+        .insert_header((header::CONTENT_TYPE, ct))
+        .insert_header((header::CONTENT_DISPOSITION, cd))
+        .insert_header((
+            header::CACHE_CONTROL,
+            header::HeaderValue::from_static("private, max-age=3600, immutable"),
         ))
-        .map_err(|e| AppError::Internal(e.to_string()))?,
-    );
-    res.headers_mut().insert(
-        header::CACHE_CONTROL,
-        header::HeaderValue::from_static("private, max-age=3600, immutable"),
-    );
-    Ok(res)
+        .insert_header((header::CONTENT_LENGTH, bytes.len().to_string()))
+        .body(bytes))
 }
 
 #[utoipa::path(
@@ -314,7 +366,9 @@ async fn download_blob_image(
         (status = 204, description = "Blob content uploaded successfully"),
         (status = 400, description = "Invalid blob identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Blob not found or write access denied", body = Problem, content_type = "application/problem+json"),
+        (status = 412, description = "`If-Match` does not match current weak ETag on blob metadata", body = Problem, content_type = "application/problem+json"),
         (status = 413, description = "Payload too large", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to store blob content", body = Problem, content_type = "application/problem+json")
     ),
@@ -326,12 +380,17 @@ async fn download_blob_image(
 )]
 #[put("/{id}/data")]
 async fn upload_blob_data(
+    req: HttpRequest,
     svc: Data<BlobServiceHandle>,
     user: ReqData<User>,
     id: PathParam<String>,
     body: Bytes,
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::from_ref(&user, &svc.teams);
+    let id = id.into_inner();
+    let blob = svc.get_blob_for_user(&perms, &id).await?;
+    let etag = weak_etag_json(&blob).map_err(|e| AppError::Internal(e.to_string()))?;
+    check_if_match(&req, &etag)?;
     svc.upload_blob_data_for_user(&perms, &id, &body).await?;
     Ok(HttpResponse::NoContent().finish())
 }

--- a/backend/src/resources/collection/rest.rs
+++ b/backend/src/resources/collection/rest.rs
@@ -8,7 +8,7 @@ use crate::accept::accepts_worship_player_json;
 #[allow(unused_imports)]
 use crate::docs::Problem;
 use crate::error::AppError;
-use crate::http_cache::{if_none_match_matches, weak_etag_json};
+use crate::http_cache::{check_if_match, if_none_match_matches, weak_etag_json};
 use crate::resources::User;
 #[allow(unused_imports)]
 use crate::resources::collection::Collection;
@@ -18,7 +18,7 @@ use crate::resources::collection::service::CollectionServiceHandle;
 #[allow(unused_imports)]
 use crate::resources::song::Song;
 use crate::resources::team::UserPermissions;
-use shared::api::{ListQuery, PageQuery};
+use shared::api::{ListQuery, PAGE_SIZE_DEFAULT, PageQuery};
 #[allow(unused_imports)]
 use shared::player::Player;
 
@@ -46,6 +46,7 @@ pub fn scope() -> Scope {
         (status = 200, description = "Return all collections. `X-Total-Count` header contains the total number of matching collections.", body = [Collection]),
         (status = 400, description = "Invalid pagination parameters", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to fetch collections", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Collections",
@@ -56,6 +57,7 @@ pub fn scope() -> Scope {
 )]
 #[get("")]
 async fn get_collections(
+    req: HttpRequest,
     svc: Data<CollectionServiceHandle>,
     user: ReqData<User>,
     query: Query<ListQuery>,
@@ -66,6 +68,9 @@ async fn get_collections(
         .map_err(crate::error::map_list_query_error)?;
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let q_ref = query.q.clone();
+    let q_link = query.clone();
+    let page = query.page.unwrap_or(0);
+    let page_size = query.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
     let collections = svc.list_collections_for_user(&perms, query).await?;
     let total = svc
         .count_collections_for_user(&perms, q_ref.as_deref())
@@ -74,6 +79,16 @@ async fn get_collections(
         .insert_header((
             header::HeaderName::from_static("x-total-count"),
             total.to_string(),
+        ))
+        .insert_header((
+            header::LINK,
+            crate::request_link::list_link_header(
+                &req,
+                |p| q_link.query_string_for_page(p),
+                page,
+                page_size,
+                total,
+            ),
         ))
         .json(collections))
 }
@@ -89,6 +104,7 @@ async fn get_collections(
         (status = 304, description = "Not modified"),
         (status = 400, description = "Invalid collection identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Collection not found", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to fetch collection", body = Problem, content_type = "application/problem+json")
     ),
@@ -128,6 +144,7 @@ async fn get_collection(
         (status = 200, description = "Return player metadata for a collection", body = Player),
         (status = 400, description = "Invalid collection identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Collection not found", body = Problem, content_type = "application/problem+json"),
         (status = 406, description = "No supported representation in Accept header", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to fetch collection player data", body = Problem, content_type = "application/problem+json")
@@ -166,6 +183,7 @@ async fn get_collection_player(
         (status = 200, description = "Return the songs for a collection. `X-Total-Count` is the total before paging.", body = [Song]),
         (status = 400, description = "Invalid collection identifier or pagination", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Collection not found", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to fetch collection songs", body = Problem, content_type = "application/problem+json")
     ),
@@ -177,6 +195,7 @@ async fn get_collection_player(
 )]
 #[get("/{id}/songs")]
 async fn get_collection_songs(
+    req: HttpRequest,
     svc: Data<CollectionServiceHandle>,
     user: ReqData<User>,
     id: Path<String>,
@@ -187,6 +206,9 @@ async fn get_collection_songs(
         .validate()
         .map_err(crate::error::map_list_query_error)?;
     let perms = UserPermissions::from_ref(&user, &svc.teams);
+    let q_link = query.clone();
+    let page = query.page.unwrap_or(0);
+    let page_size = query.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
     let (songs, total) = svc
         .collection_songs_for_user(&perms, &id, query.as_list_query())
         .await?;
@@ -194,6 +216,16 @@ async fn get_collection_songs(
         .insert_header((
             header::HeaderName::from_static("x-total-count"),
             total.to_string(),
+        ))
+        .insert_header((
+            header::LINK,
+            crate::request_link::list_link_header(
+                &req,
+                |p| q_link.query_string_for_page(p),
+                page,
+                page_size,
+                total,
+            ),
         ))
         .json(songs))
 }
@@ -206,6 +238,7 @@ async fn get_collection_songs(
         (status = 201, description = "Create a new collection", body = Collection),
         (status = 400, description = "Invalid collection payload", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to create collection", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Collections",
@@ -238,7 +271,9 @@ async fn create_collection(
         (status = 200, description = "Update an existing collection", body = Collection),
         (status = 400, description = "Invalid collection identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Collection not found", body = Problem, content_type = "application/problem+json"),
+        (status = 412, description = "`If-Match` does not match current weak ETag", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to update collection", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Collections",
@@ -249,12 +284,17 @@ async fn create_collection(
 )]
 #[put("/{id}")]
 async fn update_collection(
+    req: HttpRequest,
     svc: Data<CollectionServiceHandle>,
     user: ReqData<User>,
     id: Path<String>,
     payload: Json<CreateCollection>,
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::from_ref(&user, &svc.teams);
+    let id = id.into_inner();
+    let collection = svc.get_collection_for_user(&perms, &id).await?;
+    let etag = weak_etag_json(&collection).map_err(|e| AppError::Internal(e.to_string()))?;
+    check_if_match(&req, &etag)?;
     Ok(HttpResponse::Ok().json(
         svc.update_collection_for_user(&perms, &id, payload.into_inner())
             .await?,
@@ -272,7 +312,9 @@ async fn update_collection(
         (status = 200, description = "Partially update an existing collection", body = Collection),
         (status = 400, description = "Invalid collection identifier or payload", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Collection not found", body = Problem, content_type = "application/problem+json"),
+        (status = 412, description = "`If-Match` does not match current weak ETag", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to patch collection", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Collections",
@@ -283,12 +325,17 @@ async fn update_collection(
 )]
 #[patch("/{id}")]
 async fn patch_collection(
+    req: HttpRequest,
     svc: Data<CollectionServiceHandle>,
     user: ReqData<User>,
     id: Path<String>,
     payload: Json<PatchCollection>,
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::from_ref(&user, &svc.teams);
+    let id = id.into_inner();
+    let collection = svc.get_collection_for_user(&perms, &id).await?;
+    let etag = weak_etag_json(&collection).map_err(|e| AppError::Internal(e.to_string()))?;
+    check_if_match(&req, &etag)?;
     Ok(HttpResponse::Ok().json(
         svc.patch_collection_for_user(&perms, &id, payload.into_inner())
             .await?,
@@ -305,7 +352,9 @@ async fn patch_collection(
         (status = 204, description = "Collection deleted"),
         (status = 400, description = "Invalid collection identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Collection not found", body = Problem, content_type = "application/problem+json"),
+        (status = 412, description = "`If-Match` does not match current weak ETag", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to delete collection", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Collections",
@@ -316,11 +365,16 @@ async fn patch_collection(
 )]
 #[delete("/{id}")]
 async fn delete_collection(
+    req: HttpRequest,
     svc: Data<CollectionServiceHandle>,
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::from_ref(&user, &svc.teams);
+    let id = id.into_inner();
+    let collection = svc.get_collection_for_user(&perms, &id).await?;
+    let etag = weak_etag_json(&collection).map_err(|e| AppError::Internal(e.to_string()))?;
+    check_if_match(&req, &etag)?;
     svc.delete_collection_for_user(&perms, &id).await?;
     Ok(HttpResponse::NoContent().finish())
 }

--- a/backend/src/resources/rest.rs
+++ b/backend/src/resources/rest.rs
@@ -1,9 +1,23 @@
 use super::{blob, collection, setlist, song, team, user};
 use crate::auth::middleware::RequireUser;
+use crate::governor_peer::PeerOrFallbackIpKeyExtractor;
+use actix_governor::{Governor, GovernorConfigBuilder};
 use actix_web::{dev::HttpServiceFactory, web};
 
-pub fn scope(blob_upload_max_bytes: usize) -> impl HttpServiceFactory {
+pub fn scope(
+    blob_upload_max_bytes: usize,
+    api_rate_limit_rps: u64,
+    api_rate_limit_burst: u32,
+) -> impl HttpServiceFactory {
+    let api_governor = GovernorConfigBuilder::default()
+        .requests_per_second(api_rate_limit_rps)
+        .burst_size(api_rate_limit_burst)
+        .key_extractor(PeerOrFallbackIpKeyExtractor)
+        .use_headers()
+        .finish()
+        .expect("API rate-limit configuration");
     web::scope("/api/v1")
+        .wrap(Governor::new(&api_governor))
         .wrap(RequireUser)
         .service(blob::rest::scope(blob_upload_max_bytes))
         .service(collection::rest::scope())

--- a/backend/src/resources/setlist/rest.rs
+++ b/backend/src/resources/setlist/rest.rs
@@ -8,7 +8,7 @@ use crate::accept::accepts_worship_player_json;
 #[allow(unused_imports)]
 use crate::docs::Problem;
 use crate::error::AppError;
-use crate::http_cache::{if_none_match_matches, weak_etag_json};
+use crate::http_cache::{check_if_match, if_none_match_matches, weak_etag_json};
 use crate::resources::User;
 use crate::resources::setlist::CreateSetlist;
 use crate::resources::setlist::PatchSetlist;
@@ -18,7 +18,7 @@ use crate::resources::setlist::SetlistServiceHandle;
 #[allow(unused_imports)]
 use crate::resources::song::Song;
 use crate::resources::team::UserPermissions;
-use shared::api::{ListQuery, PageQuery};
+use shared::api::{ListQuery, PAGE_SIZE_DEFAULT, PageQuery};
 #[allow(unused_imports)]
 use shared::player::Player;
 
@@ -46,6 +46,7 @@ pub fn scope() -> Scope {
         (status = 200, description = "Return all setlists. `X-Total-Count` header contains the total number of matching setlists.", body = [Setlist]),
         (status = 400, description = "Invalid pagination parameters", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to fetch setlists", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Setlists",
@@ -56,6 +57,7 @@ pub fn scope() -> Scope {
 )]
 #[get("")]
 async fn get_setlists(
+    req: HttpRequest,
     svc: Data<SetlistServiceHandle>,
     user: ReqData<User>,
     query: Query<ListQuery>,
@@ -66,6 +68,9 @@ async fn get_setlists(
         .map_err(crate::error::map_list_query_error)?;
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let q_ref = query.q.clone();
+    let q_link = query.clone();
+    let page = query.page.unwrap_or(0);
+    let page_size = query.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
     let setlists = svc.list_setlists_for_user(&perms, query).await?;
     let total = svc
         .count_setlists_for_user(&perms, q_ref.as_deref())
@@ -74,6 +79,16 @@ async fn get_setlists(
         .insert_header((
             header::HeaderName::from_static("x-total-count"),
             total.to_string(),
+        ))
+        .insert_header((
+            header::LINK,
+            crate::request_link::list_link_header(
+                &req,
+                |p| q_link.query_string_for_page(p),
+                page,
+                page_size,
+                total,
+            ),
         ))
         .json(setlists))
 }
@@ -89,6 +104,7 @@ async fn get_setlists(
         (status = 304, description = "Not modified"),
         (status = 400, description = "Invalid setlist identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Setlist not found", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to fetch setlist", body = Problem, content_type = "application/problem+json")
     ),
@@ -128,6 +144,7 @@ async fn get_setlist(
         (status = 200, description = "Return player metadata for a setlist", body = Player),
         (status = 400, description = "Invalid setlist identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Setlist not found", body = Problem, content_type = "application/problem+json"),
         (status = 406, description = "No supported representation in Accept header", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to fetch setlist player data", body = Problem, content_type = "application/problem+json")
@@ -166,6 +183,7 @@ async fn get_setlist_player(
         (status = 200, description = "Return the songs for a setlist. `X-Total-Count` is the total before paging.", body = [Song]),
         (status = 400, description = "Invalid setlist identifier or pagination", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Setlist not found", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to fetch setlist songs", body = Problem, content_type = "application/problem+json")
     ),
@@ -177,6 +195,7 @@ async fn get_setlist_player(
 )]
 #[get("/{id}/songs")]
 async fn get_setlist_songs(
+    req: HttpRequest,
     svc: Data<SetlistServiceHandle>,
     user: ReqData<User>,
     id: Path<String>,
@@ -187,6 +206,9 @@ async fn get_setlist_songs(
         .validate()
         .map_err(crate::error::map_list_query_error)?;
     let perms = UserPermissions::from_ref(&user, &svc.teams);
+    let q_link = query.clone();
+    let page = query.page.unwrap_or(0);
+    let page_size = query.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
     let (songs, total) = svc
         .setlist_songs_for_user(&perms, &id, query.as_list_query())
         .await?;
@@ -194,6 +216,16 @@ async fn get_setlist_songs(
         .insert_header((
             header::HeaderName::from_static("x-total-count"),
             total.to_string(),
+        ))
+        .insert_header((
+            header::LINK,
+            crate::request_link::list_link_header(
+                &req,
+                |p| q_link.query_string_for_page(p),
+                page,
+                page_size,
+                total,
+            ),
         ))
         .json(songs))
 }
@@ -206,6 +238,7 @@ async fn get_setlist_songs(
         (status = 201, description = "Create a new setlist", body = Setlist),
         (status = 400, description = "Invalid setlist payload", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to create setlist", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Setlists",
@@ -238,7 +271,9 @@ async fn create_setlist(
         (status = 200, description = "Update an existing setlist", body = Setlist),
         (status = 400, description = "Invalid setlist identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Setlist not found", body = Problem, content_type = "application/problem+json"),
+        (status = 412, description = "`If-Match` does not match current weak ETag", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to update setlist", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Setlists",
@@ -249,12 +284,17 @@ async fn create_setlist(
 )]
 #[put("/{id}")]
 async fn update_setlist(
+    req: HttpRequest,
     svc: Data<SetlistServiceHandle>,
     user: ReqData<User>,
     id: Path<String>,
     payload: Json<CreateSetlist>,
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::from_ref(&user, &svc.teams);
+    let id = id.into_inner();
+    let setlist = svc.get_setlist_for_user(&perms, &id).await?;
+    let etag = weak_etag_json(&setlist).map_err(|e| AppError::Internal(e.to_string()))?;
+    check_if_match(&req, &etag)?;
     Ok(HttpResponse::Ok().json(
         svc.update_setlist_for_user(&perms, &id, payload.into_inner())
             .await?,
@@ -272,7 +312,9 @@ async fn update_setlist(
         (status = 200, description = "Partially update an existing setlist", body = Setlist),
         (status = 400, description = "Invalid setlist identifier or payload", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Setlist not found", body = Problem, content_type = "application/problem+json"),
+        (status = 412, description = "`If-Match` does not match current weak ETag", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to patch setlist", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Setlists",
@@ -283,12 +325,17 @@ async fn update_setlist(
 )]
 #[patch("/{id}")]
 async fn patch_setlist(
+    req: HttpRequest,
     svc: Data<SetlistServiceHandle>,
     user: ReqData<User>,
     id: Path<String>,
     payload: Json<PatchSetlist>,
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::from_ref(&user, &svc.teams);
+    let id = id.into_inner();
+    let setlist = svc.get_setlist_for_user(&perms, &id).await?;
+    let etag = weak_etag_json(&setlist).map_err(|e| AppError::Internal(e.to_string()))?;
+    check_if_match(&req, &etag)?;
     Ok(HttpResponse::Ok().json(
         svc.patch_setlist_for_user(&perms, &id, payload.into_inner())
             .await?,
@@ -305,7 +352,9 @@ async fn patch_setlist(
         (status = 204, description = "Setlist deleted"),
         (status = 400, description = "Invalid setlist identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Setlist not found", body = Problem, content_type = "application/problem+json"),
+        (status = 412, description = "`If-Match` does not match current weak ETag", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to delete setlist", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Setlists",
@@ -316,11 +365,16 @@ async fn patch_setlist(
 )]
 #[delete("/{id}")]
 async fn delete_setlist(
+    req: HttpRequest,
     svc: Data<SetlistServiceHandle>,
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::from_ref(&user, &svc.teams);
+    let id = id.into_inner();
+    let setlist = svc.get_setlist_for_user(&perms, &id).await?;
+    let etag = weak_etag_json(&setlist).map_err(|e| AppError::Internal(e.to_string()))?;
+    check_if_match(&req, &etag)?;
     svc.delete_setlist_for_user(&perms, &id).await?;
     Ok(HttpResponse::NoContent().finish())
 }

--- a/backend/src/resources/song/rest.rs
+++ b/backend/src/resources/song/rest.rs
@@ -8,7 +8,7 @@ use crate::accept::accepts_worship_player_json;
 #[allow(unused_imports)]
 use crate::docs::Problem;
 use crate::error::AppError;
-use crate::http_cache::{if_none_match_matches, weak_etag_json};
+use crate::http_cache::{check_if_match, if_none_match_matches, weak_etag_json};
 use crate::resources::User;
 use crate::resources::song::CreateSong;
 use crate::resources::song::PatchSong;
@@ -17,7 +17,7 @@ use crate::resources::song::Song;
 use crate::resources::song::SongUpsertOutcome;
 use crate::resources::song::service::SongServiceHandle;
 use crate::resources::team::UserPermissions;
-use shared::api::SongListQuery;
+use shared::api::{PAGE_SIZE_DEFAULT, SongListQuery};
 #[allow(unused_imports)]
 use shared::player::Player;
 
@@ -42,7 +42,7 @@ pub fn scope() -> Scope {
         ("page" = Option<u32>, Query, description = "Zero-based page index (default 0). `X-Total-Count` is the total before pagination; the last page is when `items.len() < page_size` or the list is empty (see `docs/business-logic-constraints/list-pagination.md`).", minimum = 0, nullable = true),
         ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50.", minimum = 1, maximum = 500, example = 50, nullable = true),
         ("q" = Option<String>, Query, description = "Full-text search query (titles, artists, line lyrics); uses text_search analyzer (stemming)"),
-        ("sort" = Option<String>, Query, description = "Sort: `id_desc` (default without q), `id_asc`, `title_asc`, `title_desc`, `relevance` (default with q; requires q when set explicitly)"),
+        ("sort" = Option<String>, Query, description = "Sort: JSON:API-style comma-separated keys (`-` = descending), e.g. `-id`, `title`, `relevance` (with `q`). Legacy `id_desc` / … still accepted."),
         ("lang" = Option<String>, Query, description = "Filter: song must list this language in `data.languages`."),
         ("tag" = Option<String>, Query, description = "Filter: case-insensitive substring match on stringified `data.tags`.")
     ),
@@ -50,6 +50,7 @@ pub fn scope() -> Scope {
         (status = 200, description = "Return all songs. `X-Total-Count` header contains the total number of matching songs.", body = [Song]),
         (status = 400, description = "Invalid pagination or filter parameters", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to fetch songs", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Songs",
@@ -60,6 +61,7 @@ pub fn scope() -> Scope {
 )]
 #[get("")]
 async fn get_songs(
+    req: HttpRequest,
     svc: Data<SongServiceHandle>,
     user: ReqData<User>,
     query: Query<SongListQuery>,
@@ -71,10 +73,23 @@ async fn get_songs(
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let songs = svc.list_songs_for_user(&perms, query.clone()).await?;
     let total = svc.count_songs_for_user(&perms, &query).await?;
+    let page = query.page.unwrap_or(0);
+    let page_size = query.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
+    let q_for_link = query.clone();
     Ok(HttpResponse::Ok()
         .insert_header((
             header::HeaderName::from_static("x-total-count"),
             total.to_string(),
+        ))
+        .insert_header((
+            header::LINK,
+            crate::request_link::list_link_header(
+                &req,
+                |p| q_for_link.query_string_for_page(p),
+                page,
+                page_size,
+                total,
+            ),
         ))
         .json(songs))
 }
@@ -90,6 +105,7 @@ async fn get_songs(
         (status = 304, description = "Not modified (when `If-None-Match` matches the current ETag)"),
         (status = 400, description = "Invalid song identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Song not found", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to fetch song", body = Problem, content_type = "application/problem+json")
     ),
@@ -129,6 +145,7 @@ async fn get_song(
         (status = 200, description = "Return player metadata for a song (`Content-Type: application/json`). Send `Accept: application/json`, `application/vnd.worship.player+json`, or `*/*`.", body = Player),
         (status = 400, description = "Invalid song identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Song not found", body = Problem, content_type = "application/problem+json"),
         (status = 406, description = "No supported representation in Accept header", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to fetch song player data", body = Problem, content_type = "application/problem+json")
@@ -163,6 +180,7 @@ async fn get_song_player(
         (status = 201, description = "Create a new song. If the user has no default collection yet, the server may create a system \"Default\" collection and set it as `user.default_collection` (BLC-SONG-010).", body = Song),
         (status = 400, description = "Invalid song payload", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to create song", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Songs",
@@ -195,7 +213,9 @@ async fn create_song(
         (status = 201, description = "Created the song via PUT upsert (new id). Response includes `Location: /api/v1/songs/{id}`.", body = Song),
         (status = 400, description = "Invalid song identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Song not found", body = Problem, content_type = "application/problem+json"),
+        (status = 412, description = "`If-Match` does not match current weak ETag", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to update song", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Songs",
@@ -206,6 +226,7 @@ async fn create_song(
 )]
 #[put("/{id}")]
 async fn update_song(
+    req: HttpRequest,
     svc: Data<SongServiceHandle>,
     user: ReqData<User>,
     id: Path<String>,
@@ -214,6 +235,15 @@ async fn update_song(
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let payload = payload.into_inner();
     payload.validate().map_err(AppError::invalid_request)?;
+    let id = id.into_inner();
+    match svc.get_song_for_user(&perms, &id).await {
+        Ok(song) => {
+            let etag = weak_etag_json(&song).map_err(|e| AppError::Internal(e.to_string()))?;
+            check_if_match(&req, &etag)?;
+        }
+        Err(AppError::NotFound(_)) => {}
+        Err(e) => return Err(e),
+    }
     match svc.update_song_for_user(&perms, &id, payload).await? {
         SongUpsertOutcome::Created(song) => Ok(HttpResponse::Created()
             .insert_header((header::LOCATION, format!("/api/v1/songs/{}", song.id)))
@@ -233,7 +263,9 @@ async fn update_song(
         (status = 200, description = "Partially update an existing song", body = Song),
         (status = 400, description = "Invalid song identifier or payload", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Song not found", body = Problem, content_type = "application/problem+json"),
+        (status = 412, description = "`If-Match` does not match current weak ETag", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to patch song", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Songs",
@@ -244,12 +276,17 @@ async fn update_song(
 )]
 #[patch("/{id}")]
 async fn patch_song(
+    req: HttpRequest,
     svc: Data<SongServiceHandle>,
     user: ReqData<User>,
     id: Path<String>,
     payload: Json<PatchSong>,
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::from_ref(&user, &svc.teams);
+    let id = id.into_inner();
+    let song = svc.get_song_for_user(&perms, &id).await?;
+    let etag = weak_etag_json(&song).map_err(|e| AppError::Internal(e.to_string()))?;
+    check_if_match(&req, &etag)?;
     Ok(HttpResponse::Ok().json(
         svc.patch_song_for_user(&perms, &id, payload.into_inner())
             .await?,
@@ -266,7 +303,9 @@ async fn patch_song(
         (status = 204, description = "Song deleted"),
         (status = 400, description = "Invalid song identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Song not found", body = Problem, content_type = "application/problem+json"),
+        (status = 412, description = "`If-Match` does not match current weak ETag", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to delete song", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Songs",
@@ -277,11 +316,16 @@ async fn patch_song(
 )]
 #[delete("/{id}")]
 async fn delete_song(
+    req: HttpRequest,
     svc: Data<SongServiceHandle>,
     user: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::from_ref(&user, &svc.teams);
+    let id = id.into_inner();
+    let song = svc.get_song_for_user(&perms, &id).await?;
+    let etag = weak_etag_json(&song).map_err(|e| AppError::Internal(e.to_string()))?;
+    check_if_match(&req, &etag)?;
     svc.delete_song_for_user(&perms, &id).await?;
     Ok(HttpResponse::NoContent().finish())
 }
@@ -296,6 +340,7 @@ async fn delete_song(
         (status = 200, description = "Whether the current user likes this song", body = LikeStatus),
         (status = 400, description = "Invalid song identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Song not found", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to get like status for a song", body = Problem, content_type = "application/problem+json")
     ),
@@ -325,6 +370,7 @@ async fn get_song_like_status(
         (status = 204, description = "Current user now likes this song"),
         (status = 400, description = "Invalid song identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Song not found", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to update like status for a song", body = Problem, content_type = "application/problem+json")
     ),
@@ -355,6 +401,7 @@ async fn put_song_like(
         (status = 204, description = "Current user no longer likes this song"),
         (status = 400, description = "Invalid song identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Song not found", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to update like status for a song", body = Problem, content_type = "application/problem+json")
     ),

--- a/backend/src/resources/team/invitation/rest.rs
+++ b/backend/src/resources/team/invitation/rest.rs
@@ -4,11 +4,11 @@ use crate::error::AppError;
 use crate::resources::User;
 use actix_web::http::header;
 use actix_web::{
-    HttpResponse, Scope, delete, get, post,
+    HttpRequest, HttpResponse, Scope, delete, get, post,
     web::{self, Data, Path, Query, ReqData},
 };
 
-use shared::api::PageQuery;
+use shared::api::{PAGE_SIZE_DEFAULT, PageQuery};
 #[allow(unused_imports)]
 use shared::team::Team;
 #[allow(unused_imports)]
@@ -18,6 +18,7 @@ use super::service::InvitationServiceHandle;
 
 pub fn team_invitations_scope() -> Scope {
     web::scope("/{team_id}/invitations")
+        .service(accept_team_invitation_under_team)
         .service(create_team_invitation)
         .service(list_team_invitations)
         .service(get_team_invitation)
@@ -38,6 +39,7 @@ pub fn invitations_accept_scope() -> Scope {
         (status = 201, description = "Invitation created", body = TeamInvitation),
         (status = 400, description = "Team is not shared", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 403, description = "Not a team admin", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Team not found", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Database error", body = Problem, content_type = "application/problem+json")
@@ -72,6 +74,7 @@ async fn create_team_invitation(
         (status = 200, description = "Invitations for the team. `X-Total-Count` is the total before paging.", body = [TeamInvitation]),
         (status = 400, description = "Invalid pagination parameters", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 403, description = "Not a team admin", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Team not found", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Database error", body = Problem, content_type = "application/problem+json")
@@ -84,6 +87,7 @@ async fn create_team_invitation(
 )]
 #[get("")]
 async fn list_team_invitations(
+    req: HttpRequest,
     svc: Data<InvitationServiceHandle>,
     user: ReqData<User>,
     team_id: Path<String>,
@@ -93,6 +97,9 @@ async fn list_team_invitations(
         .into_inner()
         .validate()
         .map_err(crate::error::map_list_query_error)?;
+    let q_link = query.clone();
+    let page = query.page.unwrap_or(0);
+    let page_size = query.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
     let (invitations, total) = svc
         .list_invitations_for_user(&user, team_id.as_str(), query.as_list_query())
         .await?;
@@ -100,6 +107,16 @@ async fn list_team_invitations(
         .insert_header((
             header::HeaderName::from_static("x-total-count"),
             total.to_string(),
+        ))
+        .insert_header((
+            header::LINK,
+            crate::request_link::list_link_header(
+                &req,
+                |p| q_link.query_string_for_page(p),
+                page,
+                page_size,
+                total,
+            ),
         ))
         .json(invitations))
 }
@@ -114,6 +131,7 @@ async fn list_team_invitations(
     responses(
         (status = 200, description = "Invitation details", body = TeamInvitation),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 403, description = "Not a team admin", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Team or invitation not found", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Database error", body = Problem, content_type = "application/problem+json")
@@ -147,6 +165,7 @@ async fn get_team_invitation(
     responses(
         (status = 204, description = "Invitation removed"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 403, description = "Not a team admin", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Team or invitation not found", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Database error", body = Problem, content_type = "application/problem+json")
@@ -171,13 +190,47 @@ async fn delete_team_invitation(
 
 #[utoipa::path(
     post,
-    path = "/api/v1/invitations/{invitation_id}/accept",
+    path = "/api/v1/teams/{team_id}/invitations/{invitation_id}/accept",
     params(
+        ("team_id" = String, Path, description = "Shared team identifier"),
         ("invitation_id" = String, Path, description = "Invitation identifier")
     ),
     responses(
         (status = 200, description = "Current user is on the team (added as guest if needed)", body = Team),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
+        (status = 404, description = "Invitation not found or not usable", body = Problem, content_type = "application/problem+json"),
+        (status = 500, description = "Database error", body = Problem, content_type = "application/problem+json")
+    ),
+    tag = "Teams",
+    security(
+        ("SessionCookie" = []),
+        ("SessionToken" = [])
+    )
+)]
+#[post("/{invitation_id}/accept")]
+async fn accept_team_invitation_under_team(
+    svc: Data<InvitationServiceHandle>,
+    user: ReqData<User>,
+    path: Path<(String, String)>,
+) -> Result<HttpResponse, AppError> {
+    let (team_id, invitation_id) = path.into_inner();
+    Ok(HttpResponse::Ok().json(
+        svc.accept_invitation_for_user_on_team(&user, &team_id, &invitation_id)
+            .await?,
+    ))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/invitations/{invitation_id}/accept",
+    params(
+        ("invitation_id" = String, Path, description = "Invitation identifier (deprecated path — prefer `/api/v1/teams/{team_id}/invitations/{invitation_id}/accept`)")
+    ),
+    responses(
+        (status = 200, description = "Current user is on the team (added as guest if needed). Deprecated route.", body = Team),
+        (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Invitation not found or not usable", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Database error", body = Problem, content_type = "application/problem+json")
     ),
@@ -193,8 +246,18 @@ async fn accept_team_invitation(
     user: ReqData<User>,
     invitation_id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Ok().json(
-        svc.accept_invitation_for_user(&user, invitation_id.as_str())
-            .await?,
-    ))
+    tracing::warn!(
+        invitation_id = %invitation_id.as_str(),
+        "deprecated: POST /api/v1/invitations/{{id}}/accept — use POST /api/v1/teams/{{team_id}}/invitations/{{id}}/accept"
+    );
+    Ok(HttpResponse::Ok()
+        .insert_header((header::HeaderName::from_static("deprecation"), "true"))
+        .insert_header((
+            header::HeaderName::from_static("sunset"),
+            "Sat, 01 Nov 2026 00:00:00 GMT",
+        ))
+        .json(
+            svc.accept_invitation_for_user(&user, invitation_id.as_str())
+                .await?,
+        ))
 }

--- a/backend/src/resources/team/invitation/service.rs
+++ b/backend/src/resources/team/invitation/service.rs
@@ -175,6 +175,20 @@ impl<R: TeamRepository, IR: TeamInvitationRepository> InvitationService<R, IR> {
         self.team_repo.load_team_display(&team_id_str).await
     }
 
+    /// Like [`accept_invitation_for_user`], but ensures the invitation belongs to `team_id`.
+    pub async fn accept_invitation_for_user_on_team(
+        &self,
+        user: &User,
+        team_id: &str,
+        invitation_id: &str,
+    ) -> Result<Team, AppError> {
+        let team = self.accept_invitation_for_user(user, invitation_id).await?;
+        if team.id != team_id {
+            return Err(AppError::NotFound("invitation not found".into()));
+        }
+        Ok(team)
+    }
+
     /// Asserts that a team exists, is a shared team, and the user is an admin of it.
     /// Returns the team `Thing` for binding into queries.
     async fn assert_shared_team_admin(

--- a/backend/src/resources/team/rest.rs
+++ b/backend/src/resources/team/rest.rs
@@ -4,10 +4,10 @@ use crate::error::AppError;
 use crate::resources::User;
 use actix_web::http::header;
 use actix_web::{
-    HttpResponse, Scope, delete, get, patch, post, put,
+    HttpRequest, HttpResponse, Scope, delete, get, patch, post, put,
     web::{self, Data, Json, Path, Query, ReqData},
 };
-use shared::api::{ListQuery, PageQuery};
+use shared::api::{ListQuery, PAGE_SIZE_DEFAULT, PageQuery};
 #[allow(unused_imports)]
 use shared::team::Team;
 use shared::team::{CreateTeam, PatchTeam, UpdateTeam};
@@ -37,6 +37,7 @@ pub fn scope() -> Scope {
         (status = 200, description = "Teams readable by the current user; platform admins receive all teams (except internal public). `X-Total-Count` is the total before paging.", body = [Team]),
         (status = 400, description = "Invalid pagination parameters", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to list teams", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Teams",
@@ -47,6 +48,7 @@ pub fn scope() -> Scope {
 )]
 #[get("")]
 async fn get_teams(
+    req: HttpRequest,
     svc: Data<TeamServiceHandle>,
     user: ReqData<User>,
     query: Query<PageQuery>,
@@ -55,16 +57,29 @@ async fn get_teams(
         .into_inner()
         .validate()
         .map_err(crate::error::map_list_query_error)?;
+    let q_link = query.clone();
+    let cur_page = query.page.unwrap_or(0);
+    let page_size = query.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
     let teams = svc.list_teams_for_user(&user).await?;
     let total = teams.len() as u64;
     let lq = query.as_list_query();
-    let (page, _) = ListQuery::paginate_nested_vec(teams, &lq);
+    let (teams_page, _) = ListQuery::paginate_nested_vec(teams, &lq);
     Ok(HttpResponse::Ok()
         .insert_header((
             header::HeaderName::from_static("x-total-count"),
             total.to_string(),
         ))
-        .json(page))
+        .insert_header((
+            header::LINK,
+            crate::request_link::list_link_header(
+                &req,
+                |p| q_link.query_string_for_page(p),
+                cur_page,
+                page_size,
+                total,
+            ),
+        ))
+        .json(teams_page))
 }
 
 #[utoipa::path(
@@ -76,6 +91,7 @@ async fn get_teams(
     responses(
         (status = 200, description = "Team details; platform admins may read any team except internal public", body = Team),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Team not found", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to fetch team", body = Problem, content_type = "application/problem+json")
     ),
@@ -102,6 +118,7 @@ async fn get_team(
         (status = 201, description = "Shared team created", body = Team),
         (status = 400, description = "Invalid request", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to create team", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Teams",
@@ -132,6 +149,7 @@ async fn create_team(
         (status = 200, description = "Team updated", body = Team),
         (status = 400, description = "Invalid request", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 403, description = "Insufficient team role", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Team not found", body = Problem, content_type = "application/problem+json"),
         (status = 409, description = "Sole admin cannot remove all admins", body = Problem, content_type = "application/problem+json"),
@@ -166,6 +184,7 @@ async fn update_team(
         (status = 200, description = "Team partially updated", body = Team),
         (status = 400, description = "Invalid request", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 403, description = "Insufficient team role", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Team not found", body = Problem, content_type = "application/problem+json"),
         (status = 409, description = "Sole admin cannot remove all admins", body = Problem, content_type = "application/problem+json"),
@@ -199,6 +218,7 @@ async fn patch_team(
     responses(
         (status = 204, description = "Team deleted"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 403, description = "Cannot delete personal team or insufficient role", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Team not found", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to delete team", body = Problem, content_type = "application/problem+json")

--- a/backend/src/resources/user/rest.rs
+++ b/backend/src/resources/user/rest.rs
@@ -6,10 +6,10 @@ use crate::error::AppError;
 use crate::resources::user::service::UserServiceHandle;
 use actix_web::http::header;
 use actix_web::{
-    HttpResponse, Scope, delete, get, post,
+    HttpRequest, HttpResponse, Scope, delete, get, post,
     web::{self, Data, Json, Path, Query, ReqData},
 };
-use shared::api::ListQuery;
+use shared::api::{ListQuery, PAGE_SIZE_DEFAULT};
 
 pub fn scope() -> Scope {
     web::scope("/users")
@@ -37,6 +37,7 @@ pub fn scope() -> Scope {
     responses(
         (status = 200, description = "Returns the currently authenticated user", body = User),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to load user session", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Users",
@@ -60,6 +61,7 @@ async fn get_users_me(user: ReqData<User>) -> HttpResponse {
         (status = 200, description = "Returns the user matching the provided id", body = User),
         (status = 400, description = "Invalid user identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 403, description = "Admin role required", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to fetch user", body = Problem, content_type = "application/problem+json")
     ),
@@ -89,6 +91,7 @@ async fn get_user(
         (status = 200, description = "Returns list of all users. `X-Total-Count` header contains the total matching user count (before pagination).", body = [User]),
         (status = 400, description = "Invalid pagination parameters", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 403, description = "Admin role required", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to list users", body = Problem, content_type = "application/problem+json")
     ),
@@ -100,6 +103,7 @@ async fn get_user(
 )]
 #[get("")]
 async fn get_users(
+    req: HttpRequest,
     svc: Data<UserServiceHandle>,
     query: Query<ListQuery>,
 ) -> Result<HttpResponse, AppError> {
@@ -107,12 +111,25 @@ async fn get_users(
         .into_inner()
         .validate()
         .map_err(crate::error::map_list_query_error)?;
+    let q_link = query.clone();
+    let page = query.page.unwrap_or(0);
+    let page_size = query.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
     let users = svc.get_users(query.clone()).await?;
     let total = svc.count_users(query).await?;
     Ok(HttpResponse::Ok()
         .insert_header((
             header::HeaderName::from_static("x-total-count"),
             total.to_string(),
+        ))
+        .insert_header((
+            header::LINK,
+            crate::request_link::list_link_header(
+                &req,
+                |p| q_link.query_string_for_page(p),
+                page,
+                page_size,
+                total,
+            ),
         ))
         .json(users))
 }
@@ -125,6 +142,7 @@ async fn get_users(
         (status = 201, description = "Creates a new user", body = User),
         (status = 400, description = "Invalid request payload", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 403, description = "Admin role required", body = Problem, content_type = "application/problem+json"),
         (status = 409, description = "User with that email already exists", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to create user", body = Problem, content_type = "application/problem+json")
@@ -153,6 +171,7 @@ async fn create_user(
         (status = 204, description = "User deleted"),
         (status = 400, description = "Invalid user identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 403, description = "Admin role required", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to delete user", body = Problem, content_type = "application/problem+json")
     ),

--- a/backend/src/resources/user/session/rest.rs
+++ b/backend/src/resources/user/session/rest.rs
@@ -1,11 +1,11 @@
 use actix_web::http::header;
 use actix_web::{
-    HttpResponse, delete, get, post,
+    HttpRequest, HttpResponse, delete, get, post,
     web::{Data, Path, Query, ReqData},
 };
 use serde::Deserialize;
 
-use shared::api::{ListQuery, PageQuery};
+use shared::api::{ListQuery, PAGE_SIZE_DEFAULT, PageQuery};
 
 #[allow(unused_imports)]
 use crate::docs::Problem;
@@ -26,6 +26,7 @@ use super::service::SessionServiceHandle;
         (status = 200, description = "Returns active sessions for the current user. `X-Total-Count` is the total before paging.", body = [Session]),
         (status = 400, description = "Invalid pagination parameters", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to list sessions for current user", body = Problem, content_type = "application/problem+json")
     ),
     tag = "Users",
@@ -36,6 +37,7 @@ use super::service::SessionServiceHandle;
 )]
 #[get("/me/sessions")]
 pub async fn get_sessions_for_current_user(
+    req: HttpRequest,
     svc: Data<SessionServiceHandle>,
     user: ReqData<User>,
     query: Query<PageQuery>,
@@ -44,15 +46,28 @@ pub async fn get_sessions_for_current_user(
         .into_inner()
         .validate()
         .map_err(crate::error::map_list_query_error)?;
+    let q_link = query.clone();
+    let cur_page = query.page.unwrap_or(0);
+    let page_size = query.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
     let sessions = svc.get_sessions_by_user_id(&user.id).await?;
     let lq = query.as_list_query();
-    let (page, total) = ListQuery::paginate_nested_vec(sessions, &lq);
+    let (sessions_page, total) = ListQuery::paginate_nested_vec(sessions, &lq);
     Ok(HttpResponse::Ok()
         .insert_header((
             header::HeaderName::from_static("x-total-count"),
             total.to_string(),
         ))
-        .json(page))
+        .insert_header((
+            header::LINK,
+            crate::request_link::list_link_header(
+                &req,
+                |p| q_link.query_string_for_page(p),
+                cur_page,
+                page_size,
+                total,
+            ),
+        ))
+        .json(sessions_page))
 }
 
 #[utoipa::path(
@@ -64,6 +79,7 @@ pub async fn get_sessions_for_current_user(
     responses(
         (status = 200, description = "Returns a session for the current user", body = Session),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Session not found for current user", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to fetch session", body = Problem, content_type = "application/problem+json")
     ),
@@ -91,6 +107,7 @@ pub async fn get_session_for_current_user(
     responses(
         (status = 204, description = "Session deleted"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Session not found for current user", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to delete session", body = Problem, content_type = "application/problem+json")
     ),
@@ -119,6 +136,7 @@ pub async fn delete_session_for_current_user(
     responses(
         (status = 201, description = "Creates a session for the specified user", body = Session),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 403, description = "Admin role required", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to create session", body = Problem, content_type = "application/problem+json")
     ),
@@ -153,6 +171,7 @@ pub async fn create_session_for_user(
         (status = 200, description = "Returns active sessions for the specified user. `X-Total-Count` is the total before paging.", body = [Session]),
         (status = 400, description = "Invalid pagination parameters", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 403, description = "Admin role required", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to list sessions", body = Problem, content_type = "application/problem+json")
     ),
@@ -164,6 +183,7 @@ pub async fn create_session_for_user(
 )]
 #[get("/{user_id}/sessions")]
 pub async fn get_sessions_for_user(
+    req: HttpRequest,
     svc: Data<SessionServiceHandle>,
     path: Path<UserIdPath>,
     query: Query<PageQuery>,
@@ -172,15 +192,28 @@ pub async fn get_sessions_for_user(
         .into_inner()
         .validate()
         .map_err(crate::error::map_list_query_error)?;
+    let q_link = query.clone();
+    let cur_page = query.page.unwrap_or(0);
+    let page_size = query.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
     let sessions = svc.get_sessions_by_user_id(&path.user_id).await?;
     let lq = query.as_list_query();
-    let (page, total) = ListQuery::paginate_nested_vec(sessions, &lq);
+    let (sessions_page, total) = ListQuery::paginate_nested_vec(sessions, &lq);
     Ok(HttpResponse::Ok()
         .insert_header((
             header::HeaderName::from_static("x-total-count"),
             total.to_string(),
         ))
-        .json(page))
+        .insert_header((
+            header::LINK,
+            crate::request_link::list_link_header(
+                &req,
+                |p| q_link.query_string_for_page(p),
+                cur_page,
+                page_size,
+                total,
+            ),
+        ))
+        .json(sessions_page))
 }
 
 #[utoipa::path(
@@ -193,6 +226,7 @@ pub async fn get_sessions_for_user(
     responses(
         (status = 200, description = "Returns a session for the specified user", body = Session),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 403, description = "Admin role required", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Session not found for specified user", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to fetch session", body = Problem, content_type = "application/problem+json")
@@ -221,6 +255,7 @@ pub async fn get_session_for_user(
     responses(
         (status = 204, description = "Session deleted"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 403, description = "Admin role required", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Session not found for specified user", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to delete session", body = Problem, content_type = "application/problem+json")

--- a/backend/src/settings.rs
+++ b/backend/src/settings.rs
@@ -63,6 +63,10 @@ pub struct Settings {
     /// Default: 1 request per second with a burst of 5.
     pub auth_rate_limit_rps: u64,
     pub auth_rate_limit_burst: u32,
+
+    /// Per-IP rate limit for `/api/v1/*` (token bucket). Defaults are generous for local development.
+    pub api_rate_limit_rps: u64,
+    pub api_rate_limit_burst: u32,
 }
 
 impl Default for Settings {
@@ -98,6 +102,8 @@ impl Default for Settings {
             blob_upload_max_bytes: 20 * 1024 * 1024,
             auth_rate_limit_rps: 1,
             auth_rate_limit_burst: 5,
+            api_rate_limit_rps: 50,
+            api_rate_limit_burst: 200,
         }
     }
 }

--- a/docs/business-logic-constraints/blob.md
+++ b/docs/business-logic-constraints/blob.md
@@ -20,6 +20,7 @@
 - **BLC-BLOB-009:** WHEN **POST** creates a blob THEN **`owner`** IS ALWAYS the caller’s **personal** team.
 - **BLC-BLOB-010:** WHEN **GET /blobs** or **GET /blobs/{id}** runs THEN only blobs whose **`owner`** team the caller may read are included or returned; catalog-wide readable material MAY appear without team membership where the product exposes it.
 - **BLC-BLOB-011:** WHEN **GET …/data** runs THEN the same visibility rules as metadata **GET** apply; IF bytes are available THEN they are served.
+- **BLC-BLOB-016:** **`GET /blobs/{id}/data`** responses include a weak **`ETag`** over stored bytes, **`Content-Length`**, and **`Cache-Control: private, max-age=3600, immutable`**. **`If-None-Match`** matching the current **`ETag`** yields **304** with an empty body.
 - **BLC-BLOB-012:** WHEN **PUT** runs THEN only **`file_type`**, **`width`**, **`height`**, and **`ocr`** may change.
 - **BLC-BLOB-013:** WHEN **DELETE** succeeds THEN the blob no longer appears in the API and associated stored bytes MAY be removed.
 

--- a/docs/business-logic-constraints/http-contract.md
+++ b/docs/business-logic-constraints/http-contract.md
@@ -13,3 +13,7 @@ Rules that apply across several **`/api/v1`** resources (path validation, idempo
 ## Idempotent DELETE
 
 - **BLC-HTTP-002:** WHEN **DELETE** on a resource succeeds and the client issues the same **DELETE** again for that **id** THEN the API responds **404** (same pattern as **BLC-USER-014** for users).
+
+## API rate limiting (`/api/v1/*`)
+
+- **BLC-HTTP-004:** Versioned **`/api/v1/*`** routes are rate-limited **per client IP** (see `backend` settings **`API_RATE_LIMIT_RPS`** and **`API_RATE_LIMIT_BURST`**, defaults **50** RPS and burst **200**). WHEN the limit IS exceeded THEN the API responds **429 Too Many Requests** with **`Retry-After`** and **`X-RateLimit-*`** headers ([`actix-governor`](https://docs.rs/actix-governor/latest/actix_governor/)).

--- a/docs/business-logic-constraints/list-pagination.md
+++ b/docs/business-logic-constraints/list-pagination.md
@@ -23,3 +23,5 @@ Applies to **GET** list routes that support paging: **`/users`** (admin), **`/bl
 - **BLC-LP-009:** WHEN **`q`** IS combined with **`page`** / **`page_size`** THEN filtering runs first, then pagination over those results.
 
 **Track A (current):** All list responses include an **`X-Total-Count`** header: the **total number of matching records after filters and before pagination**. Clients detect the last page when the returned **`items.len() < page_size`** or the page is **empty** (including “beyond last page” pages).
+
+- **BLC-LP-010:** List responses also include an [**RFC 5988**](https://www.rfc-editor.org/rfc/rfc5988) **`Link`** header with `first` / `prev` / `next` / `last` relations (omitting `prev` on the first page and `next` on the last). The URLs repeat the same query shape as the request with adjusted `page`.

--- a/docs/business-logic-constraints/team-invitation.md
+++ b/docs/business-logic-constraints/team-invitation.md
@@ -14,7 +14,7 @@
 - **BLC-TINV-007:** WHEN **POST** `/teams/{team_id}/invitations` runs THEN only a team **admin** MAY create; the team MUST be a valid shared team (invalid id THEN **400** or **404** consistent with team routes).
 - **BLC-TINV-008:** WHEN **GET** list or **GET** one invitation runs THEN only team **admin** MAY; wrong team or id THEN **404** for others.
 - **BLC-TINV-009:** WHEN **DELETE** an invitation runs THEN only team **admin** MAY; missing id THEN **404** vs **204** MUST stay consistent across the API.
-- **BLC-TINV-010:** WHEN **accept** runs THEN the session MUST be authenticated; the current user IS added as **guest** on the team (**members** in **GET /teams/{id}**).
+- **BLC-TINV-010:** WHEN **accept** runs THEN the session MUST be authenticated; the current user IS added as **guest** on the team (**members** in **GET /teams/{id}**). The primary route IS **`POST /api/v1/teams/{team_id}/invitations/{invitation_id}/accept`**; **`POST /api/v1/invitations/{invitation_id}/accept`** remains supported but IS deprecated ( **`Deprecation`** / **`Sunset`** headers on responses).
 - **BLC-TINV-011:** WHEN **accept** runs and the user is already **content_maintainer** or **admin** on that team THEN their role MUST NOT downgrade to **guest**.
 - **BLC-TINV-012:** WHEN **accept** runs and the user is already **guest** THEN duplicate **members** entries MUST NOT appear.
 - **BLC-TINV-013:** WHEN **accept** succeeds and the invitation still exists THEN the same invitation id MAY be used again until an admin deletes it.

--- a/shared/src/api/list_query.rs
+++ b/shared/src/api/list_query.rs
@@ -113,6 +113,13 @@ impl ListQuery {
             format!("?{}", parts.join("&"))
         }
     }
+
+    /// Query string without `?`, with `page` overridden (keeps `page_size`, `q`).
+    pub fn query_string_for_page(&self, page: u32) -> String {
+        let mut q = self.clone();
+        q.page = Some(page);
+        q.to_query_string().trim_start_matches('?').to_string()
+    }
 }
 
 fn encode_query_value(s: &str) -> String {
@@ -159,5 +166,12 @@ impl PageQuery {
             page_size: self.page_size,
             q: None,
         }
+    }
+
+    /// Query string without `?`, with `page` overridden.
+    pub fn query_string_for_page(&self, page: u32) -> String {
+        let mut q = self.as_list_query();
+        q.page = Some(page);
+        q.to_query_string().trim_start_matches('?').to_string()
     }
 }

--- a/shared/src/api/mod.rs
+++ b/shared/src/api/mod.rs
@@ -17,9 +17,11 @@ use crate::user::{CreateUser, Session, User};
 use std::vec::Vec;
 
 mod list_query;
+pub mod pagination_link;
 mod song_list_query;
 
-pub use list_query::{ListQuery, PageQuery};
+pub use list_query::{ListQuery, PageQuery, PAGE_SIZE_DEFAULT};
+pub use pagination_link::pagination_link_header;
 pub use song_list_query::{SongListQuery, SongSort};
 pub struct ApiClient<C: HttpClient> {
     client: C,

--- a/shared/src/api/pagination_link.rs
+++ b/shared/src/api/pagination_link.rs
@@ -1,0 +1,102 @@
+//! RFC 5988 pagination `Link` header (`rel=first|prev|next|last`).
+
+use super::list_query::PAGE_SIZE_DEFAULT;
+
+/// Build a `Link` header value for offset pagination (`page` is zero-based).
+///
+/// `path` is the absolute path (e.g. `/api/v1/songs`). `query_for_page` must return the
+/// **full** query string for the given page **without** a leading `?` (e.g. `page=1&page_size=50&q=x`).
+pub fn pagination_link_header(
+    origin: &str,
+    path: &str,
+    query_for_page: impl Fn(u32) -> String,
+    current_page: u32,
+    page_size_raw: u32,
+    total: u64,
+) -> String {
+    let page_size = if page_size_raw == 0 {
+        PAGE_SIZE_DEFAULT
+    } else {
+        page_size_raw
+    };
+    let ps = page_size as u64;
+    let last_page = if total == 0 {
+        0
+    } else {
+        (total.saturating_sub(1) / ps) as u32
+    };
+
+    let mut out: Vec<String> = Vec::with_capacity(4);
+    let mut push = |rel: &'static str, p: u32| {
+        let qs = query_for_page(p);
+        let url = if qs.is_empty() {
+            format!("{origin}{path}")
+        } else {
+            format!("{origin}{path}?{qs}")
+        };
+        out.push(format!("<{url}>; rel=\"{rel}\""));
+    };
+
+    push("first", 0);
+    if current_page > 0 {
+        push("prev", current_page - 1);
+    }
+    if current_page < last_page {
+        push("next", current_page + 1);
+    }
+    push("last", last_page);
+    out.join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn link_header_middle_page_has_four_rels() {
+        let h = pagination_link_header(
+            "https://ex.test",
+            "/api/v1/songs",
+            |p| format!("page={p}&page_size=10"),
+            3,
+            10,
+            100,
+        );
+        assert!(h.contains("rel=\"first\""));
+        assert!(h.contains("rel=\"prev\""));
+        assert!(h.contains("rel=\"next\""));
+        assert!(h.contains("rel=\"last\""));
+        assert!(h.contains("page=0"));
+        assert!(h.contains("page=2"));
+        assert!(h.contains("page=4"));
+        assert!(h.contains("page=9"));
+    }
+
+    #[test]
+    fn link_header_first_page_omits_prev() {
+        let h = pagination_link_header(
+            "https://ex.test",
+            "/api/v1/x",
+            |p| format!("page={p}"),
+            0,
+            10,
+            50,
+        );
+        assert!(!h.contains("rel=\"prev\""));
+        assert!(h.contains("rel=\"next\""));
+    }
+
+    #[test]
+    fn link_header_last_page_omits_next() {
+        let h = pagination_link_header(
+            "https://ex.test",
+            "/api/v1/x",
+            |p| format!("page={p}"),
+            4,
+            10,
+            50,
+        );
+        assert!(!h.contains("rel=\"next\""));
+        assert!(h.contains("rel=\"prev\""));
+    }
+}

--- a/shared/src/api/song_list_query.rs
+++ b/shared/src/api/song_list_query.rs
@@ -17,7 +17,7 @@ use super::ListQuery;
         "page": 0,
         "page_size": 50,
         "q": "grace",
-        "sort": "relevance"
+        "sort": "-id"
     }))
 )]
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
@@ -25,18 +25,18 @@ pub struct SongListQuery {
     pub page: Option<u32>,
     pub page_size: Option<u32>,
     pub q: Option<String>,
-    /// Sort order. With a non-empty `q`, defaults to `relevance` (search score). Without `q`, defaults to `id_desc`.
-    pub sort: Option<SongSort>,
+    /// Sort: comma-separated fields, `-` prefix for descending (e.g. `-id`, `title`, `-id,title`).
+    /// Use `relevance` when searching (`q` non-empty). Legacy tokens (`id_desc`, …) accepted with a warning.
+    #[cfg_attr(feature = "backend", schema(value_type = Option<String>, example = "-id"))]
+    pub sort: Option<String>,
     /// Filter to songs whose `data.languages` contains this string (exact match on an array element).
     pub lang: Option<String>,
     /// Case-insensitive substring match against the stringified `data.tags` object (keys and values).
     pub tag: Option<String>,
 }
 
-/// Allowed values for the `sort` query parameter on `GET /api/v1/songs`.
-#[cfg_attr(feature = "backend", derive(utoipa::ToSchema))]
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
+/// Parsed sort order for `/songs` queries (see [`SongSort::from_sort_param`]).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum SongSort {
     /// Newest record id first (default when `q` is absent).
     #[default]
@@ -46,6 +46,71 @@ pub enum SongSort {
     TitleDesc,
     /// Search relevance (default when `q` is present); uses full-text scores.
     Relevance,
+}
+
+impl SongSort {
+    /// Parse `sort` query value: **canonical** (`-id`, `title`, `relevance`, comma-separated, first wins)
+    /// plus **legacy** snake_case tokens (`id_desc`, …) for one release.
+    pub fn from_sort_param(raw: &str) -> Result<Self, String> {
+        let s = raw.trim();
+        if s.is_empty() {
+            return Err("sort is empty".into());
+        }
+        let first = s.split(',').next().unwrap_or("").trim();
+        match first {
+            "id_desc" => {
+                legacy_sort_warn("id_desc");
+                return Ok(Self::IdDesc);
+            }
+            "id_asc" => {
+                legacy_sort_warn("id_asc");
+                return Ok(Self::IdAsc);
+            }
+            "title_asc" => {
+                legacy_sort_warn("title_asc");
+                return Ok(Self::TitleAsc);
+            }
+            "title_desc" => {
+                legacy_sort_warn("title_desc");
+                return Ok(Self::TitleDesc);
+            }
+            _ => {}
+        }
+        if first.eq_ignore_ascii_case("relevance") {
+            return Ok(Self::Relevance);
+        }
+        let desc = first.starts_with('-');
+        let field = first.trim_start_matches('-').trim();
+        match field {
+            "id" => Ok(if desc { Self::IdDesc } else { Self::IdAsc }),
+            "title" => Ok(if desc {
+                Self::TitleDesc
+            } else {
+                Self::TitleAsc
+            }),
+            _ => Err(format!("unknown sort field: {field}")),
+        }
+    }
+
+    fn canonical_sort_param(self) -> &'static str {
+        match self {
+            Self::IdDesc => "-id",
+            Self::IdAsc => "id",
+            Self::TitleAsc => "title",
+            Self::TitleDesc => "-title",
+            Self::Relevance => "relevance",
+        }
+    }
+}
+
+fn legacy_sort_warn(token: &str) {
+    #[cfg(feature = "backend")]
+    tracing::warn!(
+        legacy_sort_token = token,
+        "deprecated sort=… token; use JSON:API-style sort (e.g. -id, title) instead"
+    );
+    #[cfg(not(feature = "backend"))]
+    let _ = token;
 }
 
 impl From<ListQuery> for SongListQuery {
@@ -75,8 +140,11 @@ impl SongListQuery {
     pub fn validate(self) -> Result<Self, String> {
         self.list_query().validate()?;
         let q_nonempty = self.q.as_ref().is_some_and(|q| !q.trim().is_empty());
-        if matches!(self.sort, Some(SongSort::Relevance)) && !q_nonempty {
-            return Err("sort=relevance requires a non-empty q parameter".into());
+        if let Some(ref st) = self.sort {
+            let parsed = SongSort::from_sort_param(st)?;
+            if matches!(parsed, SongSort::Relevance) && !q_nonempty {
+                return Err("sort=relevance requires a non-empty q parameter".into());
+            }
         }
         Ok(self)
     }
@@ -113,15 +181,12 @@ impl SongListQuery {
             q.push_str(&enc(v));
         };
 
-        if let Some(sort) = self.sort {
-            let s = match sort {
-                SongSort::IdDesc => "id_desc",
-                SongSort::IdAsc => "id_asc",
-                SongSort::TitleAsc => "title_asc",
-                SongSort::TitleDesc => "title_desc",
-                SongSort::Relevance => "relevance",
-            };
-            append(&mut q, "sort", s);
+        if let Some(ref raw) = self.sort {
+            if let Ok(sort) = SongSort::from_sort_param(raw) {
+                append(&mut q, "sort", sort.canonical_sort_param());
+            } else {
+                append(&mut q, "sort", raw.as_str());
+            }
         }
         if let Some(ref lang) = self.lang {
             if !lang.is_empty() {
@@ -136,10 +201,17 @@ impl SongListQuery {
         q
     }
 
+    /// Query string without `?`, with `page` overridden (preserves sort/lang/tag filters).
+    pub fn query_string_for_page(&self, page: u32) -> String {
+        let mut s = self.clone();
+        s.page = Some(page);
+        s.to_query_string().trim_start_matches('?').to_string()
+    }
+
     /// Effective sort: explicit `sort`, or inferred from presence of `q`.
     pub fn effective_sort(&self) -> SongSort {
-        match self.sort {
-            Some(s) => s,
+        match self.sort.as_deref() {
+            Some(s) => SongSort::from_sort_param(s).expect("sort validated"),
             None => {
                 let q_nonempty = self.q.as_ref().is_some_and(|q| !q.trim().is_empty());
                 if q_nonempty {

--- a/shared/src/error/codes.rs
+++ b/shared/src/error/codes.rs
@@ -12,6 +12,8 @@ pub enum ErrorCode {
     Conflict,
     TooManyRequests,
     NotAcceptable,
+    /// `If-Match` precondition failed (optimistic concurrency).
+    PreconditionFailed,
     Internal,
 }
 
@@ -26,6 +28,7 @@ impl ErrorCode {
             ErrorCode::Conflict => "conflict",
             ErrorCode::TooManyRequests => "too_many_requests",
             ErrorCode::NotAcceptable => "not_acceptable",
+            ErrorCode::PreconditionFailed => "precondition_failed",
             ErrorCode::Internal => "internal",
         }
     }
@@ -40,6 +43,7 @@ impl ErrorCode {
         "conflict",
         "too_many_requests",
         "not_acceptable",
+        "precondition_failed",
         "internal",
     ];
 }
@@ -70,6 +74,7 @@ mod tests {
             Conflict,
             TooManyRequests,
             NotAcceptable,
+            PreconditionFailed,
             Internal,
         ] {
             assert!(
@@ -93,6 +98,7 @@ mod tests {
                     ErrorCode::Conflict,
                     ErrorCode::TooManyRequests,
                     ErrorCode::NotAcceptable,
+                    ErrorCode::PreconditionFailed,
                     ErrorCode::Internal,
                 ]
                 .into_iter()

--- a/shared/src/player/orientation.rs
+++ b/shared/src/player/orientation.rs
@@ -1,13 +1,68 @@
-use serde::{Deserialize, Serialize};
+use serde::de::{Error as DeError, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
 #[cfg(feature = "backend")]
 use utoipa::ToSchema;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
-#[cfg_attr(feature = "backend", derive(ToSchema))]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[cfg_attr(
+    feature = "backend",
+    derive(ToSchema),
+    schema(rename_all = "snake_case")
+)]
 pub enum Orientation {
     #[default]
     Portrait,
     Landscape,
+}
+
+impl Serialize for Orientation {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.to_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for Orientation {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_str(OrientationVisitor)
+    }
+}
+
+struct OrientationVisitor;
+
+impl Visitor<'_> for OrientationVisitor {
+    type Value = Orientation;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("portrait or landscape (snake_case; PascalCase accepted)")
+    }
+
+    fn visit_str<E: DeError>(self, s: &str) -> Result<Self::Value, E> {
+        Ok(match s {
+            "portrait" => Orientation::Portrait,
+            "Portrait" => {
+                legacy_enum_warn("Orientation", s);
+                Orientation::Portrait
+            }
+            "landscape" => Orientation::Landscape,
+            "Landscape" => {
+                legacy_enum_warn("Orientation", s);
+                Orientation::Landscape
+            }
+            _ => return Err(E::custom(format!("unknown orientation: {s}"))),
+        })
+    }
+}
+
+pub(crate) fn legacy_enum_warn(enum_name: &str, value: &str) {
+    #[cfg(feature = "backend")]
+    tracing::warn!(
+        enum_name,
+        value,
+        "legacy enum wire value; prefer lower_snake_case"
+    );
+    #[cfg(not(feature = "backend"))]
+    let _ = (enum_name, value);
 }
 
 impl Orientation {

--- a/shared/src/player/scroll_type.rs
+++ b/shared/src/player/scroll_type.rs
@@ -1,9 +1,15 @@
-use serde::{Deserialize, Serialize};
+use serde::de::{Error as DeError, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
 #[cfg(feature = "backend")]
 use utoipa::ToSchema;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
-#[cfg_attr(feature = "backend", derive(ToSchema))]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[cfg_attr(
+    feature = "backend",
+    derive(ToSchema),
+    schema(rename_all = "snake_case")
+)]
 pub enum ScrollType {
     #[default]
     OnePage,
@@ -11,6 +17,56 @@ pub enum ScrollType {
     TwoPage,
     Book,
     TwoHalfPage,
+}
+
+impl Serialize for ScrollType {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.to_wire())
+    }
+}
+
+impl<'de> Deserialize<'de> for ScrollType {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_str(ScrollTypeVisitor)
+    }
+}
+
+struct ScrollTypeVisitor;
+
+impl Visitor<'_> for ScrollTypeVisitor {
+    type Value = ScrollType;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("scroll type (snake_case; legacy PascalCase accepted)")
+    }
+
+    fn visit_str<E: DeError>(self, s: &str) -> Result<Self::Value, E> {
+        parse_scroll_type(s).map_err(E::custom)
+    }
+}
+
+fn parse_scroll_type(s: &str) -> Result<ScrollType, String> {
+    const LEGACY: &[(&str, ScrollType)] = &[
+        ("OnePage", ScrollType::OnePage),
+        ("HalfPage", ScrollType::HalfPage),
+        ("TwoPage", ScrollType::TwoPage),
+        ("Book", ScrollType::Book),
+        ("TwoHalfPage", ScrollType::TwoHalfPage),
+    ];
+    for (name, v) in LEGACY {
+        if *name == s {
+            super::orientation::legacy_enum_warn("ScrollType", s);
+            return Ok(*v);
+        }
+    }
+    match s {
+        "one_page" => Ok(ScrollType::OnePage),
+        "half_page" => Ok(ScrollType::HalfPage),
+        "two_page" => Ok(ScrollType::TwoPage),
+        "book" => Ok(ScrollType::Book),
+        "two_half_page" => Ok(ScrollType::TwoHalfPage),
+        _ => Err(format!("unknown scroll type: {s}")),
+    }
 }
 
 impl ScrollType {
@@ -21,6 +77,16 @@ impl ScrollType {
             Self::TwoPage => Self::Book,
             Self::Book => Self::TwoHalfPage,
             Self::TwoHalfPage => Self::OnePage,
+        }
+    }
+
+    fn to_wire(&self) -> &'static str {
+        match self {
+            Self::OnePage => "one_page",
+            Self::HalfPage => "half_page",
+            Self::TwoPage => "two_page",
+            Self::Book => "book",
+            Self::TwoHalfPage => "two_half_page",
         }
     }
 

--- a/shared/src/song/mod.rs
+++ b/shared/src/song/mod.rs
@@ -1,7 +1,11 @@
 mod link;
 mod song;
+#[cfg(feature = "backend")]
+mod song_data_schema;
 
 pub use chordlib::outputs::{wrap_html, CharPageSet, FormatOutputLines, OutputLine};
 pub use chordlib::types::{ChordRepresentation, SimpleChord};
 pub use link::{Link, LinkOwned};
 pub use song::{CreateSong, PatchSong, PatchSongData, Song, SongUserSpecificAddons};
+#[cfg(feature = "backend")]
+pub use song_data_schema::SongDataSchema;

--- a/shared/src/song/song.rs
+++ b/shared/src/song/song.rs
@@ -1,7 +1,7 @@
 use crate::patch::Patch;
 use chordlib::inputs::chord_pro;
 use chordlib::outputs::{FormatChordPro, FormatHTML};
-use chordlib::types::{ChordRepresentation, Section, SimpleChord, Song as SongData};
+use chordlib::types::{ChordRepresentation, Section, SimpleChord, Song as ChordSong};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
@@ -11,6 +11,10 @@ use std::convert::TryFrom;
 use serde_json::json;
 #[cfg(feature = "backend")]
 use utoipa::ToSchema;
+
+#[cfg(feature = "backend")]
+#[allow(unused_imports)]
+use super::song_data_schema::SongDataSchema;
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone)]
 #[cfg_attr(feature = "backend", derive(ToSchema))]
@@ -27,9 +31,9 @@ pub struct Song {
     pub not_a_song: bool,
     /// Blob IDs for sheet-music or image assets linked to this song.
     pub blobs: Vec<String>,
-    /// ChordPro-derived payload (sections, lyrics, metadata). A dedicated `SongData` schema is planned.
-    #[cfg_attr(feature = "backend", schema(value_type = Object, additional_properties = true))]
-    pub data: SongData,
+    /// ChordPro-derived payload (sections, lyrics, metadata); see `SongData` in the OpenAPI components.
+    #[cfg_attr(feature = "backend", schema(value_type = SongDataSchema))]
+    pub data: ChordSong,
     /// Per-request flags such as whether the current user liked this song.
     pub user_specific_addons: SongUserSpecificAddons,
 }
@@ -48,8 +52,8 @@ pub struct Song {
 pub struct CreateSong {
     pub not_a_song: bool,
     pub blobs: Vec<String>,
-    #[cfg_attr(feature = "backend", schema(value_type = Object, additional_properties = true))]
-    pub data: SongData,
+    #[cfg_attr(feature = "backend", schema(value_type = SongDataSchema))]
+    pub data: ChordSong,
 }
 
 /// Partial update for a song. Absent fields are left unchanged.

--- a/shared/src/song/song_data_schema.rs
+++ b/shared/src/song/song_data_schema.rs
@@ -1,0 +1,56 @@
+//! OpenAPI schema for the ChordPro-derived song payload (mirrors [`chordlib::types::Song`] wire JSON).
+//! Runtime types use `chordlib::types::Song` directly; this type exists for `utoipa` only.
+
+use std::collections::BTreeMap;
+
+#[cfg(feature = "backend")]
+#[allow(unused_imports)]
+use serde_json::json;
+#[cfg(feature = "backend")]
+use utoipa::ToSchema;
+
+/// ChordPro-derived metadata and content (titles, tags, [`sections`](https://chordpro.org/) as structured blocks).
+#[cfg_attr(feature = "backend", derive(ToSchema))]
+#[cfg_attr(
+    feature = "backend",
+    schema(
+        as = SongData,
+        example = json!({
+            "titles": ["Amazing Grace"],
+            "subtitle": null,
+            "copyright": null,
+            "key": null,
+            "artists": [],
+            "languages": ["en"],
+            "tempo": null,
+            "time": null,
+            "tags": {},
+            "sections": []
+        })
+    )
+)]
+pub struct SongDataSchema {
+    /// Primary and alternate titles from ChordPro `{title}` / `{title:N}` directives.
+    #[cfg_attr(feature = "backend", schema(example = json!(["Example Hymn"])))]
+    pub titles: Vec<String>,
+    pub subtitle: Option<String>,
+    pub copyright: Option<String>,
+    /// Musical key; chord symbols use ChordPro conventions.
+    #[cfg_attr(feature = "backend", schema(value_type = Option<String>, example = json!("G")))]
+    pub key: Option<chordlib::types::SimpleChord>,
+    pub artists: Vec<String>,
+    /// BCP 47 language tags (e.g. `en`, `de-CH`).
+    #[cfg_attr(feature = "backend", schema(example = json!(["en"])))]
+    pub languages: Vec<String>,
+    /// Tempo in BPM (beats per minute).
+    pub tempo: Option<u32>,
+    /// Time signature as `(numerator, denominator)` (e.g. 4/4).
+    #[cfg_attr(feature = "backend", schema(value_type = Option<[u32; 2]>, example = json!([4, 4])))]
+    pub time: Option<(u32, u32)>,
+    /// Custom meta tags from ChordPro `{meta: name value}` pairs.
+    #[cfg_attr(feature = "backend", schema(additional_properties = true))]
+    pub tags: BTreeMap<String, String>,
+    /// Structured sections (verse, chorus, etc.) with lyric lines and chords.
+    #[cfg_attr(feature = "backend", schema(value_type = Vec<Object>))]
+    pub sections: Vec<chordlib::types::Section>,
+}


### PR DESCRIPTION
## Summary

Implements Phase 2 API backlog: optimistic concurrency (**`If-Match` / 412**), **SongData** OpenAPI schema, RFC 5988 **`Link`** on list responses, **sort** grammar for songs, **blob** byte **ETag** / **304**, nested **team invitation accept** (legacy path deprecated), **snake_case** player enums with legacy input, and **/api/v1** rate limiting with **429** in OpenAPI and BLC docs.

## Verification

- `cargo test` (backend, shared)
- `cargo clippy` (backend)