### PR TITLE
feat(backend): error-path logging and Surreal response checks (Bundle B)

### DIFF
--- a/backend/src/auth/middleware.rs
+++ b/backend/src/auth/middleware.rs
@@ -12,6 +12,7 @@ use crate::resources::User;
 use crate::resources::user::Role as UserRole;
 use crate::resources::user::session::service::SessionServiceHandle;
 use crate::settings::CookieConfig;
+use tracing::debug;
 
 #[derive(Clone, Default)]
 pub struct RequireUser;
@@ -73,16 +74,23 @@ where
                 Err(err) => return Err(err),
             };
 
-            let session_id = authorization_bearer(&req)
-                .or_else(|| {
-                    req.cookie(&cookie_cfg.name)
-                        .map(|cookie| cookie.value().to_owned())
-                })
-                .ok_or_else(AppError::unauthorized)?;
+            let session_id = match authorization_bearer(&req).or_else(|| {
+                req.cookie(&cookie_cfg.name)
+                    .map(|cookie| cookie.value().to_owned())
+            }) {
+                Some(id) => id,
+                None => {
+                    debug!(reason = "missing_session", "unauthorized request");
+                    return Err(AppError::unauthorized().into());
+                }
+            };
 
             let user = match svc.validate_session_and_update_metrics(&session_id).await {
                 Ok(Some(session)) => session.user,
-                Ok(None) => return Err(AppError::unauthorized().into()),
+                Ok(None) => {
+                    debug!(reason = "expired_session", "session not found or expired");
+                    return Err(AppError::unauthorized().into());
+                }
                 Err(err) => return Err(err.into()),
             };
 

--- a/backend/src/auth/oidc/model.rs
+++ b/backend/src/auth/oidc/model.rs
@@ -36,7 +36,7 @@ impl Model for Database {
             .create(("oidc_state", key))
             .content(record)
             .await
-            .map_err(AppError::database)?;
+            .map_err(|e| crate::log_and_convert!(AppError::database, "oidc_state.create", e))?;
 
         Ok(())
     }
@@ -46,7 +46,7 @@ impl Model for Database {
             .db
             .select(("oidc_state", key))
             .await
-            .map_err(AppError::database)?;
+            .map_err(|e| crate::log_and_convert!(AppError::database, "oidc_state.select", e))?;
 
         let Some(record) = record else {
             return Ok(None);
@@ -56,7 +56,7 @@ impl Model for Database {
             .db
             .delete(("oidc_state", key))
             .await
-            .map_err(AppError::database)?;
+            .map_err(|e| crate::log_and_convert!(AppError::database, "oidc_state.delete", e))?;
 
         let pending = record.into_pending();
         if pending.expires_at <= Utc::now() {
@@ -70,7 +70,7 @@ impl Model for Database {
         self.db
             .query("DELETE oidc_state WHERE expires_at <= time::now()")
             .await
-            .map_err(AppError::database)?;
+            .map_err(|e| crate::log_and_convert!(AppError::database, "oidc_state.cleanup", e))?;
         Ok(())
     }
 }

--- a/backend/src/auth/oidc/rest.rs
+++ b/backend/src/auth/oidc/rest.rs
@@ -134,7 +134,7 @@ async fn callback(
     let token_response = token_request
         .request_async(async_http_client)
         .await
-        .map_err(AppError::oidc)?;
+        .map_err(|e| crate::log_and_convert!(AppError::oidc, "oidc.token_exchange", e))?;
 
     let id_token = token_response
         .extra_fields()
@@ -143,7 +143,7 @@ async fn callback(
 
     let claims = id_token
         .claims(&oidc_client.id_token_verifier(), &nonce)
-        .map_err(AppError::oidc)?;
+        .map_err(|e| crate::log_and_convert!(AppError::oidc, "oidc.id_token_claims", e))?;
 
     let user = user_svc
         .get_user_by_email_or_create(claims.email().ok_or(AppError::Unauthorized)?)

--- a/backend/src/auth/otp/model.rs
+++ b/backend/src/auth/otp/model.rs
@@ -47,7 +47,7 @@ impl Model for Database {
             .bind(("code", otp_hmac(email, code, pepper)))
             .bind(("ttl_secs", ttl_seconds as i64))
             .await
-            .map_err(AppError::database)?;
+            .map_err(|e| crate::log_and_convert!(AppError::database, "otp.remember.query", e))?;
         Ok(())
     }
 
@@ -86,9 +86,9 @@ impl Model for Database {
             .bind(("email", email.to_owned()))
             .bind(("code", otp_hmac(email, code, pepper)))
             .await
-            .map_err(AppError::database)?
+            .map_err(|e| crate::log_and_convert!(AppError::database, "otp.validate.query", e))?
             .take::<Option<Outcome>>(7)
-            .map_err(AppError::database)?
+            .map_err(|e| crate::log_and_convert!(AppError::database, "otp.validate.take", e))?
             .ok_or_else(|| AppError::invalid_request("no otp request for that email"))?;
 
         if outcome.valid > 0 {
@@ -103,7 +103,9 @@ impl Model for Database {
                 .query("DELETE type::thing('otp', $email)")
                 .bind(("email", email.to_owned()))
                 .await
-                .map_err(AppError::database)?;
+                .map_err(|e| {
+                    crate::log_and_convert!(AppError::database, "otp.lockout_delete.query", e)
+                })?;
             return Err(AppError::too_many_requests(
                 "too many incorrect otp attempts; request a new code",
             ));

--- a/backend/src/database/migrations.rs
+++ b/backend/src/database/migrations.rs
@@ -96,18 +96,11 @@ async fn load_applied_migrations(db: &Surreal<Any>) -> AnyResult<HashMap<String,
 }
 
 fn log_surreal_error_chain(migration: &str, statement_index: usize, err: &surrealdb::Error) {
-    let mut sources: Vec<String> = Vec::new();
-    sources.push(err.to_string());
-    let mut cursor = std::error::Error::source(err);
-    while let Some(inner) = cursor {
-        sources.push(inner.to_string());
-        cursor = inner.source();
-    }
     error!(
         migration = %migration,
         statement_index = statement_index,
         error = %err,
-        error_source_chain = %sources.join(" <- "),
+        error_source_chain = %crate::observability::error_source_chain_string(err),
         error_debug = ?err,
         "SurrealDB query statement failed"
     );

--- a/backend/src/database/mod.rs
+++ b/backend/src/database/mod.rs
@@ -9,6 +9,38 @@ use surrealdb::sql::{Id, Thing};
 
 use crate::error::AppError;
 
+/// Inspect Surreal [`surrealdb::Response`] for per-statement failures (mirrors migration checks).
+pub(crate) fn surreal_take_errors(
+    context: &'static str,
+    response: &mut surrealdb::Response,
+) -> Result<(), AppError> {
+    let errors = response.take_errors();
+    if errors.is_empty() {
+        return Ok(());
+    }
+
+    let mut pairs: Vec<(usize, surrealdb::Error)> = errors.into_iter().collect();
+    pairs.sort_by_key(|(idx, _)| *idx);
+
+    let mut summary = Vec::with_capacity(pairs.len());
+    for (idx, err) in pairs {
+        tracing::error!(
+            context = context,
+            statement_index = idx,
+            error = %err,
+            error_source_chain = %crate::observability::error_source_chain_string(&err),
+            error_debug = ?err,
+            "SurrealDB query statement failed"
+        );
+        summary.push(format!("[statement {idx}] {err}"));
+    }
+
+    Err(AppError::database(format!(
+        "{context}: {}",
+        summary.join("; ")
+    )))
+}
+
 #[derive(Deserialize)]
 struct TeamIdOnly {
     id: Thing,
@@ -83,9 +115,18 @@ impl Database {
             .query("SELECT id FROM team WHERE owner = $user LIMIT 1")
             .bind(("user", user))
             .await
-            .map_err(AppError::database)?;
+            .map_err(|e| {
+                crate::log_and_convert!(AppError::database, "db.personal_team.query", e)
+            })?;
 
-        let rows: Vec<TeamIdOnly> = response.take(0).map_err(AppError::database)?;
+        surreal_take_errors("db.personal_team", &mut response)?;
+        response = response.check().map_err(|e| {
+            crate::log_and_convert!(AppError::database, "db.personal_team.check", e)
+        })?;
+
+        let rows: Vec<TeamIdOnly> = response
+            .take(0)
+            .map_err(|e| crate::log_and_convert!(AppError::database, "db.personal_team.take", e))?;
         rows.into_iter()
             .next()
             .map(|r| r.id)

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -4,6 +4,7 @@ use actix_web::{HttpMessage, HttpResponse, ResponseError};
 use thiserror::Error;
 use tracing::error;
 
+use crate::observability;
 use shared::error::Problem;
 
 #[derive(Debug, Error)]
@@ -149,9 +150,13 @@ impl From<surrealdb::Error> for AppError {
                 surrealdb::error::Db::NoRecordFound | surrealdb::error::Db::IdNotFound { .. } => {
                     AppError::NotFound("record not found".into())
                 }
-                _ => Self::database(err),
+                _ => {
+                    observability::log_error_chain("surrealdb.app_error", &err);
+                    Self::database(err)
+                }
             }
         } else {
+            observability::log_error_chain("surrealdb.app_error", &err);
             Self::database(err)
         }
     }
@@ -165,6 +170,7 @@ impl From<chordlib::Error> for AppError {
 
 impl From<reqwest::Error> for AppError {
     fn from(err: reqwest::Error) -> Self {
+        observability::log_error_chain("reqwest", &err);
         AppError::Internal(format!("HTTP client error: {}", err))
     }
 }
@@ -236,7 +242,13 @@ impl ResponseError for AppError {
 
     fn error_response(&self) -> HttpResponse {
         if matches!(self, AppError::Internal(_)) {
-            error!("{}", self);
+            error!(
+                error.code = self.code(),
+                error = %self,
+                error_source_chain = %observability::error_source_chain_string(self),
+                error_debug = ?self,
+                "internal error"
+            );
         }
         let status = self.status_code().as_u16();
         let detail = self.detail_message();

--- a/backend/src/mail.rs
+++ b/backend/src/mail.rs
@@ -12,7 +12,7 @@ pub struct MailService {
 impl MailService {
     pub fn new(from: String, credentials: Credentials) -> Result<Self, AppError> {
         let transport = AsyncSmtpTransport::<Tokio1Executor>::relay("smtp.gmail.com")
-            .map_err(AppError::mail)?
+            .map_err(|e| crate::log_and_convert!(AppError::mail, "mail.smtp_relay", e))?
             .credentials(credentials)
             .build();
         Ok(Self { transport, from })
@@ -20,15 +20,30 @@ impl MailService {
 
     pub async fn send(&self, to: &str, subject: &str, body: &str) -> Result<(), AppError> {
         let message = Message::builder()
-            .from(self.from.parse().map_err(AppError::mail)?)
-            .to(to.parse().map_err(AppError::mail)?)
+            .from(
+                self.from
+                    .parse()
+                    .map_err(|e| crate::log_and_convert!(AppError::mail, "mail.parse_from", e))?,
+            )
+            .to(to
+                .parse()
+                .map_err(|e| crate::log_and_convert!(AppError::mail, "mail.parse_to", e))?)
             .subject(subject)
             .body(body.to_owned())
-            .map_err(AppError::mail)?;
+            .map_err(|e| crate::log_and_convert!(AppError::mail, "mail.build_message", e))?;
 
-        let response = self.transport.send(message).await.map_err(AppError::mail)?;
+        let response = self
+            .transport
+            .send(message)
+            .await
+            .map_err(|e| crate::log_and_convert!(AppError::mail, "mail.transport_send", e))?;
 
         if !response.is_positive() {
+            tracing::warn!(
+                target = "mail.transport",
+                ?response,
+                "sending the mail was not positive"
+            );
             return Err(AppError::mail("sending the mail was not positive"));
         }
         Ok(())

--- a/backend/src/observability.rs
+++ b/backend/src/observability.rs
@@ -81,3 +81,36 @@ pub fn init() -> anyhow::Result<()> {
     let _ = tracing_log::LogTracer::init();
     Ok(())
 }
+
+/// Joins [`std::error::Error::source`] links with `" <- "` (top-level message first).
+pub fn error_source_chain_string(err: &(dyn std::error::Error + 'static)) -> String {
+    let mut sources: Vec<String> = Vec::new();
+    sources.push(err.to_string());
+    let mut cursor = err.source();
+    while let Some(inner) = cursor {
+        sources.push(inner.to_string());
+        cursor = inner.source();
+    }
+    sources.join(" <- ")
+}
+
+/// Logs `%err`, `?err`, and the full source chain under a stable `target` field.
+pub fn log_error_chain(target: &'static str, err: &(dyn std::error::Error + 'static)) {
+    tracing::error!(
+        target = target,
+        error = %err,
+        error_source_chain = %error_source_chain_string(err),
+        error_debug = ?err,
+        "I/O boundary error"
+    );
+}
+
+/// Log a typed error's chain, then convert with `AppError::{database,mail,oidc}` (or similar).
+#[macro_export]
+macro_rules! log_and_convert {
+    ($mapper:path, $target:literal, $err:expr) => {{
+        let err = $err;
+        $crate::observability::log_error_chain($target, &err);
+        $mapper(err)
+    }};
+}

--- a/backend/src/resources/blob/storage.rs
+++ b/backend/src/resources/blob/storage.rs
@@ -1,3 +1,4 @@
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 use actix_files::NamedFile;
@@ -45,7 +46,24 @@ impl BlobStorage for FsBlobStorage {
     fn delete_blob_file(&self, blob: &Blob) {
         if let Some(name) = blob.file_name() {
             let path = Path::new(&self.blob_dir).join(name);
-            let _ = std::fs::remove_file(path);
+            match std::fs::remove_file(&path) {
+                Ok(()) => {}
+                Err(err) if err.kind() == ErrorKind::NotFound => {
+                    tracing::debug!(
+                        blob_id = %blob.id,
+                        path = %path.display(),
+                        "blob file already absent during delete"
+                    );
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        blob_id = %blob.id,
+                        path = %path.display(),
+                        error = %err,
+                        "failed to delete blob file"
+                    );
+                }
+            }
         }
     }
 

--- a/backend/src/resources/blob/surreal_repo.rs
+++ b/backend/src/resources/blob/surreal_repo.rs
@@ -64,7 +64,7 @@ impl BlobRepository for SurrealBlobRepo {
                 .bind(("limit", limit))
                 .bind(("start", offset))
                 .await
-                .map_err(AppError::database)?
+                .map_err(|e| crate::log_and_convert!(AppError::database, "blob.list.query", e))?
         } else {
             db.db
                 .query("SELECT * FROM blob WHERE owner IN $teams LIMIT $limit START $start")
@@ -72,7 +72,7 @@ impl BlobRepository for SurrealBlobRepo {
                 .bind(("limit", limit))
                 .bind(("start", offset))
                 .await
-                .map_err(AppError::database)?
+                .map_err(|e| crate::log_and_convert!(AppError::database, "blob.list.query", e))?
         };
 
         Ok(response

--- a/backend/src/resources/collection/surreal_repo.rs
+++ b/backend/src/resources/collection/surreal_repo.rs
@@ -9,7 +9,7 @@ use shared::api::ListQuery;
 use shared::collection::{Collection, CreateCollection};
 use shared::song::{Link as SongLink, LinkOwned as SongLinkOwned};
 
-use crate::database::Database;
+use crate::database::{Database, surreal_take_errors};
 use crate::error::AppError;
 use crate::resources::common::{SongLinkRecord, belongs_to, blob_thing, resource_id};
 
@@ -217,7 +217,7 @@ impl CollectionRepository for SurrealCollectionRepo {
         song_link: SongLink,
     ) -> Result<(), AppError> {
         let db = self.inner();
-        let _ = db
+        let mut response = db
             .db
             .query(
                 r#"UPDATE type::thing("collection", $id) SET songs = array::append(songs, $song) WHERE owner IN $teams;"#,
@@ -226,6 +226,15 @@ impl CollectionRepository for SurrealCollectionRepo {
             .bind(("teams", write_teams.to_vec()))
             .bind(("song", SongLinkRecord::from(song_link)))
             .await?;
+
+        surreal_take_errors("collection.add_song_to_collection", &mut response)?;
+        let _ = response.check().map_err(|e| {
+            crate::log_and_convert!(
+                AppError::database,
+                "collection.add_song_to_collection.check",
+                e
+            )
+        })?;
 
         Ok(())
     }

--- a/backend/src/resources/team/invitation/surreal_repo.rs
+++ b/backend/src/resources/team/invitation/surreal_repo.rs
@@ -46,8 +46,14 @@ impl TeamInvitationRepository for SurrealTeamInvitationRepo {
             .create(("team_invitation", inv_id))
             .content(create)
             .await
-            .map_err(AppError::database)?;
+            .map_err(|e| {
+                crate::log_and_convert!(AppError::database, "team_invitation.create", e)
+            })?;
         if created.is_none() {
+            tracing::error!(
+                target = "team_invitation.create",
+                "failed to create team invitation (empty result)"
+            );
             return Err(AppError::database("failed to create team invitation"));
         }
         Ok(())

--- a/backend/src/resources/team/surreal_repo.rs
+++ b/backend/src/resources/team/surreal_repo.rs
@@ -95,15 +95,18 @@ impl TeamRepository for SurrealTeamRepo {
         resource: (String, String),
         name: &str,
     ) -> Result<(), AppError> {
-        self.inner()
+        let mut response = self
+            .inner()
             .db
             .query("UPDATE $tid SET name = $name")
             .bind(("tid", Thing::from(resource)))
             .bind(("name", name.to_owned()))
-            .await?
-            .check()
-            .map(|_| ())
-            .map_err(AppError::database)
+            .await?;
+        crate::database::surreal_take_errors("team.update_team_name", &mut response)?;
+        let _ = response.check().map_err(|e| {
+            crate::log_and_convert!(AppError::database, "team.update_team_name.check", e)
+        })?;
+        Ok(())
     }
 
     async fn update_team_members(
@@ -111,40 +114,49 @@ impl TeamRepository for SurrealTeamRepo {
         resource: (String, String),
         members: Vec<DbTeamMember>,
     ) -> Result<(), AppError> {
-        self.inner()
+        let mut response = self
+            .inner()
             .db
             .query("UPDATE $tid SET members = $members")
             .bind(("tid", Thing::from(resource)))
             .bind(("members", members))
-            .await?
-            .check()
-            .map(|_| ())
-            .map_err(AppError::database)
+            .await?;
+        crate::database::surreal_take_errors("team.update_team_members", &mut response)?;
+        let _ = response.check().map_err(|e| {
+            crate::log_and_convert!(AppError::database, "team.update_team_members.check", e)
+        })?;
+        Ok(())
     }
 
     async fn delete_team_record(&self, resource: (String, String)) -> Result<(), AppError> {
         let tid = Thing::from(resource);
-        self.inner()
+        let mut response = self
+            .inner()
             .db
             .query("DELETE $tid")
             .bind(("tid", tid))
-            .await?
-            .check()
-            .map(|_| ())
-            .map_err(AppError::database)
+            .await?;
+        crate::database::surreal_take_errors("team.delete_team_record", &mut response)?;
+        let _ = response.check().map_err(|e| {
+            crate::log_and_convert!(AppError::database, "team.delete_team_record.check", e)
+        })?;
+        Ok(())
     }
 
     async fn reassign_content(&self, from: Thing, to: Thing) -> Result<(), AppError> {
         for table in ["blob", "song", "collection", "setlist"] {
             let q = format!("UPDATE {table} SET owner = $to WHERE owner = $from");
-            self.inner()
+            let mut response = self
+                .inner()
                 .db
                 .query(&q)
                 .bind(("to", to.clone()))
                 .bind(("from", from.clone()))
-                .await?
-                .check()
-                .map_err(AppError::database)?;
+                .await?;
+            crate::database::surreal_take_errors("team.reassign_content", &mut response)?;
+            let _ = response.check().map_err(|e| {
+                crate::log_and_convert!(AppError::database, "team.reassign_content.check", e)
+            })?;
         }
         Ok(())
     }

--- a/backend/src/resources/user/session/surreal_repo.rs
+++ b/backend/src/resources/user/session/surreal_repo.rs
@@ -114,9 +114,9 @@ impl SessionRepository for SurrealSessionRepo {
             )
             .bind(("id", id.to_owned()))
             .await
-            .map_err(AppError::database)?
+            .map_err(|e| crate::log_and_convert!(AppError::database, "session.validate.query", e))?
             .take::<Option<SessionRecord>>(3)
-            .map_err(AppError::database)?
+            .map_err(|e| crate::log_and_convert!(AppError::database, "session.validate.take", e))?
             .map(SessionRecord::into_session))
     }
 }

--- a/backend/src/resources/user/surreal_repo.rs
+++ b/backend/src/resources/user/surreal_repo.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use shared::api::ListQuery;
 use shared::user::User;
 
-use crate::database::Database;
+use crate::database::{Database, surreal_take_errors};
 use crate::error::AppError;
 
 use super::model::{UserRecord, user_resource};
@@ -146,7 +146,7 @@ impl UserRepository for SurrealUserRepo {
         user_id: &str,
         collection_id: &str,
     ) -> Result<(), AppError> {
-        let _ = self
+        let mut response = self
             .inner()
             .db
             .query("UPDATE $user SET default_collection = $collection")
@@ -156,18 +156,26 @@ impl UserRepository for SurrealUserRepo {
                 Thing::from(("collection".to_owned(), collection_id.to_owned())),
             ))
             .await?;
+        surreal_take_errors("user.set_default_collection", &mut response)?;
+        let _ = response.check().map_err(|e| {
+            crate::log_and_convert!(AppError::database, "user.set_default_collection.check", e)
+        })?;
         Ok(())
     }
 }
 
 impl SurrealUserRepo {
     pub async fn clear_default_collection(&self, user_id: &str) -> Result<(), AppError> {
-        let _ = self
+        let mut response = self
             .inner()
             .db
             .query("UPDATE $user SET default_collection = NONE")
             .bind(("user", Thing::from(("user".to_owned(), user_id.to_owned()))))
             .await?;
+        surreal_take_errors("user.clear_default_collection", &mut response)?;
+        let _ = response.check().map_err(|e| {
+            crate::log_and_convert!(AppError::database, "user.clear_default_collection.check", e)
+        })?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Implements **Bundle B** from `docs/logging-review.md` (Phases 4–5): richer error logging at I/O boundaries and no silent discards on Surreal multi-statement responses.

## Changes

- **Phase 4:** `error_source_chain_string`, `log_error_chain`, `log_and_convert!`; `AppError::Internal` responses log `error.code` and chains; `From<surrealdb::Error>` / `From<reqwest::Error>` log before mapping; explicit `map_err(AppError::…)` sites use `log_and_convert!`.
- **Phase 5:** `surreal_take_errors` + `check` for default collection, collection song append, team updates/reassign, and personal-team lookup; `FsBlobStorage::delete_blob_file` logs debug/warn; `RequireUser` logs debug reasons for 401.

## Validation

- `cargo fmt`, `cargo clippy --all-targets`, `cargo test` (287 tests) on `backend`.

## Stack

Targets `feat/backend-logging-foundation` ([PR #94](https://github.com/xilefmusics/worship_viewer/pull/94)) so this diff stays reviewable; retarget to `main` after that PR merges if preferred.

Made with [Cursor](https://cursor.com)