### PR TITLE
feat(api)!: Phase 3 breaking changes on /api/v1 (OpenAPI 2.0.0)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -17,6 +17,7 @@ on:
       - "Dockerfile"
       - ".dockerignore"
       - ".github/workflows/backend-ci.yml"
+      - ".spectral.yaml"
 
 jobs:
   backend-validate:
@@ -41,6 +42,15 @@ jobs:
       - name: Test
         working-directory: backend
         run: cargo test
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: OpenAPI Spectral (schema property keys snake_case)
+        run: |
+          cargo run --manifest-path backend/Cargo.toml --example print_openapi --quiet > "$RUNNER_TEMP/openapi.json"
+          npx --yes @stoplight/spectral-cli@6 lint "$RUNNER_TEMP/openapi.json" -r .spectral.yaml
 
       - name: Clippy
         working-directory: backend

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,15 @@
+# Worship Viewer: enforce snake_case property keys in OpenAPI component schemas (Phase 3 §22).
+extends:
+  - - spectral:oas
+    - off
+rules:
+  oas3-schema-properties-snake-case:
+    description: Every property name under components.schemas must be snake_case ASCII
+    message: "Property name must be snake_case (lowercase, digits, underscores): {{value}}"
+    severity: error
+    given: "$.components.schemas..properties"
+    then:
+      field: "@key"
+      function: pattern
+      functionOptions:
+        match: "^[a-z][a-z0-9_]*$"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable API and packaging changes for Worship Viewer are documented here. The API version in OpenAPI `info.version` marks **wire-format** generations for `/api/v1`.
+
+## 2.0.0 — 2026-04-18
+
+Breaking HTTP/API changes (paths remain under `/api/v1`). See [docs/api-breaking-2-0.md](docs/api-breaking-2-0.md) for migration detail.
+
+- **Player responses:** `PlayerItem` is internally tagged (`type` + `blob_id` or `song`).
+- **Songs:** `blobs` are link objects (`BlobLink`: `{ "id" }`), not bare strings.
+- **Sessions:** wire model is `SessionBody`; narrow `user` by default; use `expand=user` for full user JSON.
+- **Errors:** `Problem` no longer includes legacy `error`; use `detail` and `code`.
+- **PUT bodies:** OpenAPI names `UpdateSong`, `UpdateCollection`, `UpdateSetlist`, and `UpdateBlob` (same JSON shapes as the former create types where applicable).
+- **OpenAPI:** chord payload component is consistently named `SongDataSchema` (fixes invalid `$ref` in the published document).

--- a/backend/examples/print_openapi.rs
+++ b/backend/examples/print_openapi.rs
@@ -1,0 +1,11 @@
+//! Print the OpenAPI document as JSON to stdout (for CI / Spectral).
+use utoipa::OpenApi;
+
+fn main() {
+    let doc = backend::docs::ApiDoc::openapi();
+    print!(
+        "{}",
+        serde_json::to_string_pretty(&serde_json::to_value(doc).expect("openapi as json"))
+            .expect("pretty json")
+    );
+}

--- a/backend/src/auth/otp/rest.rs
+++ b/backend/src/auth/otp/rest.rs
@@ -15,10 +15,10 @@ use crate::database::Database;
 use crate::docs::Problem;
 use crate::error::AppError;
 use crate::mail::MailService;
-use shared::user::{Session, SessionBody};
 use crate::resources::user::service::UserServiceHandle;
 use crate::resources::user::session::service::SessionServiceHandle;
 use crate::settings::{CookieConfig, OtpConfig};
+use shared::user::{Session, SessionBody};
 
 #[utoipa::path(
     post,

--- a/backend/src/auth/otp/rest.rs
+++ b/backend/src/auth/otp/rest.rs
@@ -15,7 +15,7 @@ use crate::database::Database;
 use crate::docs::Problem;
 use crate::error::AppError;
 use crate::mail::MailService;
-use crate::resources::Session;
+use shared::user::{Session, SessionBody};
 use crate::resources::user::service::UserServiceHandle;
 use crate::resources::user::session::service::SessionServiceHandle;
 use crate::settings::{CookieConfig, OtpConfig};
@@ -64,7 +64,7 @@ async fn otp_request(
     path = "/auth/otp/verify",
     request_body = OtpVerify,
     responses(
-        (status = 200, description = "OTP verified successfully; session cookie issued. When `WORSHIP_OTP_ALLOW_SELF_SIGNUP` is unset/true, a new user may be created for an unknown email; when false, the email must already exist.", body = Session),
+        (status = 200, description = "OTP verified successfully; session cookie issued. When `WORSHIP_OTP_ALLOW_SELF_SIGNUP` is unset/true, a new user may be created for an unknown email; when false, the email must already exist. Response always embeds full `User` under `user`.", body = SessionBody),
         (status = 400, description = "OTP verification failed, or signup disabled for unknown email", body = Problem, content_type = "application/problem+json"),
         (status = 429, description = "Too many incorrect attempts; request a new code", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to create session", body = Problem, content_type = "application/problem+json")
@@ -112,7 +112,7 @@ async fn otp_verify(
 
     Ok(HttpResponse::Ok()
         .cookie(session_cookie(&session.id, &cookie_cfg))
-        .json(session))
+        .json(SessionBody::from_session(session, true)))
 }
 
 trait OkIf {

--- a/backend/src/docs.rs
+++ b/backend/src/docs.rs
@@ -7,21 +7,24 @@ use crate::resources::setlist::PatchSetlist;
 use crate::resources::song::{PatchSong, PatchSongData};
 use crate::resources::user::Role;
 use crate::resources::{
-    Blob, Collection, CreateBlob, CreateCollection, CreateSetlist, CreateSong, CreateUser, Session,
-    Setlist, Song, User,
+    Blob, Collection, CreateBlob, CreateCollection, CreateSetlist, CreateSong, CreateUser, Setlist,
+    Song, UpdateBlob, UpdateCollection, UpdateSetlist, UpdateSong, User,
 };
 use shared::api::SongListQuery;
 use shared::auth::otp::{OtpRequest, OtpVerify};
-use shared::blob::FileType;
+use shared::blob::{BlobLink, FileType};
 pub use shared::error::{ErrorResponse, Problem, ProblemDetails};
 use shared::like::LikeStatus;
-use shared::player::{Orientation, Player, PlayerItem, ScrollType, TocItem};
+use shared::player::{
+    Orientation, Player, PlayerBlobItem, PlayerChordsItem, PlayerItem, ScrollType, TocItem,
+};
 use shared::song::SongDataSchema;
 use shared::song::{Link as SongLink, SongUserSpecificAddons};
 use shared::team::{
     CreateTeam, PatchTeam, Team, TeamInvitation, TeamMember, TeamMemberInput, TeamRole, TeamUser,
     TeamUserRef, UpdateTeam,
 };
+use shared::user::{SessionBody, SessionUserBody};
 
 pub mod rest {
     use super::{ApiDoc, OpenApi};
@@ -36,14 +39,16 @@ pub mod rest {
 #[openapi(
     info(
         title = "Worship Viewer API",
-        version = "1.0.0",
+        version = "2.0.0",
         description = "Versioned REST API under `/api/v1`. Authentication flows live at `/auth/*` (unversioned); clients should treat that split as stable for this major API generation.\n\n\
+            **Breaking 2.0:** See `docs/api-breaking-2-0.md` for migration (`PlayerItem`, `Song.blobs` as link objects, `Session` wire model, `Problem` without `error`, PUT bodies use `Update*` types in the spec).\n\n\
             **Timestamps:** All timestamps are UTC and use RFC 3339 with a `Z` suffix (e.g. `2026-04-18T12:00:00Z`).\n\n\
             **Identifiers:** Resource IDs are opaque printable strings returned by the API; treat them as opaque and do not parse their internal structure.\n\n\
+            **References & expand:** Cross-resource links use objects such as `BlobLink` (`{ \"id\": \"…\" }`) instead of bare id strings where noted. Session list/detail responses default to a narrow `user` link (`id` + `email`); pass `expand=user` (comma-separated with other tokens as added) to embed the full `User`.\n\n\
             **JSON naming:** Object keys use `snake_case`. Enum wire values use the casing shown in each schema (broader enum casing standardization is planned).\n\n\
             **Pagination:** List endpoints accept `page` (0-based) and `page_size` (1–500, default 50). Responses include `X-Total-Count` with the total matching rows before pagination and RFC 5988 `Link` headers (relations: first, prev, next, last) where applicable.\n\n\
             **Rate limiting:** Versioned `/api/v1/*` routes use token-bucket limits per client IP (`Retry-After`, `X-RateLimit-*` on **429**; configurable via server settings).\n\n\
-            **Errors:** Failed requests return `Content-Type: application/problem+json` ([RFC 7807](https://www.rfc-editor.org/rfc/rfc7807)) with a `Problem` body. Stable machine-readable `code` values include: `unauthorized`, `forbidden`, `not_found`, `invalid_request`, `invalid_page_size`, `conflict`, `too_many_requests`, `not_acceptable`, `precondition_failed`, `internal`. Legacy schemas `ErrorResponse` and `ProblemDetails` remain listed for one release but are deprecated in favor of `Problem`.\n\n\
+            **Errors:** Failed requests return `Content-Type: application/problem+json` ([RFC 7807](https://www.rfc-editor.org/rfc/rfc7807)) with a `Problem` body (`type`, `title`, `status`, `code`, optional `detail` / `instance`). Use `detail` for human-readable text; stable machine-readable `code` values include: `unauthorized`, `forbidden`, `not_found`, `invalid_request`, `invalid_page_size`, `conflict`, `too_many_requests`, `not_acceptable`, `precondition_failed`, `internal`. Legacy schemas `ErrorResponse` and `ProblemDetails` remain listed for one release but are deprecated in favor of `Problem`.\n\n\
             **CSRF:** Cookie sessions use `SameSite=Lax`; state-changing methods are `POST`/`PUT`/`PATCH`/`DELETE` (not `GET`). Cross-site simple requests cannot mutate state via cookies under typical browser rules. Browser `fetch` from the SPA should use `credentials: 'same-origin'` (or include cookies only on same-site requests). API clients using bearer tokens should still avoid exposing tokens to third-party origins.\n\n\
             **Examples:** See schema `example` fields on core DTOs in the components section.",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT")
@@ -120,7 +125,8 @@ pub mod rest {
     components(
         schemas(
             User,
-            Session,
+            SessionBody,
+            SessionUserBody,
             Role,
             CreateUser,
             OtpRequest,
@@ -131,24 +137,31 @@ pub mod rest {
             ProblemDetails,
             Song,
             CreateSong,
+            UpdateSong,
             PatchSong,
             PatchSongData,
             SongDataSchema,
             SongUserSpecificAddons,
             Collection,
             CreateCollection,
+            UpdateCollection,
             PatchCollection,
             Setlist,
             CreateSetlist,
+            UpdateSetlist,
             PatchSetlist,
             Blob,
+            BlobLink,
             CreateBlob,
+            UpdateBlob,
             PatchBlob,
             FileType,
             SongLink,
             LikeStatus,
             Player,
             PlayerItem,
+            PlayerBlobItem,
+            PlayerChordsItem,
             TocItem,
             ScrollType,
             Orientation,

--- a/backend/src/expand.rs
+++ b/backend/src/expand.rs
@@ -1,0 +1,14 @@
+//! Parse `?expand=` (comma-separated tokens) for optional relation embedding.
+
+/// True when `expand` includes the `user` token (e.g. `expand=user` or `expand=team,user`).
+pub fn expand_includes_user(expand: &Option<String>) -> bool {
+    expand
+        .as_deref()
+        .map(|s| {
+            s.split(',')
+                .map(str::trim)
+                .filter(|t| !t.is_empty())
+                .any(|t| t == "user")
+        })
+        .unwrap_or(false)
+}

--- a/backend/src/http_tests.rs
+++ b/backend/src/http_tests.rs
@@ -293,6 +293,17 @@ mod openapi_problem_schema {
         );
 
         let paths = v["paths"].as_object().expect("paths");
+        let problem = schemas
+            .get("Problem")
+            .expect("Problem schema")
+            .get("properties")
+            .and_then(|p| p.as_object())
+            .expect("Problem.properties");
+        assert!(
+            !problem.contains_key("error"),
+            "Problem schema must not include legacy `error` property"
+        );
+
         for (path, path_item) in paths {
             let path_item = path_item.as_object().expect("path item");
             for method in ["get", "put", "post", "delete", "patch"] {
@@ -326,6 +337,44 @@ mod openapi_problem_schema {
                         "{path} {method} {status}: schema $ref should point to Problem, got {schema_ref:?}"
                     );
                 }
+            }
+        }
+    }
+
+    #[test]
+    fn blc_docs_004_openapi_schema_property_keys_are_snake_case() {
+        let openapi = crate::docs::ApiDoc::openapi();
+        let v = serde_json::to_value(openapi).expect("openapi serializes to JSON");
+        fn check(value: &serde_json::Value, ctx: &str) {
+            match value {
+                serde_json::Value::Object(map) => {
+                    if let Some(props) = map.get("properties").and_then(|p| p.as_object()) {
+                        for (key, child) in props {
+                            assert!(
+                                key.chars().next().is_some_and(|c| c.is_ascii_lowercase())
+                                    && key
+                                        .chars()
+                                        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_'),
+                                "{ctx}: property key {key:?} must be snake_case ASCII",
+                            );
+                            check(child, &format!("{ctx}.{key}"));
+                        }
+                    }
+                    for (k, child) in map {
+                        check(child, &format!("{ctx}/{k}"));
+                    }
+                }
+                serde_json::Value::Array(items) => {
+                    for (i, item) in items.iter().enumerate() {
+                        check(item, &format!("{ctx}[{i}]"));
+                    }
+                }
+                _ => {}
+            }
+        }
+        if let Some(schemas) = v["components"]["schemas"].as_object() {
+            for (name, schema) in schemas {
+                check(schema, &format!("components.schemas.{name}"));
             }
         }
     }

--- a/backend/src/http_tests.rs
+++ b/backend/src/http_tests.rs
@@ -352,9 +352,9 @@ mod openapi_problem_schema {
                         for (key, child) in props {
                             assert!(
                                 key.chars().next().is_some_and(|c| c.is_ascii_lowercase())
-                                    && key
-                                        .chars()
-                                        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_'),
+                                    && key.chars().all(|c| c.is_ascii_lowercase()
+                                        || c.is_ascii_digit()
+                                        || c == '_'),
                                 "{ctx}: property key {key:?} must be snake_case ASCII",
                             );
                             check(child, &format!("{ctx}.{key}"));

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -5,6 +5,7 @@ pub mod auth;
 pub mod database;
 pub mod docs;
 pub mod error;
+pub mod expand;
 pub mod frontend;
 pub mod governor_peer;
 pub mod http_cache;

--- a/backend/src/resources/blob/mod.rs
+++ b/backend/src/resources/blob/mod.rs
@@ -1,4 +1,4 @@
-pub use shared::blob::{Blob, CreateBlob, PatchBlob};
+pub use shared::blob::{Blob, CreateBlob, PatchBlob, UpdateBlob};
 
 mod model;
 mod repository;

--- a/backend/src/resources/blob/rest.rs
+++ b/backend/src/resources/blob/rest.rs
@@ -13,9 +13,9 @@ use crate::http_cache::{
 use crate::resources::User;
 #[allow(unused_imports)]
 use crate::resources::blob::Blob;
-use crate::resources::blob::{CreateBlob, UpdateBlob};
 use crate::resources::blob::PatchBlob;
 use crate::resources::blob::service::BlobServiceHandle;
+use crate::resources::blob::{CreateBlob, UpdateBlob};
 use crate::resources::team::UserPermissions;
 use shared::api::{ListQuery, PAGE_SIZE_DEFAULT};
 
@@ -198,10 +198,7 @@ async fn update_blob(
     let etag = weak_etag_json(&blob).map_err(|e| AppError::Internal(e.to_string()))?;
     check_if_match(&req, &etag)?;
     let payload = CreateBlob::from(payload.into_inner());
-    Ok(HttpResponse::Ok().json(
-        svc.update_blob_for_user(&perms, &id, payload)
-            .await?,
-    ))
+    Ok(HttpResponse::Ok().json(svc.update_blob_for_user(&perms, &id, payload).await?))
 }
 
 #[utoipa::path(

--- a/backend/src/resources/blob/rest.rs
+++ b/backend/src/resources/blob/rest.rs
@@ -13,7 +13,7 @@ use crate::http_cache::{
 use crate::resources::User;
 #[allow(unused_imports)]
 use crate::resources::blob::Blob;
-use crate::resources::blob::CreateBlob;
+use crate::resources::blob::{CreateBlob, UpdateBlob};
 use crate::resources::blob::PatchBlob;
 use crate::resources::blob::service::BlobServiceHandle;
 use crate::resources::team::UserPermissions;
@@ -168,9 +168,9 @@ async fn create_blob(
     params(
         ("id" = String, Path, description = "Blob identifier")
     ),
-    request_body = CreateBlob,
+    request_body = UpdateBlob,
     responses(
-        (status = 200, description = "Update an existing blob", body = Blob),
+        (status = 200, description = "Replace blob metadata (`PUT` is full replacement; `owner` is not client-settable).", body = Blob),
         (status = 400, description = "Invalid blob identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
         (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
@@ -190,15 +190,16 @@ async fn update_blob(
     svc: Data<BlobServiceHandle>,
     user: ReqData<User>,
     id: PathParam<String>,
-    payload: Json<CreateBlob>,
+    payload: Json<UpdateBlob>,
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let id = id.into_inner();
     let blob = svc.get_blob_for_user(&perms, &id).await?;
     let etag = weak_etag_json(&blob).map_err(|e| AppError::Internal(e.to_string()))?;
     check_if_match(&req, &etag)?;
+    let payload = CreateBlob::from(payload.into_inner());
     Ok(HttpResponse::Ok().json(
-        svc.update_blob_for_user(&perms, &id, payload.into_inner())
+        svc.update_blob_for_user(&perms, &id, payload)
             .await?,
     ))
 }

--- a/backend/src/resources/collection/mod.rs
+++ b/backend/src/resources/collection/mod.rs
@@ -1,4 +1,4 @@
-pub use shared::collection::{Collection, CreateCollection, PatchCollection};
+pub use shared::collection::{Collection, CreateCollection, PatchCollection, UpdateCollection};
 
 mod model;
 mod repository;

--- a/backend/src/resources/collection/rest.rs
+++ b/backend/src/resources/collection/rest.rs
@@ -12,9 +12,9 @@ use crate::http_cache::{check_if_match, if_none_match_matches, weak_etag_json};
 use crate::resources::User;
 #[allow(unused_imports)]
 use crate::resources::collection::Collection;
-use crate::resources::collection::{CreateCollection, UpdateCollection};
 use crate::resources::collection::PatchCollection;
 use crate::resources::collection::service::CollectionServiceHandle;
+use crate::resources::collection::{CreateCollection, UpdateCollection};
 #[allow(unused_imports)]
 use crate::resources::song::Song;
 use crate::resources::team::UserPermissions;
@@ -296,10 +296,7 @@ async fn update_collection(
     let etag = weak_etag_json(&collection).map_err(|e| AppError::Internal(e.to_string()))?;
     check_if_match(&req, &etag)?;
     let payload = CreateCollection::from(payload.into_inner());
-    Ok(HttpResponse::Ok().json(
-        svc.update_collection_for_user(&perms, &id, payload)
-            .await?,
-    ))
+    Ok(HttpResponse::Ok().json(svc.update_collection_for_user(&perms, &id, payload).await?))
 }
 
 #[utoipa::path(

--- a/backend/src/resources/collection/rest.rs
+++ b/backend/src/resources/collection/rest.rs
@@ -12,7 +12,7 @@ use crate::http_cache::{check_if_match, if_none_match_matches, weak_etag_json};
 use crate::resources::User;
 #[allow(unused_imports)]
 use crate::resources::collection::Collection;
-use crate::resources::collection::CreateCollection;
+use crate::resources::collection::{CreateCollection, UpdateCollection};
 use crate::resources::collection::PatchCollection;
 use crate::resources::collection::service::CollectionServiceHandle;
 #[allow(unused_imports)]
@@ -266,9 +266,9 @@ async fn create_collection(
     params(
         ("id" = String, Path, description = "Collection identifier")
     ),
-    request_body = CreateCollection,
+    request_body = UpdateCollection,
     responses(
-        (status = 200, description = "Update an existing collection", body = Collection),
+        (status = 200, description = "Replace collection fields (`PUT` is full replacement, not upsert; missing id returns **404**).", body = Collection),
         (status = 400, description = "Invalid collection identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
         (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
@@ -288,15 +288,16 @@ async fn update_collection(
     svc: Data<CollectionServiceHandle>,
     user: ReqData<User>,
     id: Path<String>,
-    payload: Json<CreateCollection>,
+    payload: Json<UpdateCollection>,
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let id = id.into_inner();
     let collection = svc.get_collection_for_user(&perms, &id).await?;
     let etag = weak_etag_json(&collection).map_err(|e| AppError::Internal(e.to_string()))?;
     check_if_match(&req, &etag)?;
+    let payload = CreateCollection::from(payload.into_inner());
     Ok(HttpResponse::Ok().json(
-        svc.update_collection_for_user(&perms, &id, payload.into_inner())
+        svc.update_collection_for_user(&perms, &id, payload)
             .await?,
     ))
 }

--- a/backend/src/resources/mod.rs
+++ b/backend/src/resources/mod.rs
@@ -3,16 +3,16 @@ pub mod rest;
 mod common;
 
 pub mod blob;
-pub use blob::{Blob, CreateBlob};
+pub use blob::{Blob, CreateBlob, UpdateBlob};
 
 pub mod collection;
-pub use collection::{Collection, CreateCollection};
+pub use collection::{Collection, CreateCollection, UpdateCollection};
 
 pub mod setlist;
-pub use setlist::{CreateSetlist, Setlist};
+pub use setlist::{CreateSetlist, Setlist, UpdateSetlist};
 
 pub mod song;
-pub use song::{CreateSong, Song};
+pub use song::{CreateSong, Song, UpdateSong};
 
 pub mod team;
 

--- a/backend/src/resources/setlist/mod.rs
+++ b/backend/src/resources/setlist/mod.rs
@@ -1,4 +1,4 @@
-pub use shared::setlist::{CreateSetlist, PatchSetlist, Setlist};
+pub use shared::setlist::{CreateSetlist, PatchSetlist, Setlist, UpdateSetlist};
 
 mod model;
 mod repository;

--- a/backend/src/resources/setlist/rest.rs
+++ b/backend/src/resources/setlist/rest.rs
@@ -10,7 +10,7 @@ use crate::docs::Problem;
 use crate::error::AppError;
 use crate::http_cache::{check_if_match, if_none_match_matches, weak_etag_json};
 use crate::resources::User;
-use crate::resources::setlist::CreateSetlist;
+use crate::resources::setlist::{CreateSetlist, UpdateSetlist};
 use crate::resources::setlist::PatchSetlist;
 #[allow(unused_imports)]
 use crate::resources::setlist::Setlist;
@@ -266,9 +266,9 @@ async fn create_setlist(
     params(
         ("id" = String, Path, description = "Setlist identifier")
     ),
-    request_body = CreateSetlist,
+    request_body = UpdateSetlist,
     responses(
-        (status = 200, description = "Update an existing setlist", body = Setlist),
+        (status = 200, description = "Replace setlist fields (`PUT` is full replacement, not upsert; missing id returns **404**).", body = Setlist),
         (status = 400, description = "Invalid setlist identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
         (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
@@ -288,15 +288,16 @@ async fn update_setlist(
     svc: Data<SetlistServiceHandle>,
     user: ReqData<User>,
     id: Path<String>,
-    payload: Json<CreateSetlist>,
+    payload: Json<UpdateSetlist>,
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let id = id.into_inner();
     let setlist = svc.get_setlist_for_user(&perms, &id).await?;
     let etag = weak_etag_json(&setlist).map_err(|e| AppError::Internal(e.to_string()))?;
     check_if_match(&req, &etag)?;
+    let payload = CreateSetlist::from(payload.into_inner());
     Ok(HttpResponse::Ok().json(
-        svc.update_setlist_for_user(&perms, &id, payload.into_inner())
+        svc.update_setlist_for_user(&perms, &id, payload)
             .await?,
     ))
 }

--- a/backend/src/resources/setlist/rest.rs
+++ b/backend/src/resources/setlist/rest.rs
@@ -10,11 +10,11 @@ use crate::docs::Problem;
 use crate::error::AppError;
 use crate::http_cache::{check_if_match, if_none_match_matches, weak_etag_json};
 use crate::resources::User;
-use crate::resources::setlist::{CreateSetlist, UpdateSetlist};
 use crate::resources::setlist::PatchSetlist;
 #[allow(unused_imports)]
 use crate::resources::setlist::Setlist;
 use crate::resources::setlist::SetlistServiceHandle;
+use crate::resources::setlist::{CreateSetlist, UpdateSetlist};
 #[allow(unused_imports)]
 use crate::resources::song::Song;
 use crate::resources::team::UserPermissions;
@@ -296,10 +296,7 @@ async fn update_setlist(
     let etag = weak_etag_json(&setlist).map_err(|e| AppError::Internal(e.to_string()))?;
     check_if_match(&req, &etag)?;
     let payload = CreateSetlist::from(payload.into_inner());
-    Ok(HttpResponse::Ok().json(
-        svc.update_setlist_for_user(&perms, &id, payload)
-            .await?,
-    ))
+    Ok(HttpResponse::Ok().json(svc.update_setlist_for_user(&perms, &id, payload).await?))
 }
 
 #[utoipa::path(

--- a/backend/src/resources/song/mod.rs
+++ b/backend/src/resources/song/mod.rs
@@ -1,4 +1,4 @@
-pub use shared::song::{CreateSong, PatchSong, PatchSongData, Song};
+pub use shared::song::{CreateSong, PatchSong, PatchSongData, Song, UpdateSong};
 
 mod liked;
 mod model;

--- a/backend/src/resources/song/model.rs
+++ b/backend/src/resources/song/model.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use surrealdb::sql::{Id, Thing};
 
 use chordlib::types::Song as SongData;
+use shared::blob::BlobLink;
 use shared::song::{CreateSong, Song, SongUserSpecificAddons};
 
 use crate::resources::common::blob_thing;
@@ -27,7 +28,13 @@ impl SongRecord {
             id: self.id.map(id_from_thing).unwrap_or_default(),
             owner: self.owner.map(id_from_thing).unwrap_or_default(),
             not_a_song: self.not_a_song,
-            blobs: self.blobs.into_iter().map(id_from_thing).collect(),
+            blobs: self
+                .blobs
+                .into_iter()
+                .map(|t| BlobLink {
+                    id: id_from_thing(t),
+                })
+                .collect(),
             data: self.data,
             user_specific_addons: SongUserSpecificAddons::default(),
         }
@@ -42,7 +49,7 @@ impl SongRecord {
             blobs: song
                 .blobs
                 .into_iter()
-                .map(|blob_id| blob_thing(&blob_id))
+                .map(|blob| blob_thing(&blob.id))
                 .collect(),
             data: song.data,
             search_content,
@@ -115,7 +122,12 @@ mod tests {
         assert_eq!(song.id, "s1");
         assert_eq!(song.owner, "t9");
         assert!(song.not_a_song);
-        assert_eq!(song.blobs, vec!["b1".to_string()]);
+        assert_eq!(
+            song.blobs,
+            vec![BlobLink {
+                id: "b1".to_string()
+            }]
+        );
     }
 
     #[test]
@@ -137,7 +149,14 @@ mod tests {
         .expect("song data json");
         let create = CreateSong {
             not_a_song: false,
-            blobs: vec!["blob:bb".into(), "rawblob".into()],
+            blobs: vec![
+                BlobLink {
+                    id: "blob:bb".into(),
+                },
+                BlobLink {
+                    id: "rawblob".into(),
+                },
+            ],
             data,
         };
         let record = SongRecord::from_payload(None, None, create);

--- a/backend/src/resources/song/rest.rs
+++ b/backend/src/resources/song/rest.rs
@@ -10,7 +10,7 @@ use crate::docs::Problem;
 use crate::error::AppError;
 use crate::http_cache::{check_if_match, if_none_match_matches, weak_etag_json};
 use crate::resources::User;
-use crate::resources::song::CreateSong;
+use crate::resources::song::{CreateSong, UpdateSong};
 use crate::resources::song::PatchSong;
 #[allow(unused_imports)]
 use crate::resources::song::Song;
@@ -207,9 +207,9 @@ async fn create_song(
     params(
         ("id" = String, Path, description = "Song identifier")
     ),
-    request_body = CreateSong,
+    request_body = UpdateSong,
     responses(
-        (status = 200, description = "Updated an existing song.", body = Song),
+        (status = 200, description = "Updated an existing song. Upsert: if the id did not exist, responds **201** with `Location` (see BLC / `http-contract.md`).", body = Song),
         (status = 201, description = "Created the song via PUT upsert (new id). Response includes `Location: /api/v1/songs/{id}`.", body = Song),
         (status = 400, description = "Invalid song identifier", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
@@ -230,11 +230,12 @@ async fn update_song(
     svc: Data<SongServiceHandle>,
     user: ReqData<User>,
     id: Path<String>,
-    payload: Json<CreateSong>,
+    payload: Json<UpdateSong>,
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let payload = payload.into_inner();
     payload.validate().map_err(AppError::invalid_request)?;
+    let payload = CreateSong::from(payload);
     let id = id.into_inner();
     match svc.get_song_for_user(&perms, &id).await {
         Ok(song) => {

--- a/backend/src/resources/song/rest.rs
+++ b/backend/src/resources/song/rest.rs
@@ -10,12 +10,12 @@ use crate::docs::Problem;
 use crate::error::AppError;
 use crate::http_cache::{check_if_match, if_none_match_matches, weak_etag_json};
 use crate::resources::User;
-use crate::resources::song::{CreateSong, UpdateSong};
 use crate::resources::song::PatchSong;
 #[allow(unused_imports)]
 use crate::resources::song::Song;
 use crate::resources::song::SongUpsertOutcome;
 use crate::resources::song::service::SongServiceHandle;
+use crate::resources::song::{CreateSong, UpdateSong};
 use crate::resources::team::UserPermissions;
 use shared::api::{PAGE_SIZE_DEFAULT, SongListQuery};
 #[allow(unused_imports)]

--- a/backend/src/resources/song/service.rs
+++ b/backend/src/resources/song/service.rs
@@ -349,6 +349,8 @@ impl SongServiceHandle {
 
 #[cfg(test)]
 mod tests {
+    use shared::blob::BlobLink;
+
     use crate::resources::team::UserPermissions;
     use crate::test_helpers::{
         configure_personal_team_members, create_song_with_title, create_user, personal_team_id,
@@ -831,7 +833,9 @@ mod tests {
                     &owner_p,
                     CreateSong {
                         not_a_song: false,
-                        blobs: vec!["base_blob".into()],
+                        blobs: vec![BlobLink {
+                            id: "base_blob".into(),
+                        }],
                         data: base_data.clone(),
                     },
                 )
@@ -843,9 +847,13 @@ mod tests {
             let include_data = (mask & 0b100) != 0;
             let expected_not_a_song = include_not_a_song;
             let expected_blobs = if include_blobs {
-                vec!["patched_blob".to_string()]
+                vec![BlobLink {
+                    id: "patched_blob".into(),
+                }]
             } else {
-                vec!["base_blob".to_string()]
+                vec![BlobLink {
+                    id: "base_blob".into(),
+                }]
             };
             let expected_title = if include_data {
                 "PatchedTitle"
@@ -859,7 +867,9 @@ mod tests {
                     &created.id,
                     PatchSong {
                         not_a_song: include_not_a_song.then_some(true),
-                        blobs: include_blobs.then_some(vec!["patched_blob".into()]),
+                        blobs: include_blobs.then_some(vec![BlobLink {
+                            id: "patched_blob".into(),
+                        }]),
                         data: include_data.then_some(patch_data.clone()),
                     },
                 )

--- a/backend/src/resources/song/surreal_repo.rs
+++ b/backend/src/resources/song/surreal_repo.rs
@@ -200,7 +200,7 @@ impl SongRepository for SurrealSongRepo {
         let resource = resource_id("song", id)?;
         let (tb, sid) = resource.clone();
         let search_content = search_content_from_song_data(&song.data);
-        let blobs: Vec<Thing> = song.blobs.iter().map(|b| blob_thing(b)).collect();
+        let blobs: Vec<Thing> = song.blobs.iter().map(|b| blob_thing(&b.id)).collect();
 
         let mut response = db
             .db

--- a/backend/src/resources/user/session/rest.rs
+++ b/backend/src/resources/user/session/rest.rs
@@ -6,14 +6,30 @@ use actix_web::{
 use serde::Deserialize;
 
 use shared::api::{ListQuery, PAGE_SIZE_DEFAULT, PageQuery};
+use shared::user::SessionBody;
 
 #[allow(unused_imports)]
 use crate::docs::Problem;
 use crate::error::AppError;
+use crate::expand::expand_includes_user;
 use crate::resources::User;
 use crate::settings::CookieConfig;
 
 use super::service::SessionServiceHandle;
+
+#[derive(Debug, Deserialize)]
+struct SessionsPageQuery {
+    #[serde(flatten)]
+    page: PageQuery,
+    /// Comma-separated relations to expand. Use `user` to embed the full [`crate::resources::User`] instead of the default `id`+`email` link.
+    expand: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpandQuery {
+    /// Comma-separated relations to expand (`user` → full user object on `user`).
+    expand: Option<String>,
+}
 
 #[utoipa::path(
     get,
@@ -21,9 +37,10 @@ use super::service::SessionServiceHandle;
     params(
         ("page" = Option<u32>, Query, description = "Zero-based page. With `page_size`, `X-Total-Count` is pre-pagination total (`list-pagination.md`).", minimum = 0, nullable = true),
         ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50. Omit with `page` for full list.", minimum = 1, maximum = 500, example = 50, nullable = true),
+        ("expand" = Option<String>, Query, description = "Optional comma-separated relations (`user` = embed full user on each session; default is `id`+`email` link only)."),
     ),
     responses(
-        (status = 200, description = "Returns active sessions for the current user. `X-Total-Count` is the total before paging.", body = [Session]),
+        (status = 200, description = "Returns active sessions for the current user. `X-Total-Count` is the total before paging.", body = [SessionBody]),
         (status = 400, description = "Invalid pagination parameters", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
         (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
@@ -40,18 +57,23 @@ pub async fn get_sessions_for_current_user(
     req: HttpRequest,
     svc: Data<SessionServiceHandle>,
     user: ReqData<User>,
-    query: Query<PageQuery>,
+    query: Query<SessionsPageQuery>,
 ) -> Result<HttpResponse, AppError> {
-    let query = query
-        .into_inner()
+    let SessionsPageQuery { page, expand } = query.into_inner();
+    let page = page
         .validate()
         .map_err(crate::error::map_list_query_error)?;
-    let q_link = query.clone();
-    let cur_page = query.page.unwrap_or(0);
-    let page_size = query.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
+    let expand_user = expand_includes_user(&expand);
+    let q_link = page.clone();
+    let cur_page = page.page.unwrap_or(0);
+    let page_size = page.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
     let sessions = svc.get_sessions_by_user_id(&user.id).await?;
-    let lq = query.as_list_query();
+    let lq = page.as_list_query();
     let (sessions_page, total) = ListQuery::paginate_nested_vec(sessions, &lq);
+    let sessions_page: Vec<SessionBody> = sessions_page
+        .into_iter()
+        .map(|s| SessionBody::from_session(s, expand_user))
+        .collect();
     Ok(HttpResponse::Ok()
         .insert_header((
             header::HeaderName::from_static("x-total-count"),
@@ -74,10 +96,11 @@ pub async fn get_sessions_for_current_user(
     get,
     path = "/api/v1/users/me/sessions/{id}",
     params(
-        ("id" = String, Path, description = "Session identifier")
+        ("id" = String, Path, description = "Session identifier"),
+        ("expand" = Option<String>, Query, description = "Optional `user` to embed full user (default: `id`+`email` link)."),
     ),
     responses(
-        (status = 200, description = "Returns a session for the current user", body = Session),
+        (status = 200, description = "Returns a session for the current user", body = SessionBody),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
         (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Session not found for current user", body = Problem, content_type = "application/problem+json"),
@@ -94,8 +117,13 @@ pub async fn get_session_for_current_user(
     svc: Data<SessionServiceHandle>,
     user: ReqData<User>,
     path: Path<SessionPath>,
+    expand: Query<ExpandQuery>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Ok().json(svc.get_session_for_user(&path.id, &user.id).await?))
+    let session = svc.get_session_for_user(&path.id, &user.id).await?;
+    Ok(HttpResponse::Ok().json(SessionBody::from_session(
+        session,
+        expand_includes_user(&expand.expand),
+    )))
 }
 
 #[utoipa::path(
@@ -131,10 +159,11 @@ pub async fn delete_session_for_current_user(
     post,
     path = "/api/v1/users/{user_id}/sessions",
     params(
-        ("user_id" = String, Path, description = "User identifier")
+        ("user_id" = String, Path, description = "User identifier"),
+        ("expand" = Option<String>, Query, description = "Optional `user` to embed full user in the response (default: link)."),
     ),
     responses(
-        (status = 201, description = "Creates a session for the specified user", body = Session),
+        (status = 201, description = "Creates a session for the specified user", body = SessionBody),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
         (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 403, description = "Admin role required", body = Problem, content_type = "application/problem+json"),
@@ -151,12 +180,16 @@ pub async fn create_session_for_user(
     svc: Data<SessionServiceHandle>,
     cookie_cfg: Data<CookieConfig>,
     path: Path<UserIdPath>,
+    expand: Query<ExpandQuery>,
 ) -> Result<HttpResponse, AppError> {
     let ttl = cookie_cfg.session_ttl_seconds as i64;
-    Ok(HttpResponse::Created().json(
-        svc.create_session_for_user_by_id(&path.user_id, ttl)
-            .await?,
-    ))
+    let session = svc
+        .create_session_for_user_by_id(&path.user_id, ttl)
+        .await?;
+    Ok(HttpResponse::Created().json(SessionBody::from_session(
+        session,
+        expand_includes_user(&expand.expand),
+    )))
 }
 
 #[utoipa::path(
@@ -166,9 +199,10 @@ pub async fn create_session_for_user(
         ("user_id" = String, Path, description = "User identifier"),
         ("page" = Option<u32>, Query, description = "Zero-based page. With `page_size`, `X-Total-Count` is pre-pagination total (`list-pagination.md`).", minimum = 0, nullable = true),
         ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50. Omit with `page` for full list.", minimum = 1, maximum = 500, example = 50, nullable = true),
+        ("expand" = Option<String>, Query, description = "Optional comma-separated relations (`user` = full user per session)."),
     ),
     responses(
-        (status = 200, description = "Returns active sessions for the specified user. `X-Total-Count` is the total before paging.", body = [Session]),
+        (status = 200, description = "Returns active sessions for the specified user. `X-Total-Count` is the total before paging.", body = [SessionBody]),
         (status = 400, description = "Invalid pagination parameters", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
         (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
@@ -186,18 +220,23 @@ pub async fn get_sessions_for_user(
     req: HttpRequest,
     svc: Data<SessionServiceHandle>,
     path: Path<UserIdPath>,
-    query: Query<PageQuery>,
+    query: Query<SessionsPageQuery>,
 ) -> Result<HttpResponse, AppError> {
-    let query = query
-        .into_inner()
+    let SessionsPageQuery { page, expand } = query.into_inner();
+    let page = page
         .validate()
         .map_err(crate::error::map_list_query_error)?;
-    let q_link = query.clone();
-    let cur_page = query.page.unwrap_or(0);
-    let page_size = query.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
+    let expand_user = expand_includes_user(&expand);
+    let q_link = page.clone();
+    let cur_page = page.page.unwrap_or(0);
+    let page_size = page.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
     let sessions = svc.get_sessions_by_user_id(&path.user_id).await?;
-    let lq = query.as_list_query();
+    let lq = page.as_list_query();
     let (sessions_page, total) = ListQuery::paginate_nested_vec(sessions, &lq);
+    let sessions_page: Vec<SessionBody> = sessions_page
+        .into_iter()
+        .map(|s| SessionBody::from_session(s, expand_user))
+        .collect();
     Ok(HttpResponse::Ok()
         .insert_header((
             header::HeaderName::from_static("x-total-count"),
@@ -221,10 +260,11 @@ pub async fn get_sessions_for_user(
     path = "/api/v1/users/{user_id}/sessions/{id}",
     params(
         ("user_id" = String, Path, description = "User identifier"),
-        ("id" = String, Path, description = "Session identifier")
+        ("id" = String, Path, description = "Session identifier"),
+        ("expand" = Option<String>, Query, description = "Optional `user` to embed full user."),
     ),
     responses(
-        (status = 200, description = "Returns a session for the specified user", body = Session),
+        (status = 200, description = "Returns a session for the specified user", body = SessionBody),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
         (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 403, description = "Admin role required", body = Problem, content_type = "application/problem+json"),
@@ -241,8 +281,15 @@ pub async fn get_sessions_for_user(
 pub async fn get_session_for_user(
     svc: Data<SessionServiceHandle>,
     path: Path<UserSessionPath>,
+    expand: Query<ExpandQuery>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Ok().json(svc.get_session_for_user(&path.id, &path.user_id).await?))
+    let session = svc
+        .get_session_for_user(&path.id, &path.user_id)
+        .await?;
+    Ok(HttpResponse::Ok().json(SessionBody::from_session(
+        session,
+        expand_includes_user(&expand.expand),
+    )))
 }
 
 #[utoipa::path(

--- a/backend/src/resources/user/session/rest.rs
+++ b/backend/src/resources/user/session/rest.rs
@@ -283,9 +283,7 @@ pub async fn get_session_for_user(
     path: Path<UserSessionPath>,
     expand: Query<ExpandQuery>,
 ) -> Result<HttpResponse, AppError> {
-    let session = svc
-        .get_session_for_user(&path.id, &path.user_id)
-        .await?;
+    let session = svc.get_session_for_user(&path.id, &path.user_id).await?;
     Ok(HttpResponse::Ok().json(SessionBody::from_session(
         session,
         expand_includes_user(&expand.expand),

--- a/cli/src/handlers/blobs.rs
+++ b/cli/src/handlers/blobs.rs
@@ -1,5 +1,5 @@
 use shared::api::{ApiClient, ListQuery};
-use shared::blob::CreateBlob;
+use shared::blob::{CreateBlob, UpdateBlob};
 use shared::net::DefaultHttpClient;
 
 use crate::commands::BlobsCommand;
@@ -49,7 +49,7 @@ pub async fn handle_blobs(
         }
         BlobsCommand::Update { id, json } => {
             validate_resource_id(&id)?;
-            let payload: CreateBlob = serde_json::from_str(&json)?;
+            let payload: UpdateBlob = serde_json::from_str(&json)?;
             if dry_run {
                 let planned = serde_json::json!({
                     "method": "PUT",

--- a/cli/src/handlers/collections.rs
+++ b/cli/src/handlers/collections.rs
@@ -1,5 +1,5 @@
 use shared::api::{ApiClient, ListQuery};
-use shared::collection::CreateCollection;
+use shared::collection::{CreateCollection, UpdateCollection};
 use shared::net::DefaultHttpClient;
 
 use crate::commands::CollectionsCommand;
@@ -64,7 +64,7 @@ pub async fn handle_collections(
         }
         CollectionsCommand::Update { id, json } => {
             validate_resource_id(&id)?;
-            let payload: CreateCollection = serde_json::from_str(&json)?;
+            let payload: UpdateCollection = serde_json::from_str(&json)?;
             if dry_run {
                 let planned = serde_json::json!({
                     "method": "PUT",

--- a/cli/src/handlers/setlists.rs
+++ b/cli/src/handlers/setlists.rs
@@ -1,6 +1,6 @@
 use shared::api::{ApiClient, ListQuery};
 use shared::net::DefaultHttpClient;
-use shared::setlist::CreateSetlist;
+use shared::setlist::{CreateSetlist, UpdateSetlist};
 
 use crate::commands::SetlistsCommand;
 use crate::output::{self, OutputFormat};
@@ -62,7 +62,7 @@ pub async fn handle_setlists(
         }
         SetlistsCommand::Update { id, json } => {
             validate_resource_id(&id)?;
-            let payload: CreateSetlist = serde_json::from_str(&json)?;
+            let payload: UpdateSetlist = serde_json::from_str(&json)?;
             if dry_run {
                 let planned = serde_json::json!({
                     "method": "PUT",

--- a/cli/src/handlers/songs.rs
+++ b/cli/src/handlers/songs.rs
@@ -1,6 +1,6 @@
 use shared::api::{ApiClient, ListQuery};
 use shared::net::DefaultHttpClient;
-use shared::song::CreateSong;
+use shared::song::{CreateSong, UpdateSong};
 
 use crate::commands::SongsCommand;
 use crate::output::{self, OutputFormat};
@@ -54,7 +54,7 @@ pub async fn handle_songs(
         }
         SongsCommand::Update { id, json } => {
             validate_resource_id(&id)?;
-            let payload: CreateSong = serde_json::from_str(&json)?;
+            let payload: UpdateSong = serde_json::from_str(&json)?;
             if dry_run {
                 let planned = serde_json::json!({
                     "method": "PUT",

--- a/docs/api-breaking-2-0.md
+++ b/docs/api-breaking-2-0.md
@@ -1,0 +1,44 @@
+# API 2.0 breaking changes (`/api/v1`)
+
+OpenAPI `info.version` is **2.0.0**. Wire-format changes below apply to the same `/api/v1` prefix unless noted.
+
+## `PlayerItem` (player JSON)
+
+- **Before:** Externally tagged variants with PascalCase keys, e.g. `{ "Blob": "id" }`, `{ "Chords": { …song } }`.
+- **After:** Internally tagged `{ "type": "blob", "blob_id": "…" }` and `{ "type": "chords", "song": { … } }`.
+
+Affected responses: `GET …/songs/{id}/player`, `GET …/collections/{id}/player`, `GET …/setlists/{id}/player`.
+
+## `Song.blobs`
+
+- **Before:** `blobs: string[]` (raw blob ids).
+- **After:** `blobs: { "id": string }[]` ([`BlobLink`](../shared/src/blob/blob.rs)).
+
+## Sessions
+
+- **Wire type:** Responses use [`SessionBody`](../shared/src/user/session.rs) (OpenAPI component), not the internal storage shape.
+- **Default `user`:** `id` + `email` only (link).
+- **Embed full user:** `GET`/`POST` session endpoints accept `expand=user` (comma-separated list). The bundled API client appends `expand=user` for session calls so existing tooling still receives full `User` JSON by default.
+
+## Problem (errors)
+
+- **Removed:** Top-level `error` (duplicate of `detail`). Clients must use `detail` and `code`.
+
+## PUT request bodies
+
+Dedicated OpenAPI types (same JSON shape as before, new schema names):
+
+| Resource    | PUT body schema   |
+|------------|-------------------|
+| Song       | `UpdateSong`      |
+| Collection | `UpdateCollection`|
+| Setlist    | `UpdateSetlist`   |
+| Blob       | `UpdateBlob`      |
+
+`PUT /songs/{id}` remains **upsert** (201 + `Location` when created). Other PUTs are **replace** on existing ids only (404 when missing).
+
+## Verification
+
+- Rust guard: `cargo test -p backend blc_docs_004` (schema property keys snake_case).
+- CI also runs [Spectral](https://stoplight.io/open-source/spectral) on generated OpenAPI (ruleset [`.spectral.yaml`](../.spectral.yaml)).
+- Regenerate OpenAPI locally: `cargo run --manifest-path backend/Cargo.toml --example print_openapi`.

--- a/docs/business-logic-constraints/create-update-policy.md
+++ b/docs/business-logic-constraints/create-update-policy.md
@@ -1,0 +1,17 @@
+# Create vs update request bodies
+
+## Rule
+
+- Use **`Create*`** for **POST** (new resource, server assigns id where applicable).
+- Use **`Update*`** for **PUT** when the operation is a full replacement of client-writable fields on an **existing** id, or when documenting upsert semantics separately (see songs).
+- Use **`Patch*`** for **PATCH** (partial update, absent fields unchanged).
+
+If POST and PUT accept the **same** fields and differ only by id placement, `Update*` may mirror `Create*` (duplicate struct) so OpenAPI and clients distinguish create vs replace intent.
+
+## Upsert
+
+- **Songs:** `PUT /api/v1/songs/{id}` may return **201 Created** with `Location` when the id did not exist (upsert). Other resources return **404** for unknown ids on PUT unless documented otherwise.
+
+## Team
+
+`CreateTeam`, `UpdateTeam`, and `PatchTeam` already follow this split.

--- a/frontend/src/api/api.rs
+++ b/frontend/src/api/api.rs
@@ -2,17 +2,17 @@ use yew_router::prelude::Navigator;
 
 use shared::auth::otp::{OtpRequest, OtpVerify};
 use shared::blob::Blob;
-use shared::blob::CreateBlob;
+use shared::blob::{CreateBlob, UpdateBlob};
 use shared::collection::Collection;
-use shared::collection::CreateCollection;
+use shared::collection::{CreateCollection, UpdateCollection};
 use shared::error::NetworkClientError;
 use shared::net::{DefaultHttpClient, HttpClientConfig};
 use shared::player::Player;
-use shared::setlist::CreateSetlist;
+use shared::setlist::{CreateSetlist, UpdateSetlist};
 use shared::setlist::Setlist;
-use shared::song::CreateSong;
+use shared::song::{CreateSong, UpdateSong};
 use shared::song::Song;
-use shared::user::{CreateUser, Session, User};
+use shared::user::{CreateUser, SessionBody, User};
 
 use super::error::{ApiError, OperationType};
 use crate::route::Route;
@@ -86,7 +86,7 @@ impl Api {
     }
 
     #[allow(dead_code)]
-    pub async fn verify_otp(&self, email: String, code: String) -> Result<Session, ApiError> {
+    pub async fn verify_otp(&self, email: String, code: String) -> Result<SessionBody, ApiError> {
         ApiError::check_and_notify_offline(OperationType::Write);
         self.client
             .verify_otp(OtpVerify { email, code })
@@ -155,7 +155,7 @@ impl Api {
     }
 
     #[allow(dead_code)]
-    pub async fn get_sessions_for_current_user(&self) -> Result<Vec<Session>, ApiError> {
+    pub async fn get_sessions_for_current_user(&self) -> Result<Vec<SessionBody>, ApiError> {
         ApiError::check_and_notify_offline(OperationType::Read);
         self.client
             .list_my_sessions(ListQuery::default())
@@ -164,7 +164,7 @@ impl Api {
     }
 
     #[allow(dead_code)]
-    pub async fn get_session_for_current_user(&self, id: &str) -> Result<Session, ApiError> {
+    pub async fn get_session_for_current_user(&self, id: &str) -> Result<SessionBody, ApiError> {
         ApiError::check_and_notify_offline(OperationType::Read);
         self.client
             .get_my_session(id)
@@ -182,7 +182,7 @@ impl Api {
     }
 
     #[allow(dead_code)]
-    pub async fn get_sessions_for_user(&self, user_id: &str) -> Result<Vec<Session>, ApiError> {
+    pub async fn get_sessions_for_user(&self, user_id: &str) -> Result<Vec<SessionBody>, ApiError> {
         ApiError::check_and_notify_offline(OperationType::Read);
         self.client
             .list_sessions_for_user(user_id, ListQuery::default())
@@ -191,7 +191,11 @@ impl Api {
     }
 
     #[allow(dead_code)]
-    pub async fn get_session_for_user(&self, user_id: &str, id: &str) -> Result<Session, ApiError> {
+    pub async fn get_session_for_user(
+        &self,
+        user_id: &str,
+        id: &str,
+    ) -> Result<SessionBody, ApiError> {
         ApiError::check_and_notify_offline(OperationType::Read);
         self.client
             .get_session_for_user(user_id, id)
@@ -200,7 +204,7 @@ impl Api {
     }
 
     #[allow(dead_code)]
-    pub async fn create_session_for_user(&self, user_id: &str) -> Result<Session, ApiError> {
+    pub async fn create_session_for_user(&self, user_id: &str) -> Result<SessionBody, ApiError> {
         ApiError::check_and_notify_offline(OperationType::Write);
         self.client
             .create_session_for_user(user_id)
@@ -255,7 +259,7 @@ impl Api {
     }
 
     #[allow(dead_code)]
-    pub async fn update_song(&self, id: &str, payload: &CreateSong) -> Result<Song, ApiError> {
+    pub async fn update_song(&self, id: &str, payload: &UpdateSong) -> Result<Song, ApiError> {
         ApiError::check_and_notify_offline(OperationType::Write);
         self.client
             .update_song(id, payload.clone())
@@ -342,7 +346,7 @@ impl Api {
     pub async fn update_collection(
         &self,
         id: &str,
-        payload: &CreateCollection,
+        payload: &UpdateCollection,
     ) -> Result<Collection, ApiError> {
         ApiError::check_and_notify_offline(OperationType::Write);
         self.client
@@ -397,7 +401,6 @@ impl Api {
     }
 
     #[allow(dead_code)]
-    #[allow(dead_code)]
     pub async fn create_setlist(&self, payload: &CreateSetlist) -> Result<Setlist, ApiError> {
         ApiError::check_and_notify_offline(OperationType::Write);
         self.client
@@ -410,7 +413,7 @@ impl Api {
     pub async fn update_setlist(
         &self,
         id: &str,
-        payload: &CreateSetlist,
+        payload: &UpdateSetlist,
     ) -> Result<Setlist, ApiError> {
         ApiError::check_and_notify_offline(OperationType::Write);
         self.client
@@ -456,7 +459,7 @@ impl Api {
     }
 
     #[allow(dead_code)]
-    pub async fn update_blob(&self, id: &str, payload: &CreateBlob) -> Result<Blob, ApiError> {
+    pub async fn update_blob(&self, id: &str, payload: &UpdateBlob) -> Result<Blob, ApiError> {
         ApiError::check_and_notify_offline(OperationType::Write);
         self.client
             .update_blob(id, payload.clone())

--- a/frontend/src/api/mod.rs
+++ b/frontend/src/api/mod.rs
@@ -9,6 +9,6 @@ pub use shared::auth::otp::{OtpRequest, OtpVerify};
 #[allow(unused_imports)]
 pub use shared::error::ErrorResponse;
 #[allow(unused_imports)]
-pub use shared::user::{CreateUser, Session, User};
+pub use shared::user::{CreateUser, SessionBody, User};
 
 mod error;

--- a/frontend/src/pages/editor.rs
+++ b/frontend/src/pages/editor.rs
@@ -2,7 +2,7 @@ use crate::api::use_api;
 use crate::components::{SongEditor, SongSavePayload};
 use crate::route::Route;
 use serde::Deserialize;
-use shared::song::{CreateSong, Song};
+use shared::song::{CreateSong, Song, UpdateSong};
 use std::collections::HashMap;
 use stylist::Style;
 use yew::prelude::*;
@@ -82,7 +82,10 @@ pub fn editor_page() -> Html {
             if let Some(id) = payload.id.clone() {
                 let api = api.clone();
                 wasm_bindgen_futures::spawn_local(async move {
-                    let updated = api.update_song(&id, &data).await.unwrap();
+                    let updated = api
+                        .update_song(&id, &UpdateSong::from(data.clone()))
+                        .await
+                        .unwrap();
                     song_handle.set(Some(updated.into()));
                 });
             } else {

--- a/frontend/src/pages/player/page.rs
+++ b/frontend/src/pages/player/page.rs
@@ -16,15 +16,15 @@ pub struct Props {
 #[function_component(PageComponent)]
 pub fn page_components(props: &Props) -> Html {
     match &props.item {
-        PlayerItem::Blob(id) => html! {
+        PlayerItem::Blob(b) => html! {
             <div class={Style::new(include_str!("page.css")).expect("Unwrapping CSS should work!")}>
-                <img src={format!("/api/v1/blobs/{}/data", id)}/>
+                <img src={format!("/api/v1/blobs/{}/data", b.blob_id)}/>
             </div>
         },
-        PlayerItem::Chords(song) => {
+        PlayerItem::Chords(c) => {
             html! {
                 <SongViewer
-                    song={song.clone()}
+                    song={c.song.clone()}
                     override_key={props.override_key.clone()}
                     override_representation={props.override_representation.clone()}
                 />

--- a/frontend/src/pages/player/player.rs
+++ b/frontend/src/pages/player/player.rs
@@ -4,7 +4,7 @@ use crate::components::{Topbar, TopbarButton, TopbarSelect, TopbarSelectOption, 
 use crate::route::Route;
 use gloo::timers::callback::Timeout;
 use serde::Deserialize;
-use shared::player::{Orientation, PlayerItem, TocItem};
+use shared::player::{Orientation, PlayerBlobItem, PlayerItem, TocItem};
 use shared::song::{ChordRepresentation, SimpleChord};
 use std::collections::HashMap;
 use stylist::{css, yew::Global, Style};
@@ -125,10 +125,12 @@ pub fn player_page() -> Html {
         let id = match player
             .as_ref()
             .map(|p| p.item().0)
-            .unwrap_or(&PlayerItem::Blob("".to_string()))
+            .unwrap_or(&PlayerItem::Blob(PlayerBlobItem {
+                blob_id: String::new(),
+            }))
         {
             PlayerItem::Blob(_) => "".to_string(),
-            PlayerItem::Chords(song) => song.id.clone(),
+            PlayerItem::Chords(c) => c.song.id.clone(),
         };
 
         move |_: MouseEvent| {
@@ -430,7 +432,7 @@ pub fn player_page() -> Html {
             <div class={if *active {"bottom active"} else {"bottom"}}>
                 <select
                     onchange={onchange2}
-                    class={if let PlayerItem::Chords(_) = player.item().0 {"visible"} else {"invisible"}}
+                    class={if let PlayerItem::Chords(_) = player.item().0 { "visible" } else { "invisible" }}
                 >
                     {
                         vec!["default", "nashville"]
@@ -446,7 +448,7 @@ pub fn player_page() -> Html {
                 </select>
                 <select
                     onchange={onchange}
-                    class={if let PlayerItem::Chords(_) = player.item().0 {"visible"} else {"invisible"}}
+                    class={if let PlayerItem::Chords(_) = player.item().0 { "visible" } else { "invisible" }}
                 >
                     {
                         vec!["default", "A", "Bb", "B", "C", "Db", "D", "Eb", "E", "F", "F#", "G", "Ab"]

--- a/frontend/src/pages/setlist_editor.rs
+++ b/frontend/src/pages/setlist_editor.rs
@@ -2,7 +2,7 @@ use crate::api::use_api;
 use crate::components::{SetlistEditor, SetlistSavePayload};
 use crate::route::Route;
 use serde::Deserialize;
-use shared::setlist::{CreateSetlist, Setlist};
+use shared::setlist::{CreateSetlist, Setlist, UpdateSetlist};
 use std::collections::HashMap;
 use stylist::Style;
 use yew::prelude::*;
@@ -79,7 +79,10 @@ pub fn setlist_editor_page() -> Html {
             if let Some(id) = payload.id.clone() {
                 let api = api.clone();
                 wasm_bindgen_futures::spawn_local(async move {
-                    let updated = api.update_setlist(&id, &data).await.unwrap();
+                    let updated = api
+                        .update_setlist(&id, &UpdateSetlist::from(data.clone()))
+                        .await
+                        .unwrap();
                     setlist_handle.set(Some(updated.into()));
                 });
             } else {

--- a/shared/src/api/mod.rs
+++ b/shared/src/api/mod.rs
@@ -123,11 +123,7 @@ impl<C: HttpClient> ApiClient<C> {
     ) -> Result<SessionBody, NetworkClientError> {
         self.client
             .post(
-                &append_query_param(
-                    format!("api/v1/users/{user_id}/sessions"),
-                    "expand",
-                    "user",
-                ),
+                &append_query_param(format!("api/v1/users/{user_id}/sessions"), "expand", "user"),
                 &serde_json::json!({}),
             )
             .await

--- a/shared/src/api/mod.rs
+++ b/shared/src/api/mod.rs
@@ -1,6 +1,6 @@
 use crate::auth::otp::{OtpRequest, OtpVerify};
-use crate::blob::{Blob, CreateBlob};
-use crate::collection::{Collection, CreateCollection};
+use crate::blob::{Blob, CreateBlob, UpdateBlob};
+use crate::collection::{Collection, CreateCollection, UpdateCollection};
 use crate::error::NetworkClientError;
 use crate::like::LikeStatus;
 use crate::net::HttpClient;
@@ -10,10 +10,10 @@ use crate::net::HttpClient;
 ))]
 use crate::net::{DefaultHttpClient, HttpClientConfig};
 use crate::player::Player;
-use crate::setlist::{CreateSetlist, Setlist};
-use crate::song::{CreateSong, Song};
+use crate::setlist::{CreateSetlist, Setlist, UpdateSetlist};
+use crate::song::{CreateSong, Song, UpdateSong};
 use crate::team::{CreateTeam, Team, UpdateTeam};
-use crate::user::{CreateUser, Session, User};
+use crate::user::{CreateUser, SessionBody, User};
 use std::vec::Vec;
 
 mod list_query;
@@ -52,7 +52,7 @@ impl<C: HttpClient> ApiClient<C> {
             .await
     }
 
-    pub async fn verify_otp(&self, payload: OtpVerify) -> Result<Session, NetworkClientError> {
+    pub async fn verify_otp(&self, payload: OtpVerify) -> Result<SessionBody, NetworkClientError> {
         self.client.post("auth/otp/verify", &payload).await
     }
 
@@ -92,14 +92,22 @@ impl<C: HttpClient> ApiClient<C> {
     pub async fn list_my_sessions(
         &self,
         query: ListQuery,
-    ) -> Result<Vec<Session>, NetworkClientError> {
-        let path = format!("api/v1/users/me/sessions{}", query.to_query_string());
+    ) -> Result<Vec<SessionBody>, NetworkClientError> {
+        let path = append_query_param(
+            format!("api/v1/users/me/sessions{}", query.to_query_string()),
+            "expand",
+            "user",
+        );
         self.client.get(&path).await
     }
 
-    pub async fn get_my_session(&self, id: &str) -> Result<Session, NetworkClientError> {
+    pub async fn get_my_session(&self, id: &str) -> Result<SessionBody, NetworkClientError> {
         self.client
-            .get(&format!("api/v1/users/me/sessions/{id}"))
+            .get(&append_query_param(
+                format!("api/v1/users/me/sessions/{id}"),
+                "expand",
+                "user",
+            ))
             .await
     }
 
@@ -112,10 +120,14 @@ impl<C: HttpClient> ApiClient<C> {
     pub async fn create_session_for_user(
         &self,
         user_id: &str,
-    ) -> Result<Session, NetworkClientError> {
+    ) -> Result<SessionBody, NetworkClientError> {
         self.client
             .post(
-                &format!("api/v1/users/{user_id}/sessions"),
+                &append_query_param(
+                    format!("api/v1/users/{user_id}/sessions"),
+                    "expand",
+                    "user",
+                ),
                 &serde_json::json!({}),
             )
             .await
@@ -125,8 +137,12 @@ impl<C: HttpClient> ApiClient<C> {
         &self,
         user_id: &str,
         query: ListQuery,
-    ) -> Result<Vec<Session>, NetworkClientError> {
-        let path = format!("api/v1/users/{user_id}/sessions{}", query.to_query_string());
+    ) -> Result<Vec<SessionBody>, NetworkClientError> {
+        let path = append_query_param(
+            format!("api/v1/users/{user_id}/sessions{}", query.to_query_string()),
+            "expand",
+            "user",
+        );
         self.client.get(&path).await
     }
 
@@ -134,9 +150,13 @@ impl<C: HttpClient> ApiClient<C> {
         &self,
         user_id: &str,
         id: &str,
-    ) -> Result<Session, NetworkClientError> {
+    ) -> Result<SessionBody, NetworkClientError> {
         self.client
-            .get(&format!("api/v1/users/{user_id}/sessions/{id}"))
+            .get(&append_query_param(
+                format!("api/v1/users/{user_id}/sessions/{id}"),
+                "expand",
+                "user",
+            ))
             .await
     }
 
@@ -209,7 +229,7 @@ impl<C: HttpClient> ApiClient<C> {
     pub async fn update_song(
         &self,
         id: &str,
-        payload: CreateSong,
+        payload: UpdateSong,
     ) -> Result<Song, NetworkClientError> {
         self.client
             .put(&format!("api/v1/songs/{id}"), &payload)
@@ -292,7 +312,7 @@ impl<C: HttpClient> ApiClient<C> {
     pub async fn update_collection(
         &self,
         id: &str,
-        payload: CreateCollection,
+        payload: UpdateCollection,
     ) -> Result<Collection, NetworkClientError> {
         self.client
             .put(&format!("api/v1/collections/{id}"), &payload)
@@ -352,7 +372,7 @@ impl<C: HttpClient> ApiClient<C> {
     pub async fn update_setlist(
         &self,
         id: &str,
-        payload: CreateSetlist,
+        payload: UpdateSetlist,
     ) -> Result<Setlist, NetworkClientError> {
         self.client
             .put(&format!("api/v1/setlists/{id}"), &payload)
@@ -391,7 +411,7 @@ impl<C: HttpClient> ApiClient<C> {
     pub async fn update_blob(
         &self,
         id: &str,
-        payload: CreateBlob,
+        payload: UpdateBlob,
     ) -> Result<Blob, NetworkClientError> {
         self.client
             .put(&format!("api/v1/blobs/{id}"), &payload)
@@ -417,4 +437,9 @@ impl<C: HttpClient> ApiClient<C> {
     pub async fn download_blob_image_url(&self, id: &str) -> String {
         format!("api/v1/blobs/{id}/data")
     }
+}
+
+fn append_query_param(path: String, key: &str, value: &str) -> String {
+    let sep = if path.contains('?') { '&' } else { '?' };
+    format!("{path}{sep}{key}={value}")
 }

--- a/shared/src/blob/blob.rs
+++ b/shared/src/blob/blob.rs
@@ -4,6 +4,13 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "backend")]
 use utoipa::ToSchema;
 
+/// Cross-resource reference to a blob (opaque `id` as returned by the API).
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "backend", derive(ToSchema))]
+pub struct BlobLink {
+    pub id: String,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "backend", derive(ToSchema))]
 pub struct Blob {
@@ -35,6 +42,29 @@ pub struct CreateBlob {
     pub height: u32,
     /// OCR or extracted text used for search (may be empty).
     pub ocr: String,
+}
+
+/// Full replacement body for `PUT /api/v1/blobs/{id}` metadata (same shape as [`CreateBlob`]; does not upload bytes).
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "backend", derive(ToSchema))]
+pub struct UpdateBlob {
+    pub file_type: FileType,
+    pub width: u32,
+    pub height: u32,
+    /// OCR or extracted text used for search (may be empty).
+    pub ocr: String,
+}
+
+impl From<UpdateBlob> for CreateBlob {
+    fn from(value: UpdateBlob) -> Self {
+        Self {
+            file_type: value.file_type,
+            width: value.width,
+            height: value.height,
+            ocr: value.ocr,
+        }
+    }
 }
 
 /// Partial update for a blob. Absent fields are left unchanged.

--- a/shared/src/blob/mod.rs
+++ b/shared/src/blob/mod.rs
@@ -1,5 +1,5 @@
 mod blob;
 mod file_type;
 
-pub use blob::{Blob, CreateBlob, PatchBlob};
+pub use blob::{Blob, BlobLink, CreateBlob, PatchBlob, UpdateBlob};
 pub use file_type::FileType;

--- a/shared/src/collection/collection.rs
+++ b/shared/src/collection/collection.rs
@@ -24,6 +24,26 @@ pub struct CreateCollection {
     pub songs: Vec<SongLink>,
 }
 
+/// Full replacement body for `PUT /api/v1/collections/{id}`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "backend", derive(ToSchema))]
+pub struct UpdateCollection {
+    pub title: String,
+    pub cover: String,
+    pub songs: Vec<SongLink>,
+}
+
+impl From<UpdateCollection> for CreateCollection {
+    fn from(value: UpdateCollection) -> Self {
+        Self {
+            title: value.title,
+            cover: value.cover,
+            songs: value.songs,
+        }
+    }
+}
+
 /// Partial update for a collection. Absent fields are left unchanged.
 #[derive(Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(deny_unknown_fields)]

--- a/shared/src/collection/mod.rs
+++ b/shared/src/collection/mod.rs
@@ -1,3 +1,3 @@
 mod collection;
 
-pub use collection::{Collection, CreateCollection, PatchCollection};
+pub use collection::{Collection, CreateCollection, PatchCollection, UpdateCollection};

--- a/shared/src/error/mod.rs
+++ b/shared/src/error/mod.rs
@@ -24,8 +24,7 @@ pub struct ErrorResponse {
 
 /// [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem document (`application/problem+json`).
 ///
-/// Canonical error body for HTTP 4xx/5xx responses. Extension members include `code` and legacy `error`
-/// (same value as `detail` when both are present).
+/// Canonical error body for HTTP 4xx/5xx responses. Extension members include `code`.
 #[cfg_attr(feature = "backend", derive(utoipa::ToSchema))]
 #[cfg_attr(feature = "backend", schema(title = "Problem"))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -45,13 +44,9 @@ pub struct Problem {
     /// Optional URI reference that identifies the specific occurrence.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub instance: Option<String>,
-    /// Same as `detail` (legacy alias).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
 }
 
 impl Problem {
-    /// Build a problem document with `detail` and legacy `error` set to the same string.
     pub fn new(
         type_uri: String,
         title: String,
@@ -65,9 +60,8 @@ impl Problem {
             title,
             status,
             code: code.into(),
-            detail: Some(detail.clone()),
+            detail: Some(detail),
             instance,
-            error: Some(detail),
         }
     }
 }
@@ -89,8 +83,6 @@ pub struct ProblemDetails {
     pub detail: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub instance: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
 }
 
 impl From<Problem> for ProblemDetails {
@@ -102,7 +94,6 @@ impl From<Problem> for ProblemDetails {
             code: p.code,
             detail: p.detail,
             instance: p.instance,
-            error: p.error,
         }
     }
 }
@@ -116,7 +107,6 @@ impl From<ProblemDetails> for Problem {
             code: p.code,
             detail: p.detail,
             instance: p.instance,
-            error: p.error,
         }
     }
 }

--- a/shared/src/player/mod.rs
+++ b/shared/src/player/mod.rs
@@ -6,6 +6,6 @@ mod toc_item;
 
 pub use orientation::Orientation;
 pub use player::Player;
-pub use player_item::PlayerItem;
+pub use player_item::{PlayerBlobItem, PlayerChordsItem, PlayerItem};
 pub use scroll_type::ScrollType;
 pub use toc_item::TocItem;

--- a/shared/src/player/player.rs
+++ b/shared/src/player/player.rs
@@ -322,14 +322,18 @@ impl From<SongLinkOwned> for Player {
                     .song
                     .blobs
                     .iter()
-                    .map(|blob| PlayerItem::Blob(blob.to_string()))
+                    .map(|blob| {
+                        PlayerItem::Blob(super::PlayerBlobItem {
+                            blob_id: blob.id.clone(),
+                        })
+                    })
                     .collect::<Vec<PlayerItem>>();
                 if link.song.data.sections.len() > 0 || items.len() == 0 {
                     let mut song = link.song.clone();
                     if let Some(key) = link.key {
                         song.data.transpose(key);
                     }
-                    items.push(PlayerItem::Chords(song))
+                    items.push(PlayerItem::Chords(super::PlayerChordsItem { song }))
                 }
                 items
             },

--- a/shared/src/player/player_item.rs
+++ b/shared/src/player/player_item.rs
@@ -4,14 +4,31 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
 #[cfg_attr(feature = "backend", derive(ToSchema))]
 pub enum PlayerItem {
-    Blob(String),
-    Chords(Song),
+    Blob(PlayerBlobItem),
+    Chords(PlayerChordsItem),
+}
+
+/// Sheet-music or image item in a player sequence (`type`: `"blob"`).
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[cfg_attr(feature = "backend", derive(ToSchema))]
+pub struct PlayerBlobItem {
+    pub blob_id: String,
+}
+
+/// ChordPro-backed song item in a player sequence (`type`: `"chords"`).
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[cfg_attr(feature = "backend", derive(ToSchema))]
+pub struct PlayerChordsItem {
+    pub song: Song,
 }
 
 impl Default for PlayerItem {
     fn default() -> Self {
-        Self::Blob(String::default())
+        Self::Blob(PlayerBlobItem {
+            blob_id: String::new(),
+        })
     }
 }

--- a/shared/src/setlist/mod.rs
+++ b/shared/src/setlist/mod.rs
@@ -1,3 +1,3 @@
 mod setlist;
 
-pub use setlist::{CreateSetlist, PatchSetlist, Setlist};
+pub use setlist::{CreateSetlist, PatchSetlist, Setlist, UpdateSetlist};

--- a/shared/src/setlist/setlist.rs
+++ b/shared/src/setlist/setlist.rs
@@ -21,6 +21,33 @@ pub struct CreateSetlist {
     pub songs: Vec<SongLink>,
 }
 
+/// Full replacement body for `PUT /api/v1/setlists/{id}`.
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "backend", derive(ToSchema))]
+pub struct UpdateSetlist {
+    pub title: String,
+    pub songs: Vec<SongLink>,
+}
+
+impl From<CreateSetlist> for UpdateSetlist {
+    fn from(value: CreateSetlist) -> Self {
+        Self {
+            title: value.title,
+            songs: value.songs,
+        }
+    }
+}
+
+impl From<UpdateSetlist> for CreateSetlist {
+    fn from(value: UpdateSetlist) -> Self {
+        Self {
+            title: value.title,
+            songs: value.songs,
+        }
+    }
+}
+
 /// Partial update for a setlist. Absent fields are left unchanged.
 #[derive(Deserialize, Debug, Default, PartialEq, Clone)]
 #[serde(deny_unknown_fields)]

--- a/shared/src/song/mod.rs
+++ b/shared/src/song/mod.rs
@@ -6,6 +6,8 @@ mod song_data_schema;
 pub use chordlib::outputs::{wrap_html, CharPageSet, FormatOutputLines, OutputLine};
 pub use chordlib::types::{ChordRepresentation, SimpleChord};
 pub use link::{Link, LinkOwned};
-pub use song::{CreateSong, PatchSong, PatchSongData, Song, SongUserSpecificAddons};
+pub use song::{
+    CreateSong, PatchSong, PatchSongData, Song, SongUserSpecificAddons, UpdateSong,
+};
 #[cfg(feature = "backend")]
 pub use song_data_schema::SongDataSchema;

--- a/shared/src/song/mod.rs
+++ b/shared/src/song/mod.rs
@@ -6,8 +6,6 @@ mod song_data_schema;
 pub use chordlib::outputs::{wrap_html, CharPageSet, FormatOutputLines, OutputLine};
 pub use chordlib::types::{ChordRepresentation, SimpleChord};
 pub use link::{Link, LinkOwned};
-pub use song::{
-    CreateSong, PatchSong, PatchSongData, Song, SongUserSpecificAddons, UpdateSong,
-};
+pub use song::{CreateSong, PatchSong, PatchSongData, Song, SongUserSpecificAddons, UpdateSong};
 #[cfg(feature = "backend")]
 pub use song_data_schema::SongDataSchema;

--- a/shared/src/song/song.rs
+++ b/shared/src/song/song.rs
@@ -1,3 +1,4 @@
+use crate::blob::BlobLink;
 use crate::patch::Patch;
 use chordlib::inputs::chord_pro;
 use chordlib::outputs::{FormatChordPro, FormatHTML};
@@ -29,9 +30,9 @@ pub struct Song {
     pub owner: String,
     /// When true, this record is not treated as a musical song (e.g. scripture or spoken content).
     pub not_a_song: bool,
-    /// Blob IDs for sheet-music or image assets linked to this song.
-    pub blobs: Vec<String>,
-    /// ChordPro-derived payload (sections, lyrics, metadata); see `SongData` in the OpenAPI components.
+    /// Linked blob assets (`id` is the blob resource identifier).
+    pub blobs: Vec<BlobLink>,
+    /// ChordPro-derived payload (sections, lyrics, metadata); see `SongDataSchema` in the OpenAPI components.
     #[cfg_attr(feature = "backend", schema(value_type = SongDataSchema))]
     pub data: ChordSong,
     /// Per-request flags such as whether the current user liked this song.
@@ -51,9 +52,54 @@ pub struct Song {
 )]
 pub struct CreateSong {
     pub not_a_song: bool,
-    pub blobs: Vec<String>,
+    pub blobs: Vec<BlobLink>,
     #[cfg_attr(feature = "backend", schema(value_type = SongDataSchema))]
     pub data: ChordSong,
+}
+
+/// Full replacement body for `PUT /api/v1/songs/{id}` (same fields as [`CreateSong`]; server-owned `id` is path-only).
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "backend", derive(ToSchema))]
+#[cfg_attr(
+    feature = "backend",
+    schema(example = json!({
+        "not_a_song": false,
+        "blobs": [],
+        "data": { "titles": ["Example Hymn"], "sections": [] }
+    }))
+)]
+pub struct UpdateSong {
+    pub not_a_song: bool,
+    pub blobs: Vec<BlobLink>,
+    #[cfg_attr(feature = "backend", schema(value_type = SongDataSchema))]
+    pub data: ChordSong,
+}
+
+impl From<UpdateSong> for CreateSong {
+    fn from(value: UpdateSong) -> Self {
+        Self {
+            not_a_song: value.not_a_song,
+            blobs: value.blobs,
+            data: value.data,
+        }
+    }
+}
+
+impl From<CreateSong> for UpdateSong {
+    fn from(value: CreateSong) -> Self {
+        Self {
+            not_a_song: value.not_a_song,
+            blobs: value.blobs,
+            data: value.data,
+        }
+    }
+}
+
+impl UpdateSong {
+    pub fn validate(&self) -> Result<(), String> {
+        CreateSong::from(self.clone()).validate()
+    }
 }
 
 /// Partial update for a song. Absent fields are left unchanged.
@@ -66,7 +112,7 @@ pub struct CreateSong {
 )]
 pub struct PatchSong {
     pub not_a_song: Option<bool>,
-    pub blobs: Option<Vec<String>>,
+    pub blobs: Option<Vec<BlobLink>>,
     #[cfg_attr(feature = "backend", schema(value_type = PatchSongData))]
     pub data: Option<PatchSongData>,
 }
@@ -226,7 +272,11 @@ mod tests {
             blobs: vec![],
             data: chordlib::types::Song::default(),
         };
-        s.blobs = (0..=MAX_BLOBS_PER_SONG).map(|i| format!("b{i}")).collect();
+        s.blobs = (0..=MAX_BLOBS_PER_SONG)
+            .map(|i| BlobLink {
+                id: format!("b{i}"),
+            })
+            .collect();
         assert!(s.validate().is_err());
         s.blobs.pop();
         assert!(s.validate().is_ok());

--- a/shared/src/song/song_data_schema.rs
+++ b/shared/src/song/song_data_schema.rs
@@ -14,7 +14,6 @@ use utoipa::ToSchema;
 #[cfg_attr(
     feature = "backend",
     schema(
-        as = SongData,
         example = json!({
             "titles": ["Amazing Grace"],
             "subtitle": null,

--- a/shared/src/user/mod.rs
+++ b/shared/src/user/mod.rs
@@ -5,5 +5,5 @@ mod user;
 
 pub use request::CreateUser;
 pub use role::Role;
-pub use session::Session;
+pub use session::{Session, SessionBody, SessionUserBody};
 pub use user::User;

--- a/shared/src/user/session.rs
+++ b/shared/src/user/session.rs
@@ -7,26 +7,58 @@ use serde::{Deserialize, Serialize};
 #[allow(unused_imports)]
 use serde_json::json;
 
+use crate::team::TeamUser;
+
 use super::User;
 
+/// Wire representation of a session. `user` is a [`TeamUser`] link unless the client
+/// passes `expand=user`, in which case it is the full [`User`] object.
 #[cfg_attr(feature = "backend", derive(utoipa::ToSchema))]
 #[cfg_attr(
     feature = "backend",
     schema(example = json!({
         "id": "550e8400-e29b-41d4-a716-446655440000",
-        "user": {
-            "id": "user-1",
-            "email": "singer@example.com",
-            "role": "default",
-            "default_collection": null,
-            "created_at": "2024-01-01T12:00:00Z",
-            "last_login_at": null,
-            "request_count": 0
-        },
+        "user": { "id": "user-1", "email": "singer@example.com" },
         "created_at": "2024-01-01T12:00:00Z",
         "expires_at": "2025-01-01T12:00:00Z"
     }))
 )]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SessionBody {
+    pub id: String,
+    pub user: SessionUserBody,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[cfg_attr(feature = "backend", derive(utoipa::ToSchema))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum SessionUserBody {
+    /// Try full user first so link-shaped JSON (missing required user fields) falls through to [`TeamUser`].
+    Expanded(User),
+    Link(TeamUser),
+}
+
+impl SessionBody {
+    pub fn from_session(session: Session, expand_user: bool) -> Self {
+        let user = if expand_user {
+            SessionUserBody::Expanded(session.user)
+        } else {
+            SessionUserBody::Link(TeamUser {
+                id: session.user.id.clone(),
+                email: session.user.email.clone(),
+            })
+        };
+        Self {
+            id: session.id,
+            user,
+            created_at: session.created_at,
+            expires_at: session.expires_at,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
 pub struct Session {
     pub id: String,


### PR DESCRIPTION
## Summary

Ships Phase 3 (§§19–23) as **breaking wire changes on existing `/api/v1`** paths. OpenAPI `info.version` is **2.0.0**; there is no parallel `/api/v2` or second OpenAPI document.

## Changes

- **§19** — `PlayerItem` internally tagged (`type` + `blob_id` / `song`).
- **§20** — `BlobLink` on songs; `SessionBody` + `expand=user` for full user embeds.
- **§21** — `Problem` no longer includes legacy `error`; use `detail` and `code`.
- **§22** — Rust test + Spectral ruleset (snake_case property keys under `components.schemas`).
- **§23** — `Update*` PUT request bodies; create/update policy doc.

## Docs

- `docs/api-breaking-2-0.md`
- `docs/business-logic-constraints/create-update-policy.md`
- `CHANGELOG.md`

## Verification

- `cargo test` (backend)
- `cargo check --target wasm32-unknown-unknown` (frontend)
- Spectral lint on generated OpenAPI (CI)

Made with [Cursor](https://cursor.com)