### PR TITLE
feat(backend): observability foundation (tracing, request correlation)

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -25,7 +25,9 @@ thiserror = "1"
 time = "0.3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+tracing-actix-web = "0.7"
+tracing-log = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 uuid = { version = "1", features = ["v4"] }
 rand = { version = "0.8", features = ["std"] }
 envy = "0.4.2"

--- a/backend/src/auth/middleware.rs
+++ b/backend/src/auth/middleware.rs
@@ -86,6 +86,7 @@ where
                 Err(err) => return Err(err.into()),
             };
 
+            tracing::Span::current().record("user_id", tracing::field::display(&user.id));
             req.extensions_mut().insert(user);
 
             let response = service.call(req).await?;

--- a/backend/src/docs.rs
+++ b/backend/src/docs.rs
@@ -278,9 +278,11 @@ mod tests {
 
     #[test]
     fn openapi_contact_reflects_settings() {
-        let mut s = Settings::default();
-        s.openapi_contact_email = Some("ops@example.com".into());
-        s.openapi_imprint_url = Some("https://example.com/imprint".into());
+        let s = Settings {
+            openapi_contact_email: Some("ops@example.com".into()),
+            openapi_imprint_url: Some("https://example.com/imprint".into()),
+            ..Default::default()
+        };
         let doc = openapi_document(&s);
         let v = serde_json::to_value(doc).expect("openapi json");
         assert_eq!(v["info"]["contact"]["email"], "ops@example.com");

--- a/backend/src/http_tests.rs
+++ b/backend/src/http_tests.rs
@@ -19,6 +19,7 @@
 
 use std::sync::Arc;
 
+use actix_web::middleware::Compat;
 use actix_web::web::Data;
 use actix_web::{App, test};
 use anyhow::Result as AnyResult;
@@ -71,6 +72,9 @@ fn build_app(
 
     App::new()
         .wrap(crate::request_id::RequestId)
+        .wrap(Compat::new(tracing_actix_web::TracingLogger::<
+            crate::request_id::WorshipRootSpan,
+        >::new()))
         .app_data(Data::from(db.clone()))
         .app_data(Data::new(blob_service(&db, blob_dir)))
         .app_data(Data::new(collection_service(&db)))

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -10,6 +10,7 @@ pub mod frontend;
 pub mod governor_peer;
 pub mod http_cache;
 pub mod mail;
+pub mod observability;
 pub mod request_id;
 pub mod request_link;
 pub mod resources;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,11 +1,12 @@
 use std::sync::Arc;
 
-use actix_web::{App, HttpServer, middleware::Logger, web::Data};
+use actix_web::middleware::Compat;
+use actix_web::{App, HttpServer, web::Data};
 use anyhow::{Context, Result as AnyResult};
 use chrono::Utc;
 use lettre::transport::smtp::authentication::Credentials;
 use tracing::info;
-use tracing_subscriber::EnvFilter;
+use tracing_actix_web::TracingLogger;
 
 use backend::auth;
 use backend::auth::oidc;
@@ -28,23 +29,11 @@ use backend::settings::Settings;
 
 #[actix_web::main]
 async fn main() -> AnyResult<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
-        )
-        .with_target(false)
-        .compact()
-        .init();
+    backend::observability::init()?;
 
     let settings = Settings::from_env()?;
 
-    let production = matches!(
-        std::env::var("WORSHIP_PRODUCTION").ok().as_deref(),
-        Some("true" | "1" | "yes")
-    ) || matches!(
-        std::env::var("RUST_ENV").ok().as_deref(),
-        Some("production")
-    );
+    let production = backend::observability::is_production();
     if production && settings.initial_admin_user_test_session {
         anyhow::bail!(
             "refusing to start: initial_admin_user_test_session is enabled under WORSHIP_PRODUCTION or RUST_ENV=production"
@@ -165,6 +154,9 @@ async fn main() -> AnyResult<()> {
     HttpServer::new(move || {
         App::new()
             .wrap(backend::request_id::RequestId)
+            .wrap(Compat::new(TracingLogger::<
+                backend::request_id::WorshipRootSpan,
+            >::new()))
             .app_data(backend::error::json_config())
             .app_data(db_data.clone())
             .app_data(Data::new(mail_service.clone()))
@@ -180,9 +172,6 @@ async fn main() -> AnyResult<()> {
             .app_data(oidc_clients.clone())
             .app_data(cookie_config.clone())
             .app_data(otp_config.clone())
-            .wrap(Logger::new(
-                r#"%a "%r" %s %b "%{Referer}i" "%{User-Agent}i" %T"#,
-            ))
             .service(auth::rest::scope(
                 settings.auth_rate_limit_rps,
                 settings.auth_rate_limit_burst,

--- a/backend/src/observability.rs
+++ b/backend/src/observability.rs
@@ -1,0 +1,83 @@
+//! Tracing subscriber setup (`tracing` + `tracing-subscriber` + `tracing-log` bridge).
+
+use tracing_subscriber::EnvFilter;
+
+/// Matches production detection in `main` (initial admin / unsafe dev checks).
+pub fn is_production() -> bool {
+    matches!(
+        std::env::var("WORSHIP_PRODUCTION").ok().as_deref(),
+        Some("true" | "1" | "yes")
+    ) || matches!(
+        std::env::var("RUST_ENV").ok().as_deref(),
+        Some("production")
+    )
+}
+
+#[derive(Clone, Copy)]
+enum LogFormat {
+    Json,
+    Compact,
+    Pretty,
+}
+
+fn resolve_log_format() -> LogFormat {
+    match std::env::var("LOG_FORMAT").ok().as_deref() {
+        Some(s) => match s.to_ascii_lowercase().as_str() {
+            "json" => LogFormat::Json,
+            "compact" => LogFormat::Compact,
+            "pretty" => LogFormat::Pretty,
+            _ => {
+                if is_production() {
+                    LogFormat::Json
+                } else {
+                    LogFormat::Compact
+                }
+            }
+        },
+        None => {
+            if is_production() {
+                LogFormat::Json
+            } else {
+                LogFormat::Compact
+            }
+        }
+    }
+}
+
+/// Installs the global `tracing` subscriber and bridges `log` crate output into it.
+///
+/// Call once at process startup. Safe to call from tests if no other subscriber is set;
+/// `tracing-log` init is best-effort if the global logger is already configured.
+pub fn init() -> anyhow::Result<()> {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+
+    match resolve_log_format() {
+        LogFormat::Json => {
+            tracing_subscriber::fmt()
+                .with_env_filter(filter)
+                .json()
+                .flatten_event(true)
+                .with_current_span(true)
+                .with_span_list(false)
+                .with_target(true)
+                .init();
+        }
+        LogFormat::Compact => {
+            tracing_subscriber::fmt()
+                .with_env_filter(filter)
+                .compact()
+                .with_target(true)
+                .init();
+        }
+        LogFormat::Pretty => {
+            tracing_subscriber::fmt()
+                .with_env_filter(filter)
+                .pretty()
+                .with_target(true)
+                .init();
+        }
+    }
+
+    let _ = tracing_log::LogTracer::init();
+    Ok(())
+}

--- a/backend/src/request_id.rs
+++ b/backend/src/request_id.rs
@@ -1,10 +1,13 @@
 use std::future::{Ready, ready};
 use std::rc::Rc;
 
+use actix_web::body::MessageBody;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready};
 use actix_web::http::header::HeaderName;
 use actix_web::{Error, HttpMessage};
 use futures_util::future::LocalBoxFuture;
+use tracing::Span;
+use tracing_actix_web::RootSpanBuilder;
 use uuid::Uuid;
 
 static X_REQUEST_ID: HeaderName = HeaderName::from_static("x-request-id");
@@ -12,6 +15,10 @@ static X_REQUEST_ID: HeaderName = HeaderName::from_static("x-request-id");
 /// Request path and query (`/api/v1/...?a=1`), stored for diagnostics (e.g. Problem Details `instance`).
 #[derive(Clone)]
 pub struct ApiRequestTarget(pub String);
+
+/// Start time for request latency (stored in request extensions; read in [`WorshipRootSpan::on_request_end`]).
+#[derive(Clone, Copy)]
+pub struct RequestStartedAt(pub std::time::Instant);
 
 /// If `traceparent` is a valid W3C trace context value (`version-trace_id-span_id-flags`),
 /// returns the 16-hex-character **span id** segment (often aligned with OpenTelemetry span id).
@@ -33,9 +40,70 @@ fn span_id_from_traceparent(traceparent: &str) -> Option<String> {
     Some(span_id.to_ascii_lowercase())
 }
 
-/// Middleware that assigns `X-Request-Id`: prefers the span id from a valid `traceparent`
-/// header (W3C trace context), otherwise a random UUID v4. The value is stored in request
-/// extensions as a `String`.
+fn request_id_string(req: &ServiceRequest) -> String {
+    req.headers()
+        .get("traceparent")
+        .and_then(|v| v.to_str().ok())
+        .and_then(span_id_from_traceparent)
+        .unwrap_or_else(|| Uuid::new_v4().to_string())
+}
+
+/// Root span for [`tracing_actix_web::TracingLogger`]: correlates logs with `traceparent` / `X-Request-Id`
+/// and records `status` / `latency_ms` on completion.
+pub struct WorshipRootSpan;
+
+impl RootSpanBuilder for WorshipRootSpan {
+    fn on_request_start(request: &ServiceRequest) -> Span {
+        let id = request_id_string(request);
+        request.extensions_mut().insert(id.clone());
+        let target = request
+            .uri()
+            .path_and_query()
+            .map(|pq| pq.to_string())
+            .unwrap_or_else(|| request.uri().path().to_string());
+        request.extensions_mut().insert(ApiRequestTarget(target));
+        request
+            .extensions_mut()
+            .insert(RequestStartedAt(std::time::Instant::now()));
+
+        let route = request
+            .match_pattern()
+            .unwrap_or_else(|| request.path().to_string());
+
+        tracing::info_span!(
+            "http.request",
+            request_id = %id,
+            method = %request.method(),
+            route = %route,
+            user_id = tracing::field::Empty,
+            status = tracing::field::Empty,
+            latency_ms = tracing::field::Empty,
+        )
+    }
+
+    fn on_request_end<B: MessageBody>(span: Span, outcome: &Result<ServiceResponse<B>, Error>) {
+        match outcome {
+            Ok(response) => {
+                let status = response.response().status().as_u16();
+                span.record("status", status);
+                let latency_ms = response
+                    .request()
+                    .extensions()
+                    .get::<RequestStartedAt>()
+                    .map(|t| t.0.elapsed().as_millis() as u64)
+                    .unwrap_or(0);
+                span.record("latency_ms", latency_ms);
+            }
+            Err(err) => {
+                let status = err.as_response_error().status_code().as_u16();
+                span.record("status", status);
+            }
+        }
+    }
+}
+
+/// Sets `X-Request-Id` on the response. Correlation id and [`ApiRequestTarget`] are populated by
+/// [`WorshipRootSpan`] inside [`tracing_actix_web::TracingLogger`]; this middleware must run inside that logger.
 #[derive(Clone, Default)]
 pub struct RequestId;
 
@@ -73,25 +141,17 @@ where
     forward_ready!(service);
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
-        let id = req
-            .headers()
-            .get("traceparent")
-            .and_then(|v| v.to_str().ok())
-            .and_then(span_id_from_traceparent)
-            .unwrap_or_else(|| Uuid::new_v4().to_string());
-        req.extensions_mut().insert(id.clone());
-        let target = req
-            .uri()
-            .path_and_query()
-            .map(|pq| pq.to_string())
-            .unwrap_or_else(|| req.uri().path().to_string());
-        req.extensions_mut().insert(ApiRequestTarget(target));
-
+        let id =
+            req.extensions().get::<String>().cloned().expect(
+                "correlation id missing: register TracingLogger::<WorshipRootSpan> outermost",
+            );
         let service = Rc::clone(&self.service);
         Box::pin(async move {
             let mut resp = service.call(req).await?;
-            resp.headers_mut()
-                .insert(X_REQUEST_ID.clone(), id.parse().unwrap());
+            resp.headers_mut().insert(
+                X_REQUEST_ID.clone(),
+                id.parse().expect("request id is a valid HeaderValue"),
+            );
             Ok(resp)
         })
     }

--- a/backend/src/settings.rs
+++ b/backend/src/settings.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use serde::Deserialize;
 
 #[derive(Clone, Debug)]
@@ -17,7 +19,7 @@ pub struct OtpConfig {
     pub allow_self_signup: bool,
 }
 
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Deserialize)]
 #[serde(default)]
 pub struct Settings {
     pub host: String,
@@ -74,6 +76,56 @@ pub struct Settings {
     /// Legal imprint / contact page URL under `info.contact.url` when set (`OPENAPI_IMPRINT_URL`).
     #[serde(default)]
     pub openapi_imprint_url: Option<String>,
+}
+
+impl fmt::Debug for Settings {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Settings")
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("post_login_path", &self.post_login_path)
+            .field("cookie_name", &self.cookie_name)
+            .field("cookie_secure", &self.cookie_secure)
+            .field("session_ttl_seconds", &self.session_ttl_seconds)
+            .field("otp_ttl_seconds", &self.otp_ttl_seconds)
+            .field("otp_pepper", &"<redacted>")
+            .field("otp_max_attempts", &self.otp_max_attempts)
+            .field("otp_allow_self_signup", &self.otp_allow_self_signup)
+            .field("db_address", &self.db_address)
+            .field("db_namespace", &self.db_namespace)
+            .field("db_database", &self.db_database)
+            .field("db_username", &self.db_username)
+            .field(
+                "db_password",
+                &self.db_password.as_ref().map(|_| "<redacted>"),
+            )
+            .field("db_migration_path", &self.db_migration_path)
+            .field("oidc_issuer_url", &self.oidc_issuer_url)
+            .field("oidc_client_id", &self.oidc_client_id)
+            .field(
+                "oidc_client_secret",
+                &self.oidc_client_secret.as_ref().map(|_| "<redacted>"),
+            )
+            .field("oidc_redirect_url", &self.oidc_redirect_url)
+            .field("oidc_scopes", &self.oidc_scopes)
+            .field("initial_admin_user_email", &self.initial_admin_user_email)
+            .field(
+                "initial_admin_user_test_session",
+                &self.initial_admin_user_test_session,
+            )
+            .field("gmail_app_password", &"<redacted>")
+            .field("gmail_from", &self.gmail_from)
+            .field("static_dir", &self.static_dir)
+            .field("blob_dir", &self.blob_dir)
+            .field("blob_upload_max_bytes", &self.blob_upload_max_bytes)
+            .field("auth_rate_limit_rps", &self.auth_rate_limit_rps)
+            .field("auth_rate_limit_burst", &self.auth_rate_limit_burst)
+            .field("api_rate_limit_rps", &self.api_rate_limit_rps)
+            .field("api_rate_limit_burst", &self.api_rate_limit_burst)
+            .field("openapi_contact_email", &self.openapi_contact_email)
+            .field("openapi_imprint_url", &self.openapi_imprint_url)
+            .finish()
+    }
 }
 
 impl Default for Settings {
@@ -147,5 +199,28 @@ impl Settings {
             max_attempts: self.otp_max_attempts,
             allow_self_signup: self.otp_allow_self_signup,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Settings;
+
+    #[test]
+    fn settings_debug_redacts_secrets() {
+        let s = Settings {
+            otp_pepper: "unique_pepper_value_123".into(),
+            gmail_app_password: "unique_gmail_secret_456".into(),
+            db_password: Some("unique_db_pass_789".into()),
+            oidc_client_secret: Some("unique_oidc_secret_abc".into()),
+            ..Default::default()
+        };
+
+        let out = format!("{s:?}");
+        assert!(!out.contains("unique_pepper_value_123"));
+        assert!(!out.contains("unique_gmail_secret_456"));
+        assert!(!out.contains("unique_db_pass_789"));
+        assert!(!out.contains("unique_oidc_secret_abc"));
+        assert!(out.contains("<redacted>"));
     }
 }


### PR DESCRIPTION
## Summary

Implements **Bundle A** from the logging review: centralized tracing setup, request correlation via `TracingLogger` + custom `WorshipRootSpan`, `tracing-log` bridge, JSON/compact/pretty output (`LOG_FORMAT` + production detection), and redacted `Debug` for `Settings`.

## Changes

- New `backend/src/observability.rs`: `init()`, `is_production()`, `LogTracer`, formatter selection
- Replace actix `Logger` with `Compat(TracingLogger::<WorshipRootSpan>)`; slim `RequestId` middleware for `X-Request-Id`
- `RequireUser` records `user_id` on the current span when authenticated
- Manual `Settings` `Debug` redacting secrets + unit test

## Validation

- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (backend)

Made with [Cursor](https://cursor.com)