### PR TITLE
feat(backend): production logging stack (tracing, errors, audit)

### DIFF
--- a/backend/src/auth/middleware.rs
+++ b/backend/src/auth/middleware.rs
@@ -12,6 +12,7 @@ use crate::resources::User;
 use crate::resources::user::Role as UserRole;
 use crate::resources::user::session::service::SessionServiceHandle;
 use crate::settings::CookieConfig;
+use tracing::debug;
 
 #[derive(Clone, Default)]
 pub struct RequireUser;
@@ -73,16 +74,23 @@ where
                 Err(err) => return Err(err),
             };
 
-            let session_id = authorization_bearer(&req)
-                .or_else(|| {
-                    req.cookie(&cookie_cfg.name)
-                        .map(|cookie| cookie.value().to_owned())
-                })
-                .ok_or_else(AppError::unauthorized)?;
+            let session_id = match authorization_bearer(&req).or_else(|| {
+                req.cookie(&cookie_cfg.name)
+                    .map(|cookie| cookie.value().to_owned())
+            }) {
+                Some(id) => id,
+                None => {
+                    debug!(reason = "missing_session", "unauthorized request");
+                    return Err(AppError::unauthorized().into());
+                }
+            };
 
             let user = match svc.validate_session_and_update_metrics(&session_id).await {
                 Ok(Some(session)) => session.user,
-                Ok(None) => return Err(AppError::unauthorized().into()),
+                Ok(None) => {
+                    debug!(reason = "expired_session", "session not found or expired");
+                    return Err(AppError::unauthorized().into());
+                }
                 Err(err) => return Err(err.into()),
             };
 

--- a/backend/src/auth/oidc/client.rs
+++ b/backend/src/auth/oidc/client.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Result as AnyResult};
 use openidconnect::core::{CoreClient, CoreProviderMetadata};
 use openidconnect::reqwest::async_http_client;
 use openidconnect::{ClientId, ClientSecret, IssuerUrl, RedirectUrl};
+use tracing::info;
 
 use crate::settings::Settings;
 
@@ -82,6 +83,14 @@ pub async fn build_clients(settings: &Settings) -> AnyResult<OidcClients> {
         &settings.oidc_redirect_url,
     )
     .await?;
+
+    info!(
+        event = "oidc.provider.registered",
+        provider = %OidcProvider::Google,
+        issuer = %settings.oidc_issuer_url,
+        scopes = ?settings.oidc_scopes.as_slice(),
+        "registered OIDC provider"
+    );
 
     Ok(OidcClients {
         google: OidcClientRegistration {

--- a/backend/src/auth/oidc/model.rs
+++ b/backend/src/auth/oidc/model.rs
@@ -36,7 +36,7 @@ impl Model for Database {
             .create(("oidc_state", key))
             .content(record)
             .await
-            .map_err(AppError::database)?;
+            .map_err(|e| crate::log_and_convert!(AppError::database, "oidc_state.create", e))?;
 
         Ok(())
     }
@@ -46,7 +46,7 @@ impl Model for Database {
             .db
             .select(("oidc_state", key))
             .await
-            .map_err(AppError::database)?;
+            .map_err(|e| crate::log_and_convert!(AppError::database, "oidc_state.select", e))?;
 
         let Some(record) = record else {
             return Ok(None);
@@ -56,7 +56,7 @@ impl Model for Database {
             .db
             .delete(("oidc_state", key))
             .await
-            .map_err(AppError::database)?;
+            .map_err(|e| crate::log_and_convert!(AppError::database, "oidc_state.delete", e))?;
 
         let pending = record.into_pending();
         if pending.expires_at <= Utc::now() {
@@ -70,7 +70,7 @@ impl Model for Database {
         self.db
             .query("DELETE oidc_state WHERE expires_at <= time::now()")
             .await
-            .map_err(AppError::database)?;
+            .map_err(|e| crate::log_and_convert!(AppError::database, "oidc_state.cleanup", e))?;
         Ok(())
     }
 }

--- a/backend/src/auth/oidc/rest.rs
+++ b/backend/src/auth/oidc/rest.rs
@@ -134,7 +134,7 @@ async fn callback(
     let token_response = token_request
         .request_async(async_http_client)
         .await
-        .map_err(AppError::oidc)?;
+        .map_err(|e| crate::log_and_convert!(AppError::oidc, "oidc.token_exchange", e))?;
 
     let id_token = token_response
         .extra_fields()
@@ -143,7 +143,7 @@ async fn callback(
 
     let claims = id_token
         .claims(&oidc_client.id_token_verifier(), &nonce)
-        .map_err(AppError::oidc)?;
+        .map_err(|e| crate::log_and_convert!(AppError::oidc, "oidc.id_token_claims", e))?;
 
     let user = user_svc
         .get_user_by_email_or_create(claims.email().ok_or(AppError::Unauthorized)?)

--- a/backend/src/auth/oidc/rest.rs
+++ b/backend/src/auth/oidc/rest.rs
@@ -14,6 +14,7 @@ use openidconnect::reqwest::async_http_client;
 use openidconnect::{Nonce, Scope};
 use serde::Deserialize;
 use time::Duration as CookieDuration;
+use tracing::instrument;
 use utoipa::IntoParams;
 
 use super::{Model as OidcModel, OidcClients, OidcProvider, PendingOidc};
@@ -38,6 +39,7 @@ use crate::settings::CookieConfig;
     ),
     tag = "Auth"
 )]
+#[instrument(level = "debug", err, skip_all, fields(provider = "google"))]
 #[get("/login")]
 async fn login(
     db: Data<Database>,
@@ -98,6 +100,7 @@ async fn login(
     ),
     tag = "Auth"
 )]
+#[instrument(level = "debug", err, skip_all, fields(provider = "google"))]
 #[get("/callback")]
 async fn callback(
     db: Data<Database>,
@@ -108,10 +111,18 @@ async fn callback(
     query: web::Query<AuthCallbackQuery>,
 ) -> Result<HttpResponse, AppError> {
     db.cleanup_expired_oidc_states().await?;
-    let pending = db
-        .take_oidc_state(&query.state)
-        .await?
-        .ok_or_else(AppError::invalid_state)?;
+    let pending = match db.take_oidc_state(&query.state).await? {
+        Some(p) => p,
+        None => {
+            crate::audit!(
+                "audit.auth.login.failure",
+                provider = tracing::field::display(&"google"),
+                reason = tracing::field::display(&"invalid_oidc_state")
+                ; "oidc login failed"
+            );
+            return Err(AppError::invalid_state());
+        }
+    };
 
     let PendingOidc {
         pkce_verifier,
@@ -123,9 +134,18 @@ async fn callback(
     } = pending;
 
     let oidc_clients = oidc_clients.get_ref();
-    let registration = oidc_clients
-        .get(&provider)
-        .ok_or_else(|| AppError::invalid_request("oauth provider not configured"))?;
+    let registration = match oidc_clients.get(&provider) {
+        Some(r) => r,
+        None => {
+            crate::audit!(
+                "audit.auth.login.failure",
+                provider = tracing::field::display(&"google"),
+                reason = tracing::field::display(&"provider_not_configured")
+                ; "oidc login failed"
+            );
+            return Err(AppError::invalid_request("oauth provider not configured"));
+        }
+    };
     let oidc_client = registration.client();
 
     let mut token_request = oidc_client.exchange_code(AuthorizationCode::new(query.code.clone()));
@@ -134,23 +154,102 @@ async fn callback(
     let token_response = token_request
         .request_async(async_http_client)
         .await
-        .map_err(|e| crate::log_and_convert!(AppError::oidc, "oidc.token_exchange", e))?;
+        .map_err(|e| {
+            crate::audit!(
+                "audit.auth.login.failure",
+                provider = tracing::field::display(&"google"),
+                reason = tracing::field::display(&"token_exchange_failed")
+                ; "oidc login failed"
+            );
+            crate::log_and_convert!(AppError::oidc, "oidc.token_exchange", e)
+        })?;
 
-    let id_token = token_response
-        .extra_fields()
-        .id_token()
-        .ok_or_else(|| AppError::invalid_request("provider response missing id_token"))?;
+    let id_token = match token_response.extra_fields().id_token() {
+        Some(t) => t,
+        None => {
+            crate::audit!(
+                "audit.auth.login.failure",
+                provider = tracing::field::display(&"google"),
+                reason = tracing::field::display(&"missing_id_token")
+                ; "oidc login failed"
+            );
+            return Err(AppError::invalid_request(
+                "provider response missing id_token",
+            ));
+        }
+    };
 
     let claims = id_token
         .claims(&oidc_client.id_token_verifier(), &nonce)
-        .map_err(|e| crate::log_and_convert!(AppError::oidc, "oidc.id_token_claims", e))?;
+        .map_err(|e| {
+            crate::audit!(
+                "audit.auth.login.failure",
+                provider = tracing::field::display(&"google"),
+                reason = tracing::field::display(&"id_token_invalid")
+                ; "oidc login failed"
+            );
+            crate::log_and_convert!(AppError::oidc, "oidc.id_token_claims", e)
+        })?;
 
-    let user = user_svc
-        .get_user_by_email_or_create(claims.email().ok_or(AppError::Unauthorized)?)
-        .await?;
-    let session = session_svc
-        .create_session(Session::new(user, cookie_cfg.session_ttl_seconds as i64))
-        .await?;
+    let Some(email_addr) = claims.email() else {
+        crate::audit!(
+            "audit.auth.login.failure",
+            provider = tracing::field::display(&"google"),
+            reason = tracing::field::display(&"missing_email_claim")
+            ; "oidc login failed"
+        );
+        return Err(AppError::Unauthorized);
+    };
+
+    let user = match user_svc
+        .get_user_by_email_or_create(email_addr.as_str())
+        .await
+    {
+        Ok(u) => u,
+        Err(e) => {
+            crate::audit!(
+                "audit.auth.login.failure",
+                provider = tracing::field::display(&"google"),
+                reason = tracing::field::display(&"user_provision_failed"),
+                email_hash = tracing::field::display(
+                    &crate::observability::audit_email_hash(email_addr.as_str())
+                )
+                ; "oidc login failed"
+            );
+            return Err(e);
+        }
+    };
+
+    let session = match session_svc
+        .create_session(Session::new(
+            user.clone(),
+            cookie_cfg.session_ttl_seconds as i64,
+        ))
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            crate::audit!(
+                "audit.auth.login.failure",
+                provider = tracing::field::display(&"google"),
+                reason = tracing::field::display(&"session_create_failed"),
+                email_hash = tracing::field::display(
+                    &crate::observability::audit_email_hash(email_addr.as_str())
+                )
+                ; "oidc login failed"
+            );
+            return Err(e);
+        }
+    };
+
+    crate::audit!(
+        "audit.auth.login.success",
+        provider = tracing::field::display(&"google"),
+        user_id = tracing::field::display(&user.id),
+        session_id = tracing::field::display(&session.id)
+        ; "login succeeded"
+    );
+
     let redirect_target =
         resolve_frontend_redirect(&cookie_cfg.post_login_path, redirect_to.as_deref());
 

--- a/backend/src/auth/otp/model.rs
+++ b/backend/src/auth/otp/model.rs
@@ -47,7 +47,7 @@ impl Model for Database {
             .bind(("code", otp_hmac(email, code, pepper)))
             .bind(("ttl_secs", ttl_seconds as i64))
             .await
-            .map_err(AppError::database)?;
+            .map_err(|e| crate::log_and_convert!(AppError::database, "otp.remember.query", e))?;
         Ok(())
     }
 
@@ -86,9 +86,9 @@ impl Model for Database {
             .bind(("email", email.to_owned()))
             .bind(("code", otp_hmac(email, code, pepper)))
             .await
-            .map_err(AppError::database)?
+            .map_err(|e| crate::log_and_convert!(AppError::database, "otp.validate.query", e))?
             .take::<Option<Outcome>>(7)
-            .map_err(AppError::database)?
+            .map_err(|e| crate::log_and_convert!(AppError::database, "otp.validate.take", e))?
             .ok_or_else(|| AppError::invalid_request("no otp request for that email"))?;
 
         if outcome.valid > 0 {
@@ -103,7 +103,9 @@ impl Model for Database {
                 .query("DELETE type::thing('otp', $email)")
                 .bind(("email", email.to_owned()))
                 .await
-                .map_err(AppError::database)?;
+                .map_err(|e| {
+                    crate::log_and_convert!(AppError::database, "otp.lockout_delete.query", e)
+                })?;
             return Err(AppError::too_many_requests(
                 "too many incorrect otp attempts; request a new code",
             ));

--- a/backend/src/auth/otp/rest.rs
+++ b/backend/src/auth/otp/rest.rs
@@ -19,6 +19,7 @@ use crate::resources::user::service::UserServiceHandle;
 use crate::resources::user::session::service::SessionServiceHandle;
 use crate::settings::{CookieConfig, OtpConfig};
 use shared::user::{Session, SessionBody};
+use tracing::instrument;
 
 #[utoipa::path(
     post,
@@ -32,6 +33,7 @@ use shared::user::{Session, SessionBody};
     ),
     tag = "Auth"
 )]
+#[instrument(level = "debug", err, skip_all, fields(provider = "otp"))]
 #[post("/otp/request")]
 async fn otp_request(
     db: Data<Database>,
@@ -56,6 +58,14 @@ async fn otp_request(
         &format!("Hello {email},\n\nto complete your sign-in or verification for WorshipViewer, please use the one-time password below:\n\n🔐 OTP: {code}\n\nThis code is valid for the next 5 minutes.  \nIf you did not request this, please ignore this message.\n\nBlessings,\nThe WorshipViewer Team"),
     ).await?;
 
+    let email_domain = email.split('@').nth(1).unwrap_or("unknown");
+    crate::audit!(
+        "audit.auth.otp.requested",
+        email_domain = tracing::field::display(email_domain),
+        delivered = tracing::field::display(&true)
+        ; "otp requested"
+    );
+
     Ok(HttpResponse::NoContent().finish())
 }
 
@@ -71,6 +81,7 @@ async fn otp_request(
     ),
     tag = "Auth"
 )]
+#[instrument(level = "debug", err, skip_all, fields(provider = "otp"))]
 #[post("/otp/verify")]
 async fn otp_verify(
     db: Data<Database>,
@@ -94,21 +105,79 @@ async fn otp_verify(
         .ok_if(|value| !value.is_empty())
         .ok_or_else(|| AppError::invalid_request("otp code is required"))?;
 
-    db.validate_otp(&email, &code, &otp_cfg.pepper, otp_cfg.max_attempts)
-        .await?;
+    match db
+        .validate_otp(&email, &code, &otp_cfg.pepper, otp_cfg.max_attempts)
+        .await
+    {
+        Ok(()) => {}
+        Err(e) => {
+            let reason = match &e {
+                AppError::TooManyRequests(_) => "otp_locked_out",
+                AppError::InvalidRequest(msg) if msg.contains("no otp request") => "otp_not_found",
+                AppError::InvalidRequest(_) => "otp_invalid",
+                _ => "otp_verify_failed",
+            };
+            crate::audit!(
+                "audit.auth.login.failure",
+                provider = tracing::field::display(&"otp"),
+                reason = tracing::field::display(&reason),
+                email_hash = tracing::field::display(&crate::observability::audit_email_hash(
+                    &email
+                ))
+                ; "otp verify failed"
+            );
+            return Err(e);
+        }
+    }
 
     let user = if otp_cfg.allow_self_signup {
         user_svc.get_user_by_email_or_create(&email).await?
     } else {
         user_svc.get_user_by_email(&email).await?.ok_or_else(|| {
+            crate::audit!(
+                "audit.auth.login.failure",
+                provider = tracing::field::display(&"otp"),
+                reason = tracing::field::display(&"self_signup_disabled"),
+                email_hash = tracing::field::display(&crate::observability::audit_email_hash(
+                    &email
+                ))
+                ; "otp verify failed"
+            );
             AppError::invalid_request(
                 "no user exists for this email; self-signup via OTP is disabled",
             )
         })?
     };
-    let session = session_svc
-        .create_session(Session::new(user, cookie_cfg.session_ttl_seconds as i64))
-        .await?;
+
+    let session = match session_svc
+        .create_session(Session::new(
+            user.clone(),
+            cookie_cfg.session_ttl_seconds as i64,
+        ))
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            crate::audit!(
+                "audit.auth.login.failure",
+                provider = tracing::field::display(&"otp"),
+                reason = tracing::field::display(&"session_create_failed"),
+                email_hash = tracing::field::display(&crate::observability::audit_email_hash(
+                    &email
+                ))
+                ; "otp verify failed"
+            );
+            return Err(e);
+        }
+    };
+
+    crate::audit!(
+        "audit.auth.login.success",
+        provider = tracing::field::display(&"otp"),
+        user_id = tracing::field::display(&user.id),
+        session_id = tracing::field::display(&session.id)
+        ; "login succeeded"
+    );
 
     Ok(HttpResponse::Ok()
         .cookie(session_cookie(&session.id, &cookie_cfg))

--- a/backend/src/auth/rest.rs
+++ b/backend/src/auth/rest.rs
@@ -1,4 +1,7 @@
 use actix_governor::{Governor, GovernorConfigBuilder};
+
+use crate::governor_audit::AuditRateLimit429;
+use crate::governor_peer::ProblemJsonPeerIpKeyExtractor;
 use actix_web::{
     HttpRequest, HttpResponse,
     cookie::{Cookie, SameSite},
@@ -17,6 +20,7 @@ pub fn scope(auth_rate_limit_rps: u64, auth_rate_limit_burst: u32) -> actix_web:
     let governor_conf = GovernorConfigBuilder::default()
         .requests_per_second(auth_rate_limit_rps)
         .burst_size(auth_rate_limit_burst)
+        .key_extractor(ProblemJsonPeerIpKeyExtractor)
         .finish()
         .expect("valid rate-limit configuration");
 
@@ -26,6 +30,7 @@ pub fn scope(auth_rate_limit_rps: u64, auth_rate_limit_burst: u32) -> actix_web:
         .service(
             web::scope("")
                 .wrap(Governor::new(&governor_conf))
+                .wrap(AuditRateLimit429)
                 .service(oidc::rest::login)
                 .service(otp::rest::otp_request)
                 .service(otp::rest::otp_verify)
@@ -54,10 +59,35 @@ async fn logout(
         .cookie(&cookie_cfg.name)
         .map(|cookie| cookie.value().to_owned());
 
-    if let Some(session_id) = bearer_session.as_deref().or(cookie_session.as_deref())
-        && let Err(err) = svc.delete_session(session_id).await
-    {
-        warn!(session = session_id, "failed to drop session: {}", err);
+    if let Some(session_id) = bearer_session.as_deref().or(cookie_session.as_deref()) {
+        match svc.delete_session(session_id).await {
+            Ok(deleted) => {
+                let had_cookie = cookie_session.is_some();
+                crate::audit!(
+                    "audit.auth.logout",
+                    session_id = tracing::field::display(session_id),
+                    had_cookie = tracing::field::display(&had_cookie)
+                    ; "logout"
+                );
+                crate::audit!(
+                    "audit.session.revoked",
+                    session_id = tracing::field::display(&deleted.id),
+                    user_id = tracing::field::display(&deleted.user.id),
+                    actor_user_id = tracing::field::display(&deleted.user.id)
+                    ; "session revoked"
+                );
+            }
+            Err(err) => {
+                warn!(session = session_id, "failed to drop session: {}", err);
+            }
+        }
+    } else {
+        crate::audit!(
+            "audit.auth.logout",
+            session_id = tracing::field::display(&"none"),
+            had_cookie = tracing::field::display(&cookie_session.is_some())
+            ; "logout"
+        );
     }
 
     let mut response = HttpResponse::NoContent();

--- a/backend/src/database/migrations.rs
+++ b/backend/src/database/migrations.rs
@@ -96,18 +96,11 @@ async fn load_applied_migrations(db: &Surreal<Any>) -> AnyResult<HashMap<String,
 }
 
 fn log_surreal_error_chain(migration: &str, statement_index: usize, err: &surrealdb::Error) {
-    let mut sources: Vec<String> = Vec::new();
-    sources.push(err.to_string());
-    let mut cursor = std::error::Error::source(err);
-    while let Some(inner) = cursor {
-        sources.push(inner.to_string());
-        cursor = inner.source();
-    }
     error!(
         migration = %migration,
         statement_index = statement_index,
         error = %err,
-        error_source_chain = %sources.join(" <- "),
+        error_source_chain = %crate::observability::error_source_chain_string(err),
         error_debug = ?err,
         "SurrealDB query statement failed"
     );

--- a/backend/src/database/mod.rs
+++ b/backend/src/database/mod.rs
@@ -6,6 +6,7 @@ use surrealdb::Surreal;
 use surrealdb::engine::any::{Any, connect};
 use surrealdb::opt::auth::Database as DbAuth;
 use surrealdb::sql::{Id, Thing};
+use tracing::instrument;
 
 use crate::error::AppError;
 
@@ -61,6 +62,18 @@ pub struct Database {
 }
 
 impl Database {
+    #[instrument(
+        name = "database.connect",
+        level = "debug",
+        err,
+        skip(username, password),
+        fields(
+            db_address = %address,
+            db_namespace = %namespace,
+            db_database = %database,
+            has_credentials = username.is_some() && password.is_some()
+        )
+    )]
     pub async fn connect(
         address: &str,
         namespace: &str,
@@ -103,6 +116,13 @@ impl Database {
         Ok(Self { db })
     }
 
+    #[instrument(
+        name = "database.migrate",
+        level = "debug",
+        err,
+        skip(self),
+        fields(migration_path = %migration_path)
+    )]
     pub async fn migrate(&self, migration_path: &str) -> AnyResult<()> {
         migrations::run(&self.db, migration_path).await
     }

--- a/backend/src/database/mod.rs
+++ b/backend/src/database/mod.rs
@@ -9,6 +9,38 @@ use surrealdb::sql::{Id, Thing};
 
 use crate::error::AppError;
 
+/// Inspect Surreal [`surrealdb::Response`] for per-statement failures (mirrors migration checks).
+pub(crate) fn surreal_take_errors(
+    context: &'static str,
+    response: &mut surrealdb::Response,
+) -> Result<(), AppError> {
+    let errors = response.take_errors();
+    if errors.is_empty() {
+        return Ok(());
+    }
+
+    let mut pairs: Vec<(usize, surrealdb::Error)> = errors.into_iter().collect();
+    pairs.sort_by_key(|(idx, _)| *idx);
+
+    let mut summary = Vec::with_capacity(pairs.len());
+    for (idx, err) in pairs {
+        tracing::error!(
+            context = context,
+            statement_index = idx,
+            error = %err,
+            error_source_chain = %crate::observability::error_source_chain_string(&err),
+            error_debug = ?err,
+            "SurrealDB query statement failed"
+        );
+        summary.push(format!("[statement {idx}] {err}"));
+    }
+
+    Err(AppError::database(format!(
+        "{context}: {}",
+        summary.join("; ")
+    )))
+}
+
 #[derive(Deserialize)]
 struct TeamIdOnly {
     id: Thing,
@@ -83,9 +115,18 @@ impl Database {
             .query("SELECT id FROM team WHERE owner = $user LIMIT 1")
             .bind(("user", user))
             .await
-            .map_err(AppError::database)?;
+            .map_err(|e| {
+                crate::log_and_convert!(AppError::database, "db.personal_team.query", e)
+            })?;
 
-        let rows: Vec<TeamIdOnly> = response.take(0).map_err(AppError::database)?;
+        surreal_take_errors("db.personal_team", &mut response)?;
+        response = response.check().map_err(|e| {
+            crate::log_and_convert!(AppError::database, "db.personal_team.check", e)
+        })?;
+
+        let rows: Vec<TeamIdOnly> = response
+            .take(0)
+            .map_err(|e| crate::log_and_convert!(AppError::database, "db.personal_team.take", e))?;
         rows.into_iter()
             .next()
             .map(|r| r.id)

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -4,6 +4,7 @@ use actix_web::{HttpMessage, HttpResponse, ResponseError};
 use thiserror::Error;
 use tracing::error;
 
+use crate::observability;
 use shared::error::Problem;
 
 #[derive(Debug, Error)]
@@ -149,9 +150,13 @@ impl From<surrealdb::Error> for AppError {
                 surrealdb::error::Db::NoRecordFound | surrealdb::error::Db::IdNotFound { .. } => {
                     AppError::NotFound("record not found".into())
                 }
-                _ => Self::database(err),
+                _ => {
+                    observability::log_error_chain("surrealdb.app_error", &err);
+                    Self::database(err)
+                }
             }
         } else {
+            observability::log_error_chain("surrealdb.app_error", &err);
             Self::database(err)
         }
     }
@@ -165,6 +170,7 @@ impl From<chordlib::Error> for AppError {
 
 impl From<reqwest::Error> for AppError {
     fn from(err: reqwest::Error) -> Self {
+        observability::log_error_chain("reqwest", &err);
         AppError::Internal(format!("HTTP client error: {}", err))
     }
 }
@@ -236,7 +242,13 @@ impl ResponseError for AppError {
 
     fn error_response(&self) -> HttpResponse {
         if matches!(self, AppError::Internal(_)) {
-            error!("{}", self);
+            error!(
+                error.code = self.code(),
+                error = %self,
+                error_source_chain = %observability::error_source_chain_string(self),
+                error_debug = ?self,
+                "internal error"
+            );
         }
         let status = self.status_code().as_u16();
         let detail = self.detail_message();

--- a/backend/src/governor_audit.rs
+++ b/backend/src/governor_audit.rs
@@ -1,0 +1,112 @@
+//! Rate-limit responses as RFC 7807 Problem JSON and audit logging for 429s.
+
+use std::future::{Ready, ready};
+use std::rc::Rc;
+
+use actix_governor::governor::NotUntil;
+use actix_governor::governor::clock::{Clock, DefaultClock, QuantaInstant};
+use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready};
+use actix_web::http::header::ContentType;
+use actix_web::{Error, HttpMessage, HttpResponse, HttpResponseBuilder};
+use futures_util::future::LocalBoxFuture;
+use shared::error::Problem;
+
+use crate::resources::User;
+
+/// Problem Details body for actix-governor 429 responses (retry headers already on `response`).
+pub fn rate_limit_problem_response(
+    negative: &NotUntil<QuantaInstant>,
+    mut response: HttpResponseBuilder,
+    instance: Option<String>,
+) -> HttpResponse {
+    let wait_time = negative
+        .wait_time_from(DefaultClock::default().now())
+        .as_secs();
+    let detail = format!("rate limit exceeded; retry after {wait_time}s");
+    let problem = Problem::new(
+        "https://worship-viewer.invalid/problems/too_many_requests".into(),
+        "Too Many Requests".into(),
+        429,
+        "too_many_requests",
+        detail,
+        instance,
+    );
+    response.content_type(ContentType::json()).json(problem)
+}
+
+/// Logs [`crate::audit!("audit.rate_limit.rejected", ...)`] when the inner service returns 429.
+#[derive(Clone, Default)]
+pub struct AuditRateLimit429;
+
+impl<S, B> Transform<S, ServiceRequest> for AuditRateLimit429
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type InitError = ();
+    type Transform = AuditRateLimit429Middleware<S>;
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ready(Ok(AuditRateLimit429Middleware {
+            service: Rc::new(service),
+        }))
+    }
+}
+
+pub struct AuditRateLimit429Middleware<S> {
+    service: Rc<S>,
+}
+
+impl<S, B> Service<ServiceRequest> for AuditRateLimit429Middleware<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    forward_ready!(service);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let route = req
+            .match_pattern()
+            .map(|p| p.to_string())
+            .unwrap_or_else(|| req.path().to_string());
+        let user_id = req.extensions().get::<User>().map(|u| u.id.clone());
+        let client_ip = req
+            .peer_addr()
+            .map(|a| a.ip().to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+        let svc = Rc::clone(&self.service);
+
+        Box::pin(async move {
+            let resp = svc.call(req).await?;
+            if resp.status() == actix_web::http::StatusCode::TOO_MANY_REQUESTS {
+                match &user_id {
+                    Some(uid) => {
+                        crate::audit!(
+                            "audit.rate_limit.rejected",
+                            route = tracing::field::display(&route),
+                            client_ip = tracing::field::display(&client_ip),
+                            user_id = tracing::field::display(uid)
+                            ; "rate limit exceeded"
+                        );
+                    }
+                    None => {
+                        crate::audit!(
+                            "audit.rate_limit.rejected",
+                            route = tracing::field::display(&route),
+                            client_ip = tracing::field::display(&client_ip)
+                            ; "rate limit exceeded"
+                        );
+                    }
+                }
+            }
+            Ok(resp)
+        })
+    }
+}

--- a/backend/src/governor_peer.rs
+++ b/backend/src/governor_peer.rs
@@ -4,7 +4,10 @@
 
 use std::net::{IpAddr, Ipv4Addr};
 
-use actix_governor::KeyExtractor;
+use actix_governor::governor::NotUntil;
+use actix_governor::governor::clock::QuantaInstant;
+use actix_governor::{KeyExtractor, PeerIpKeyExtractor};
+use actix_web::HttpResponse;
 use actix_web::dev::ServiceRequest;
 
 /// Same IPv6 /56 normalization as [`actix_governor::PeerIpKeyExtractor`].
@@ -30,5 +33,34 @@ impl KeyExtractor for PeerOrFallbackIpKeyExtractor {
             .map(|s| normalize_ip_key(s.ip()))
             .unwrap_or_else(|| IpAddr::V4(Ipv4Addr::LOCALHOST));
         Ok(ip)
+    }
+
+    fn exceed_rate_limit_response(
+        &self,
+        negative: &NotUntil<QuantaInstant>,
+        response: actix_web::HttpResponseBuilder,
+    ) -> HttpResponse {
+        crate::governor_audit::rate_limit_problem_response(negative, response, None)
+    }
+}
+
+/// Like [`PeerIpKeyExtractor`], but 429 responses use `application/problem+json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProblemJsonPeerIpKeyExtractor;
+
+impl KeyExtractor for ProblemJsonPeerIpKeyExtractor {
+    type Key = IpAddr;
+    type KeyExtractionError = actix_governor::SimpleKeyExtractionError<&'static str>;
+
+    fn extract(&self, req: &ServiceRequest) -> Result<Self::Key, Self::KeyExtractionError> {
+        PeerIpKeyExtractor.extract(req)
+    }
+
+    fn exceed_rate_limit_response(
+        &self,
+        negative: &NotUntil<QuantaInstant>,
+        response: actix_web::HttpResponseBuilder,
+    ) -> HttpResponse {
+        crate::governor_audit::rate_limit_problem_response(negative, response, None)
     }
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -7,6 +7,7 @@ pub mod docs;
 pub mod error;
 pub mod expand;
 pub mod frontend;
+pub mod governor_audit;
 pub mod governor_peer;
 pub mod http_cache;
 pub mod mail;

--- a/backend/src/mail.rs
+++ b/backend/src/mail.rs
@@ -12,7 +12,7 @@ pub struct MailService {
 impl MailService {
     pub fn new(from: String, credentials: Credentials) -> Result<Self, AppError> {
         let transport = AsyncSmtpTransport::<Tokio1Executor>::relay("smtp.gmail.com")
-            .map_err(AppError::mail)?
+            .map_err(|e| crate::log_and_convert!(AppError::mail, "mail.smtp_relay", e))?
             .credentials(credentials)
             .build();
         Ok(Self { transport, from })
@@ -20,15 +20,30 @@ impl MailService {
 
     pub async fn send(&self, to: &str, subject: &str, body: &str) -> Result<(), AppError> {
         let message = Message::builder()
-            .from(self.from.parse().map_err(AppError::mail)?)
-            .to(to.parse().map_err(AppError::mail)?)
+            .from(
+                self.from
+                    .parse()
+                    .map_err(|e| crate::log_and_convert!(AppError::mail, "mail.parse_from", e))?,
+            )
+            .to(to
+                .parse()
+                .map_err(|e| crate::log_and_convert!(AppError::mail, "mail.parse_to", e))?)
             .subject(subject)
             .body(body.to_owned())
-            .map_err(AppError::mail)?;
+            .map_err(|e| crate::log_and_convert!(AppError::mail, "mail.build_message", e))?;
 
-        let response = self.transport.send(message).await.map_err(AppError::mail)?;
+        let response = self
+            .transport
+            .send(message)
+            .await
+            .map_err(|e| crate::log_and_convert!(AppError::mail, "mail.transport_send", e))?;
 
         if !response.is_positive() {
+            tracing::warn!(
+                target = "mail.transport",
+                ?response,
+                "sending the mail was not positive"
+            );
             return Err(AppError::mail("sending the mail was not positive"));
         }
         Ok(())

--- a/backend/src/mail.rs
+++ b/backend/src/mail.rs
@@ -1,5 +1,6 @@
 use lettre::transport::smtp::authentication::Credentials;
 use lettre::{AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor};
+use tracing::instrument;
 
 use crate::error::AppError;
 
@@ -10,6 +11,7 @@ pub struct MailService {
 }
 
 impl MailService {
+    #[instrument(level = "debug", err, skip(credentials), fields(from = %from))]
     pub fn new(from: String, credentials: Credentials) -> Result<Self, AppError> {
         let transport = AsyncSmtpTransport::<Tokio1Executor>::relay("smtp.gmail.com")
             .map_err(|e| crate::log_and_convert!(AppError::mail, "mail.smtp_relay", e))?
@@ -18,6 +20,16 @@ impl MailService {
         Ok(Self { transport, from })
     }
 
+    #[instrument(
+        level = "debug",
+        err,
+        skip(self, body),
+        fields(
+            to = tracing::field::display(to),
+            subject = tracing::field::display(subject),
+            transport_ok = tracing::field::Empty
+        )
+    )]
     pub async fn send(&self, to: &str, subject: &str, body: &str) -> Result<(), AppError> {
         let message = Message::builder()
             .from(
@@ -39,6 +51,7 @@ impl MailService {
             .map_err(|e| crate::log_and_convert!(AppError::mail, "mail.transport_send", e))?;
 
         if !response.is_positive() {
+            tracing::Span::current().record("transport_ok", tracing::field::display(&false));
             tracing::warn!(
                 target = "mail.transport",
                 ?response,
@@ -46,6 +59,7 @@ impl MailService {
             );
             return Err(AppError::mail("sending the mail was not positive"));
         }
+        tracing::Span::current().record("transport_ok", tracing::field::display(&true));
         Ok(())
     }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -44,7 +44,6 @@ async fn main() -> AnyResult<()> {
         .with_context(|| format!("static_dir {:?} could not be resolved", settings.static_dir))?
         .to_string_lossy()
         .into_owned();
-    info!("Serving static files from {}", static_dir);
 
     let cookie_config = Data::new(settings.cookie_config());
     let otp_config = Data::new(settings.otp_config());
@@ -123,6 +122,27 @@ async fn main() -> AnyResult<()> {
 
     let oidc_clients = Data::new(Arc::new(oidc::build_clients(&settings).await?));
 
+    info!(
+        event = "startup",
+        host = %settings.host,
+        port = settings.port,
+        cookie_secure = settings.cookie_secure,
+        session_ttl_seconds = settings.session_ttl_seconds,
+        otp_ttl_seconds = settings.otp_ttl_seconds,
+        otp_allow_self_signup = settings.otp_allow_self_signup,
+        otp_max_attempts = settings.otp_max_attempts,
+        auth_rate_limit_rps = settings.auth_rate_limit_rps,
+        auth_rate_limit_burst = settings.auth_rate_limit_burst,
+        api_rate_limit_rps = settings.api_rate_limit_rps,
+        api_rate_limit_burst = settings.api_rate_limit_burst,
+        blob_upload_max_bytes = settings.blob_upload_max_bytes,
+        blob_dir = %settings.blob_dir,
+        production = production,
+        static_dir = %static_dir,
+        oidc_providers = ?["google"],
+        "backend starting"
+    );
+
     let team_resolver = Arc::new(SurrealTeamResolver::new(db.clone()));
     let blob_service = BlobServiceHandle::build_with_team_resolver(
         db.clone(),
@@ -143,11 +163,6 @@ async fn main() -> AnyResult<()> {
     let team_resolver_data = Data::new(team_resolver);
     let invitation_service = InvitationServiceHandle::build(db.clone());
     let db_data = Data::from(db);
-
-    info!(
-        "Starting server on http://{}:{}",
-        settings.host, settings.port
-    );
 
     let docs_settings = settings.clone();
 

--- a/backend/src/observability.rs
+++ b/backend/src/observability.rs
@@ -81,3 +81,36 @@ pub fn init() -> anyhow::Result<()> {
     let _ = tracing_log::LogTracer::init();
     Ok(())
 }
+
+/// Joins [`std::error::Error::source`] links with `" <- "` (top-level message first).
+pub fn error_source_chain_string(err: &(dyn std::error::Error + 'static)) -> String {
+    let mut sources: Vec<String> = Vec::new();
+    sources.push(err.to_string());
+    let mut cursor = err.source();
+    while let Some(inner) = cursor {
+        sources.push(inner.to_string());
+        cursor = inner.source();
+    }
+    sources.join(" <- ")
+}
+
+/// Logs `%err`, `?err`, and the full source chain under a stable `target` field.
+pub fn log_error_chain(target: &'static str, err: &(dyn std::error::Error + 'static)) {
+    tracing::error!(
+        target = target,
+        error = %err,
+        error_source_chain = %error_source_chain_string(err),
+        error_debug = ?err,
+        "I/O boundary error"
+    );
+}
+
+/// Log a typed error's chain, then convert with `AppError::{database,mail,oidc}` (or similar).
+#[macro_export]
+macro_rules! log_and_convert {
+    ($mapper:path, $target:literal, $err:expr) => {{
+        let err = $err;
+        $crate::observability::log_error_chain($target, &err);
+        $mapper(err)
+    }};
+}

--- a/backend/src/observability.rs
+++ b/backend/src/observability.rs
@@ -1,6 +1,41 @@
 //! Tracing subscriber setup (`tracing` + `tracing-subscriber` + `tracing-log` bridge).
 
+use hex;
+use ring::digest;
 use tracing_subscriber::EnvFilter;
+
+/// Compile-time guard: audit [`crate::audit!`] events must use the `audit.` prefix.
+pub const fn audit_event_name_ok(name: &str) -> bool {
+    let b = name.as_bytes();
+    b.len() >= 6
+        && b[0] == b'a'
+        && b[1] == b'u'
+        && b[2] == b'd'
+        && b[3] == b'i'
+        && b[4] == b't'
+        && b[5] == b'.'
+}
+
+/// SHA-256 hex digest of `email` for audit logs (never log raw email on failure paths).
+pub fn audit_email_hash(email: &str) -> String {
+    let d = digest::digest(&digest::SHA256, email.as_bytes());
+    hex::encode(d.as_ref())
+}
+
+/// Structured audit line: sets `audit = true` and enforces `event` literals starting with `audit.`.
+///
+/// Fields use `ident = expr` only (use [`tracing::field::display`] / [`tracing::field::debug`] in the expr).
+#[macro_export]
+macro_rules! audit {
+    ($event:literal ; $msg:literal) => {
+        const _: () = assert!($crate::observability::audit_event_name_ok($event));
+        tracing::info!(audit = true, event = $event, $msg);
+    };
+    ($event:literal, $($key:ident = $value:expr),+ ; $msg:literal) => {
+        const _: () = assert!($crate::observability::audit_event_name_ok($event));
+        tracing::info!(audit = true, event = $event, $($key = $value),+, $msg);
+    };
+}
 
 /// Matches production detection in `main` (initial admin / unsafe dev checks).
 pub fn is_production() -> bool {

--- a/backend/src/resources/blob/service.rs
+++ b/backend/src/resources/blob/service.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use actix_files::NamedFile;
+use tracing::instrument;
 
 use shared::api::ListQuery;
 use shared::blob::{Blob, CreateBlob, PatchBlob};
@@ -33,6 +34,7 @@ impl<R, T, S> BlobService<R, T, S> {
 }
 
 impl<R: BlobRepository, T: TeamResolver, S: BlobStorage> BlobService<R, T, S> {
+    #[instrument(level = "debug", err, skip(self, perms))]
     pub async fn list_blobs_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -42,6 +44,7 @@ impl<R: BlobRepository, T: TeamResolver, S: BlobStorage> BlobService<R, T, S> {
         self.repo.get_blobs(read_teams, pagination).await
     }
 
+    #[instrument(level = "debug", err, skip(self, perms))]
     pub async fn count_blobs_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -51,6 +54,7 @@ impl<R: BlobRepository, T: TeamResolver, S: BlobStorage> BlobService<R, T, S> {
         self.repo.count_blobs(read_teams, pagination).await
     }
 
+    #[instrument(level = "debug", err, skip(self, perms))]
     pub async fn get_blob_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -60,6 +64,7 @@ impl<R: BlobRepository, T: TeamResolver, S: BlobStorage> BlobService<R, T, S> {
         self.repo.get_blob(read_teams, id).await
     }
 
+    #[instrument(level = "debug", err, skip(self, perms, blob))]
     pub async fn create_blob_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -70,6 +75,7 @@ impl<R: BlobRepository, T: TeamResolver, S: BlobStorage> BlobService<R, T, S> {
         Ok(created)
     }
 
+    #[instrument(level = "debug", err, skip(self, perms, blob))]
     pub async fn update_blob_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -82,6 +88,7 @@ impl<R: BlobRepository, T: TeamResolver, S: BlobStorage> BlobService<R, T, S> {
         Ok(updated)
     }
 
+    #[instrument(level = "debug", err, skip(self, perms, patch))]
     pub async fn patch_blob_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -98,6 +105,7 @@ impl<R: BlobRepository, T: TeamResolver, S: BlobStorage> BlobService<R, T, S> {
         self.update_blob_for_user(perms, id, merged).await
     }
 
+    #[instrument(level = "debug", err, skip(self, perms))]
     pub async fn delete_blob_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -109,6 +117,7 @@ impl<R: BlobRepository, T: TeamResolver, S: BlobStorage> BlobService<R, T, S> {
         Ok(deleted)
     }
 
+    #[instrument(level = "debug", err, skip(self, perms, data))]
     pub async fn upload_blob_data_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -126,6 +135,7 @@ impl<R: BlobRepository, T: TeamResolver, S: BlobStorage> BlobService<R, T, S> {
         self.storage.write_blob_bytes(&blob, data)
     }
 
+    #[instrument(level = "debug", err, skip(self, perms))]
     pub async fn open_blob_data_file_for_user(
         &self,
         perms: &UserPermissions<T>,

--- a/backend/src/resources/blob/storage.rs
+++ b/backend/src/resources/blob/storage.rs
@@ -1,3 +1,4 @@
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 use actix_files::NamedFile;
@@ -45,7 +46,24 @@ impl BlobStorage for FsBlobStorage {
     fn delete_blob_file(&self, blob: &Blob) {
         if let Some(name) = blob.file_name() {
             let path = Path::new(&self.blob_dir).join(name);
-            let _ = std::fs::remove_file(path);
+            match std::fs::remove_file(&path) {
+                Ok(()) => {}
+                Err(err) if err.kind() == ErrorKind::NotFound => {
+                    tracing::debug!(
+                        blob_id = %blob.id,
+                        path = %path.display(),
+                        "blob file already absent during delete"
+                    );
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        blob_id = %blob.id,
+                        path = %path.display(),
+                        error = %err,
+                        "failed to delete blob file"
+                    );
+                }
+            }
         }
     }
 

--- a/backend/src/resources/blob/surreal_repo.rs
+++ b/backend/src/resources/blob/surreal_repo.rs
@@ -64,7 +64,7 @@ impl BlobRepository for SurrealBlobRepo {
                 .bind(("limit", limit))
                 .bind(("start", offset))
                 .await
-                .map_err(AppError::database)?
+                .map_err(|e| crate::log_and_convert!(AppError::database, "blob.list.query", e))?
         } else {
             db.db
                 .query("SELECT * FROM blob WHERE owner IN $teams LIMIT $limit START $start")
@@ -72,7 +72,7 @@ impl BlobRepository for SurrealBlobRepo {
                 .bind(("limit", limit))
                 .bind(("start", offset))
                 .await
-                .map_err(AppError::database)?
+                .map_err(|e| crate::log_and_convert!(AppError::database, "blob.list.query", e))?
         };
 
         Ok(response

--- a/backend/src/resources/collection/service.rs
+++ b/backend/src/resources/collection/service.rs
@@ -4,6 +4,7 @@ use shared::api::ListQuery;
 use shared::collection::{Collection, CreateCollection, PatchCollection};
 use shared::player::Player;
 use shared::song::Song;
+use tracing::instrument;
 
 use crate::database::Database;
 use crate::error::AppError;
@@ -29,6 +30,7 @@ impl<R, T, L> CollectionService<R, T, L> {
 }
 
 impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionService<R, T, L> {
+    #[instrument(level = "debug", err, skip(self, perms))]
     pub async fn list_collections_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -38,6 +40,7 @@ impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionServic
         self.repo.get_collections(read_teams, pagination).await
     }
 
+    #[instrument(level = "debug", err, skip(self, perms))]
     pub async fn count_collections_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -47,6 +50,7 @@ impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionServic
         self.repo.count_collections(read_teams, q).await
     }
 
+    #[instrument(level = "debug", err, skip(self, perms))]
     pub async fn get_collection_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -56,6 +60,7 @@ impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionServic
         self.repo.get_collection(read_teams, id).await
     }
 
+    #[instrument(level = "debug", err, skip(self, perms))]
     pub async fn collection_player_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -68,6 +73,7 @@ impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionServic
         player_from_song_links(liked_set, links)
     }
 
+    #[instrument(level = "debug", err, skip(self, perms))]
     pub async fn collection_songs_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -93,6 +99,7 @@ impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionServic
         Ok((page, total))
     }
 
+    #[instrument(level = "debug", err, skip(self, perms, collection))]
     pub async fn create_collection_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -103,6 +110,7 @@ impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionServic
             .await
     }
 
+    #[instrument(level = "debug", err, skip(self, perms, collection))]
     pub async fn update_collection_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -115,6 +123,7 @@ impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionServic
             .await
     }
 
+    #[instrument(level = "debug", err, skip(self, perms, patch))]
     pub async fn patch_collection_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -130,6 +139,7 @@ impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionServic
         self.update_collection_for_user(perms, id, merged).await
     }
 
+    #[instrument(level = "debug", err, skip(self, perms))]
     pub async fn delete_collection_for_user(
         &self,
         perms: &UserPermissions<T>,

--- a/backend/src/resources/collection/surreal_repo.rs
+++ b/backend/src/resources/collection/surreal_repo.rs
@@ -9,7 +9,7 @@ use shared::api::ListQuery;
 use shared::collection::{Collection, CreateCollection};
 use shared::song::{Link as SongLink, LinkOwned as SongLinkOwned};
 
-use crate::database::Database;
+use crate::database::{Database, surreal_take_errors};
 use crate::error::AppError;
 use crate::resources::common::{SongLinkRecord, belongs_to, blob_thing, resource_id};
 
@@ -217,7 +217,7 @@ impl CollectionRepository for SurrealCollectionRepo {
         song_link: SongLink,
     ) -> Result<(), AppError> {
         let db = self.inner();
-        let _ = db
+        let mut response = db
             .db
             .query(
                 r#"UPDATE type::thing("collection", $id) SET songs = array::append(songs, $song) WHERE owner IN $teams;"#,
@@ -226,6 +226,15 @@ impl CollectionRepository for SurrealCollectionRepo {
             .bind(("teams", write_teams.to_vec()))
             .bind(("song", SongLinkRecord::from(song_link)))
             .await?;
+
+        surreal_take_errors("collection.add_song_to_collection", &mut response)?;
+        let _ = response.check().map_err(|e| {
+            crate::log_and_convert!(
+                AppError::database,
+                "collection.add_song_to_collection.check",
+                e
+            )
+        })?;
 
         Ok(())
     }

--- a/backend/src/resources/rest.rs
+++ b/backend/src/resources/rest.rs
@@ -1,5 +1,6 @@
 use super::{blob, collection, setlist, song, team, user};
 use crate::auth::middleware::RequireUser;
+use crate::governor_audit::AuditRateLimit429;
 use crate::governor_peer::PeerOrFallbackIpKeyExtractor;
 use actix_governor::{Governor, GovernorConfigBuilder};
 use actix_web::{dev::HttpServiceFactory, web};
@@ -18,6 +19,7 @@ pub fn scope(
         .expect("API rate-limit configuration");
     web::scope("/api/v1")
         .wrap(Governor::new(&api_governor))
+        .wrap(AuditRateLimit429)
         .wrap(RequireUser)
         .service(blob::rest::scope(blob_upload_max_bytes))
         .service(collection::rest::scope())

--- a/backend/src/resources/setlist/service.rs
+++ b/backend/src/resources/setlist/service.rs
@@ -4,6 +4,7 @@ use shared::api::ListQuery;
 use shared::player::Player;
 use shared::setlist::{CreateSetlist, PatchSetlist, Setlist};
 use shared::song::Song;
+use tracing::instrument;
 
 use crate::error::AppError;
 use crate::resources::song::LikedSongIds;
@@ -27,6 +28,7 @@ impl<R, T, L> SetlistService<R, T, L> {
 }
 
 impl<R: SetlistRepository, T: TeamResolver, L: LikedSongIds> SetlistService<R, T, L> {
+    #[instrument(level = "debug", err, skip(self, perms))]
     pub async fn list_setlists_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -36,6 +38,7 @@ impl<R: SetlistRepository, T: TeamResolver, L: LikedSongIds> SetlistService<R, T
         self.repo.get_setlists(read_teams, pagination).await
     }
 
+    #[instrument(level = "debug", err, skip(self, perms))]
     pub async fn count_setlists_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -45,6 +48,7 @@ impl<R: SetlistRepository, T: TeamResolver, L: LikedSongIds> SetlistService<R, T
         self.repo.count_setlists(read_teams, q).await
     }
 
+    #[instrument(level = "debug", err, skip(self, perms))]
     pub async fn get_setlist_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -54,6 +58,7 @@ impl<R: SetlistRepository, T: TeamResolver, L: LikedSongIds> SetlistService<R, T
         self.repo.get_setlist(read_teams, id).await
     }
 
+    #[instrument(level = "debug", err, skip(self, perms))]
     pub async fn setlist_player_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -66,6 +71,7 @@ impl<R: SetlistRepository, T: TeamResolver, L: LikedSongIds> SetlistService<R, T
         player_from_song_links(liked_set, links)
     }
 
+    #[instrument(level = "debug", err, skip(self, perms))]
     pub async fn setlist_songs_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -91,6 +97,7 @@ impl<R: SetlistRepository, T: TeamResolver, L: LikedSongIds> SetlistService<R, T
         Ok((page, total))
     }
 
+    #[instrument(level = "debug", err, skip(self, perms, setlist))]
     pub async fn create_setlist_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -99,6 +106,7 @@ impl<R: SetlistRepository, T: TeamResolver, L: LikedSongIds> SetlistService<R, T
         self.repo.create_setlist(&perms.user().id, setlist).await
     }
 
+    #[instrument(level = "debug", err, skip(self, perms, setlist))]
     pub async fn update_setlist_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -109,6 +117,7 @@ impl<R: SetlistRepository, T: TeamResolver, L: LikedSongIds> SetlistService<R, T
         self.repo.update_setlist(write_teams, id, setlist).await
     }
 
+    #[instrument(level = "debug", err, skip(self, perms, patch))]
     pub async fn patch_setlist_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -123,6 +132,7 @@ impl<R: SetlistRepository, T: TeamResolver, L: LikedSongIds> SetlistService<R, T
         self.update_setlist_for_user(perms, id, merged).await
     }
 
+    #[instrument(level = "debug", err, skip(self, perms))]
     pub async fn delete_setlist_for_user(
         &self,
         perms: &UserPermissions<T>,

--- a/backend/src/resources/song/service.rs
+++ b/backend/src/resources/song/service.rs
@@ -18,6 +18,7 @@ use crate::resources::team::{TeamResolver, UserPermissions};
 use crate::resources::user::SurrealUserRepo;
 use crate::resources::user::UserRepository;
 use shared::collection::CreateCollection;
+use tracing::instrument;
 
 use super::liked::LikedSongIds;
 use super::repository::{SongRepository, SongUpsertOutcome};
@@ -129,6 +130,7 @@ impl<
         current
     }
 
+    #[instrument(level = "debug", err, skip(self, perms, query))]
     pub async fn list_songs_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -149,6 +151,7 @@ impl<
             .collect())
     }
 
+    #[instrument(level = "debug", err, skip(self, perms, query))]
     pub async fn count_songs_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -158,6 +161,7 @@ impl<
         self.repo.count_songs(read_teams, query).await
     }
 
+    #[instrument(level = "debug", err, skip(self, perms))]
     pub async fn get_song_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -171,6 +175,7 @@ impl<
         Ok(song)
     }
 
+    #[instrument(level = "debug", err, skip(self, perms))]
     pub async fn song_player_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -188,6 +193,7 @@ impl<
         }))
     }
 
+    #[instrument(level = "debug", err, skip(self, perms, song))]
     pub async fn create_song_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -247,6 +253,7 @@ impl<
         Ok(created)
     }
 
+    #[instrument(level = "debug", err, skip(self, perms, song))]
     pub async fn update_song_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -259,6 +266,7 @@ impl<
             .await
     }
 
+    #[instrument(level = "debug", err, skip(self, perms, patch))]
     pub async fn patch_song_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -279,6 +287,7 @@ impl<
             .map(SongUpsertOutcome::into_song)
     }
 
+    #[instrument(level = "debug", err, skip(self, perms))]
     pub async fn delete_song_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -288,6 +297,7 @@ impl<
         self.repo.delete_song(write_teams, id).await
     }
 
+    #[instrument(level = "debug", err, skip(self, perms))]
     pub async fn song_like_status_for_user(
         &self,
         perms: &UserPermissions<T>,
@@ -301,6 +311,7 @@ impl<
         Ok(LikeStatus { liked })
     }
 
+    #[instrument(level = "debug", err, skip(self, perms))]
     pub async fn set_song_like_status_for_user(
         &self,
         perms: &UserPermissions<T>,

--- a/backend/src/resources/team/invitation/service.rs
+++ b/backend/src/resources/team/invitation/service.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 use shared::api::ListQuery;
 use shared::team::{Team, TeamInvitation};
 use shared::user::User;
+use tracing::instrument;
 
 use crate::database::{Database, record_id_string};
 use crate::error::AppError;
@@ -19,6 +20,16 @@ use crate::resources::team::model::{
 };
 use crate::resources::team::repository::TeamRepository;
 use crate::resources::team::surreal_repo::SurrealTeamRepo;
+
+fn audit_invitation_accepted(team_id: &str, invitation_id: &str, user_id: &str) {
+    crate::audit!(
+        "audit.team.invitation.accepted",
+        team_id = tracing::field::display(team_id),
+        invitation_id = tracing::field::display(invitation_id),
+        user_id = tracing::field::display(user_id)
+        ; "invitation accepted"
+    );
+}
 
 /// Application service for team invitation management.
 #[derive(Clone)]
@@ -37,6 +48,7 @@ impl<R, IR> InvitationService<R, IR> {
 }
 
 impl<R: TeamRepository, IR: TeamInvitationRepository> InvitationService<R, IR> {
+    #[instrument(level = "debug", err, skip(self, user))]
     pub async fn create_invitation_for_user(
         &self,
         user: &User,
@@ -50,6 +62,7 @@ impl<R: TeamRepository, IR: TeamInvitationRepository> InvitationService<R, IR> {
         self.get_invitation_for_user(user, team_id, &inv_id).await
     }
 
+    #[instrument(level = "debug", err, skip(self, user, pagination))]
     pub async fn list_invitations_for_user(
         &self,
         user: &User,
@@ -66,6 +79,7 @@ impl<R: TeamRepository, IR: TeamInvitationRepository> InvitationService<R, IR> {
         Ok((page, total))
     }
 
+    #[instrument(level = "debug", err, skip(self, user))]
     pub async fn get_invitation_for_user(
         &self,
         user: &User,
@@ -88,6 +102,7 @@ impl<R: TeamRepository, IR: TeamInvitationRepository> InvitationService<R, IR> {
         row.into_invitation()
     }
 
+    #[instrument(level = "debug", err, skip(self, user))]
     pub async fn delete_invitation_for_user(
         &self,
         user: &User,
@@ -114,6 +129,7 @@ impl<R: TeamRepository, IR: TeamInvitationRepository> InvitationService<R, IR> {
         Ok(())
     }
 
+    #[instrument(level = "debug", err, skip(self, user))]
     pub async fn accept_invitation_for_user(
         &self,
         user: &User,
@@ -153,7 +169,9 @@ impl<R: TeamRepository, IR: TeamInvitationRepository> InvitationService<R, IR> {
         };
 
         if !needs_guest {
-            return self.team_repo.load_team_display(&team_id_str).await;
+            let team = self.team_repo.load_team_display(&team_id_str).await?;
+            audit_invitation_accepted(&team_id_str, invitation_id, &user.id);
+            return Ok(team);
         }
 
         map.insert(
@@ -172,10 +190,13 @@ impl<R: TeamRepository, IR: TeamInvitationRepository> InvitationService<R, IR> {
             .update_team_members(resource, members)
             .await?;
 
-        self.team_repo.load_team_display(&team_id_str).await
+        let team = self.team_repo.load_team_display(&team_id_str).await?;
+        audit_invitation_accepted(&team_id_str, invitation_id, &user.id);
+        Ok(team)
     }
 
     /// Like [`accept_invitation_for_user`], but ensures the invitation belongs to `team_id`.
+    #[instrument(level = "debug", err, skip(self, user))]
     pub async fn accept_invitation_for_user_on_team(
         &self,
         user: &User,

--- a/backend/src/resources/team/invitation/surreal_repo.rs
+++ b/backend/src/resources/team/invitation/surreal_repo.rs
@@ -46,8 +46,14 @@ impl TeamInvitationRepository for SurrealTeamInvitationRepo {
             .create(("team_invitation", inv_id))
             .content(create)
             .await
-            .map_err(AppError::database)?;
+            .map_err(|e| {
+                crate::log_and_convert!(AppError::database, "team_invitation.create", e)
+            })?;
         if created.is_none() {
+            tracing::error!(
+                target = "team_invitation.create",
+                "failed to create team invitation (empty result)"
+            );
             return Err(AppError::database("failed to create team invitation"));
         }
         Ok(())

--- a/backend/src/resources/team/resolver.rs
+++ b/backend/src/resources/team/resolver.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use serde::Deserialize;
 use surrealdb::sql::Thing;
 use tokio::sync::OnceCell;
+use tracing::instrument;
 
 use shared::user::{Role as UserRole, User};
 
@@ -120,14 +121,17 @@ impl SurrealTeamResolver {
 
 #[async_trait]
 impl TeamResolver for SurrealTeamResolver {
+    #[instrument(level = "debug", err, skip(self, user), fields(user_id = %user.id))]
     async fn content_read_teams(&self, user: &User) -> Result<Vec<Thing>, AppError> {
         content_read_team_things(&self.db, user).await
     }
 
+    #[instrument(level = "debug", err, skip(self, user), fields(user_id = %user.id))]
     async fn content_write_teams(&self, user: &User) -> Result<Vec<Thing>, AppError> {
         content_write_team_things(&self.db, user).await
     }
 
+    #[instrument(level = "debug", err, skip(self), fields(user_id = %user_id))]
     async fn personal_team(&self, user_id: &str) -> Result<Thing, AppError> {
         self.db.personal_team_thing_for_user(user_id).await
     }

--- a/backend/src/resources/team/service.rs
+++ b/backend/src/resources/team/service.rs
@@ -5,12 +5,13 @@ use std::sync::Arc;
 use shared::patch::Patch;
 use shared::team::{CreateTeam, PatchTeam, Team, UpdateTeam};
 use shared::user::{Role as UserRole, User};
+use tracing::instrument;
 
 use crate::database::Database;
 use crate::error::AppError;
 
 use super::model::{
-    TeamCreatePayload, build_create_shared_members, can_read_team, effective_admin,
+    DbTeamMember, TeamCreatePayload, build_create_shared_members, can_read_team, effective_admin,
     ensure_shared_team_has_admin_after_update, inputs_to_db_members, member_or_owner_readable,
     member_self_leave_payload, team_fetched_to_stored, team_resource_or_reject_public,
     thing_user_id, validate_personal_members_not_owner,
@@ -18,6 +19,34 @@ use super::model::{
 use super::repository::TeamRepository;
 use super::resolver::{TeamResolver, UserPermissions};
 use super::surreal_repo::SurrealTeamRepo;
+
+fn audit_team_member_role_changes(
+    team_id: &str,
+    actor_user_id: &str,
+    before: &[DbTeamMember],
+    after: &[DbTeamMember],
+) {
+    let old_map: BTreeMap<String, &str> = before
+        .iter()
+        .map(|m| (thing_user_id(&m.user), m.role.as_str()))
+        .collect();
+    for m in after {
+        let uid = thing_user_id(&m.user);
+        let old = old_map.get(&uid).copied().unwrap_or("");
+        let new = m.role.as_str();
+        if old != new {
+            crate::audit!(
+                "audit.team.role.changed",
+                team_id = tracing::field::display(team_id),
+                target_user_id = tracing::field::display(&uid),
+                old_role = tracing::field::display(old),
+                new_role = tracing::field::display(new),
+                actor_user_id = tracing::field::display(actor_user_id)
+                ; "team member role changed"
+            );
+        }
+    }
+}
 
 /// Application service: authorization and orchestration for teams.
 #[derive(Clone)]
@@ -33,6 +62,7 @@ impl<R, TR> TeamService<R, TR> {
 }
 
 impl<R: TeamRepository, TR: TeamResolver> TeamService<R, TR> {
+    #[instrument(level = "debug", err, skip(self, user))]
     pub async fn list_teams_for_user(&self, user: &User) -> Result<Vec<Team>, AppError> {
         let app_admin = user.role == UserRole::Admin;
         let rows = self.repo.fetch_teams_for_user(&user.id, app_admin).await?;
@@ -50,6 +80,7 @@ impl<R: TeamRepository, TR: TeamResolver> TeamService<R, TR> {
         Ok(list)
     }
 
+    #[instrument(level = "debug", err, skip(self, user))]
     pub async fn get_team_for_user(&self, user: &User, id: &str) -> Result<Team, AppError> {
         let app_admin = user.role == UserRole::Admin;
         let row = self
@@ -64,6 +95,7 @@ impl<R: TeamRepository, TR: TeamResolver> TeamService<R, TR> {
         row.into_team()
     }
 
+    #[instrument(level = "debug", err, skip(self, user, payload))]
     pub async fn create_shared_team_for_user(
         &self,
         user: &User,
@@ -90,6 +122,7 @@ impl<R: TeamRepository, TR: TeamResolver> TeamService<R, TR> {
         self.repo.load_team_display(&id).await
     }
 
+    #[instrument(level = "debug", err, skip(self, user, payload))]
     pub async fn update_team_for_user(
         &self,
         user: &User,
@@ -145,6 +178,7 @@ impl<R: TeamRepository, TR: TeamResolver> TeamService<R, TR> {
             } else {
                 ensure_shared_team_has_admin_after_update(&new_members)?;
             }
+            audit_team_member_role_changes(id, &user.id, &stored.members, &new_members);
             self.repo.update_team_members(resource, new_members).await?;
             return self.repo.load_team_display(id).await;
         }
@@ -165,12 +199,14 @@ impl<R: TeamRepository, TR: TeamResolver> TeamService<R, TR> {
             } else {
                 ensure_shared_team_has_admin_after_update(&new_members)?;
             }
+            audit_team_member_role_changes(id, &user.id, &stored.members, &new_members);
             self.repo.update_team_members(resource, new_members).await?;
         }
 
         self.repo.load_team_display(id).await
     }
 
+    #[instrument(level = "debug", err, skip(self, user, patch))]
     pub async fn patch_team_for_user(
         &self,
         user: &User,
@@ -192,6 +228,7 @@ impl<R: TeamRepository, TR: TeamResolver> TeamService<R, TR> {
             .await
     }
 
+    #[instrument(level = "debug", err, skip(self, user))]
     pub async fn delete_team_for_user(&self, user: &User, id: &str) -> Result<Team, AppError> {
         let perms = UserPermissions::from_ref(user, &self.resolver);
         let resource = team_resource_or_reject_public(id)?;

--- a/backend/src/resources/team/surreal_repo.rs
+++ b/backend/src/resources/team/surreal_repo.rs
@@ -95,15 +95,18 @@ impl TeamRepository for SurrealTeamRepo {
         resource: (String, String),
         name: &str,
     ) -> Result<(), AppError> {
-        self.inner()
+        let mut response = self
+            .inner()
             .db
             .query("UPDATE $tid SET name = $name")
             .bind(("tid", Thing::from(resource)))
             .bind(("name", name.to_owned()))
-            .await?
-            .check()
-            .map(|_| ())
-            .map_err(AppError::database)
+            .await?;
+        crate::database::surreal_take_errors("team.update_team_name", &mut response)?;
+        let _ = response.check().map_err(|e| {
+            crate::log_and_convert!(AppError::database, "team.update_team_name.check", e)
+        })?;
+        Ok(())
     }
 
     async fn update_team_members(
@@ -111,40 +114,49 @@ impl TeamRepository for SurrealTeamRepo {
         resource: (String, String),
         members: Vec<DbTeamMember>,
     ) -> Result<(), AppError> {
-        self.inner()
+        let mut response = self
+            .inner()
             .db
             .query("UPDATE $tid SET members = $members")
             .bind(("tid", Thing::from(resource)))
             .bind(("members", members))
-            .await?
-            .check()
-            .map(|_| ())
-            .map_err(AppError::database)
+            .await?;
+        crate::database::surreal_take_errors("team.update_team_members", &mut response)?;
+        let _ = response.check().map_err(|e| {
+            crate::log_and_convert!(AppError::database, "team.update_team_members.check", e)
+        })?;
+        Ok(())
     }
 
     async fn delete_team_record(&self, resource: (String, String)) -> Result<(), AppError> {
         let tid = Thing::from(resource);
-        self.inner()
+        let mut response = self
+            .inner()
             .db
             .query("DELETE $tid")
             .bind(("tid", tid))
-            .await?
-            .check()
-            .map(|_| ())
-            .map_err(AppError::database)
+            .await?;
+        crate::database::surreal_take_errors("team.delete_team_record", &mut response)?;
+        let _ = response.check().map_err(|e| {
+            crate::log_and_convert!(AppError::database, "team.delete_team_record.check", e)
+        })?;
+        Ok(())
     }
 
     async fn reassign_content(&self, from: Thing, to: Thing) -> Result<(), AppError> {
         for table in ["blob", "song", "collection", "setlist"] {
             let q = format!("UPDATE {table} SET owner = $to WHERE owner = $from");
-            self.inner()
+            let mut response = self
+                .inner()
                 .db
                 .query(&q)
                 .bind(("to", to.clone()))
                 .bind(("from", from.clone()))
-                .await?
-                .check()
-                .map_err(AppError::database)?;
+                .await?;
+            crate::database::surreal_take_errors("team.reassign_content", &mut response)?;
+            let _ = response.check().map_err(|e| {
+                crate::log_and_convert!(AppError::database, "team.reassign_content.check", e)
+            })?;
         }
         Ok(())
     }

--- a/backend/src/resources/user/rest.rs
+++ b/backend/src/resources/user/rest.rs
@@ -184,8 +184,16 @@ async fn create_user(
 #[delete("/{id}")]
 async fn delete_user(
     svc: Data<UserServiceHandle>,
+    actor: ReqData<User>,
     id: Path<String>,
 ) -> Result<HttpResponse, AppError> {
-    svc.delete_user(&id).await?;
+    let deleted = svc.delete_user(&id).await?;
+    let actor = actor.into_inner();
+    crate::audit!(
+        "audit.user.deleted",
+        user_id = tracing::field::display(&deleted.id),
+        actor_user_id = tracing::field::display(&actor.id)
+        ; "user deleted"
+    );
     Ok(HttpResponse::NoContent().finish())
 }

--- a/backend/src/resources/user/service.rs
+++ b/backend/src/resources/user/service.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use shared::api::ListQuery;
 use shared::user::User;
+use tracing::instrument;
 
 use crate::database::Database;
 use crate::error::AppError;
@@ -25,23 +26,28 @@ impl<R, T> UserService<R, T> {
 }
 
 impl<R: UserRepository, T: TeamRepository> UserService<R, T> {
+    #[instrument(level = "debug", err, skip(self, pagination))]
     pub async fn get_users(&self, pagination: ListQuery) -> Result<Vec<User>, AppError> {
         self.repo.get_users(pagination).await
     }
 
+    #[instrument(level = "debug", err, skip(self, query))]
     pub async fn count_users(&self, query: ListQuery) -> Result<u64, AppError> {
         self.repo.count_users(query).await
     }
 
+    #[instrument(level = "debug", err, skip(self))]
     pub async fn get_user(&self, id: &str) -> Result<User, AppError> {
         self.repo.get_user(id).await
     }
 
+    #[instrument(level = "debug", err, skip(self))]
     pub async fn get_user_by_email(&self, email: &str) -> Result<Option<User>, AppError> {
         self.repo.get_user_by_email(email).await
     }
 
     /// Create a user and their personal team.
+    #[instrument(level = "debug", err, skip(self, user))]
     pub async fn create_user(&self, user: User) -> Result<User, AppError> {
         let created = self.repo.create_user_record(user).await?;
         self.team_repo
@@ -51,13 +57,22 @@ impl<R: UserRepository, T: TeamRepository> UserService<R, T> {
                 members: vec![],
             })
             .await?;
+        crate::audit!(
+            "audit.user.created",
+            user_id = tracing::field::display(&created.id),
+            email = tracing::field::display(&created.email),
+            role = tracing::field::debug(&created.role)
+            ; "user created"
+        );
         Ok(created)
     }
 
+    #[instrument(level = "debug", err, skip(self, request))]
     pub async fn create_user_from_request(&self, request: CreateUser) -> Result<User, AppError> {
         self.create_user(request.into_user()).await
     }
 
+    #[instrument(level = "debug", err, skip(self))]
     pub async fn get_user_by_email_or_create(&self, email: &str) -> Result<User, AppError> {
         if let Some(user) = self.repo.get_user_by_email(email).await? {
             return Ok(user);
@@ -65,10 +80,12 @@ impl<R: UserRepository, T: TeamRepository> UserService<R, T> {
         self.create_user(User::new(email.to_lowercase())).await
     }
 
+    #[instrument(level = "debug", err, skip(self))]
     pub async fn delete_user(&self, id: &str) -> Result<User, AppError> {
         self.repo.delete_user(id).await
     }
 
+    #[instrument(level = "debug", err, skip(self))]
     pub async fn set_default_collection(
         &self,
         user_id: &str,

--- a/backend/src/resources/user/session/rest.rs
+++ b/backend/src/resources/user/session/rest.rs
@@ -151,7 +151,15 @@ pub async fn delete_session_for_current_user(
     user: ReqData<User>,
     path: Path<SessionPath>,
 ) -> Result<HttpResponse, AppError> {
-    svc.delete_session_for_user(&path.id, &user.id).await?;
+    let user = user.into_inner();
+    let deleted = svc.delete_session_for_user(&path.id, &user.id).await?;
+    crate::audit!(
+        "audit.session.revoked",
+        session_id = tracing::field::display(&deleted.id),
+        user_id = tracing::field::display(&deleted.user.id),
+        actor_user_id = tracing::field::display(&user.id)
+        ; "session revoked"
+    );
     Ok(HttpResponse::NoContent().finish())
 }
 
@@ -314,9 +322,18 @@ pub async fn get_session_for_user(
 #[delete("/{user_id}/sessions/{id}")]
 pub async fn delete_session_for_user(
     svc: Data<SessionServiceHandle>,
+    actor: ReqData<User>,
     path: Path<UserSessionPath>,
 ) -> Result<HttpResponse, AppError> {
-    svc.delete_session_for_user(&path.id, &path.user_id).await?;
+    let actor = actor.into_inner();
+    let deleted = svc.delete_session_for_user(&path.id, &path.user_id).await?;
+    crate::audit!(
+        "audit.session.revoked",
+        session_id = tracing::field::display(&deleted.id),
+        user_id = tracing::field::display(&deleted.user.id),
+        actor_user_id = tracing::field::display(&actor.id)
+        ; "session revoked"
+    );
     Ok(HttpResponse::NoContent().finish())
 }
 

--- a/backend/src/resources/user/session/service.rs
+++ b/backend/src/resources/user/session/service.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use shared::user::Session;
+use tracing::instrument;
 
 use crate::database::Database;
 use crate::error::AppError;
@@ -24,22 +25,36 @@ impl<S, U> SessionService<S, U> {
 }
 
 impl<S: SessionRepository, U: UserRepository> SessionService<S, U> {
+    #[instrument(level = "debug", err, skip(self))]
     pub async fn get_session(&self, id: &str) -> Result<Session, AppError> {
         self.repo.get_session(id).await
     }
 
+    #[instrument(level = "debug", err, skip(self))]
     pub async fn get_session_for_user(&self, id: &str, user_id: &str) -> Result<Session, AppError> {
         self.repo.get_session_for_user(id, user_id).await
     }
 
+    #[instrument(level = "debug", err, skip(self, session))]
     pub async fn create_session(&self, session: Session) -> Result<Session, AppError> {
-        self.repo.create_session(session).await
+        let stored = self.repo.create_session(session).await?;
+        let ttl_seconds = (stored.expires_at - stored.created_at).num_seconds();
+        crate::audit!(
+            "audit.session.created",
+            session_id = tracing::field::display(&stored.id),
+            user_id = tracing::field::display(&stored.user.id),
+            ttl_seconds = tracing::field::display(&ttl_seconds)
+            ; "session created"
+        );
+        Ok(stored)
     }
 
+    #[instrument(level = "debug", err, skip(self))]
     pub async fn delete_session(&self, id: &str) -> Result<Session, AppError> {
         self.repo.delete_session(id).await
     }
 
+    #[instrument(level = "debug", err, skip(self))]
     pub async fn delete_session_for_user(
         &self,
         id: &str,
@@ -48,10 +63,12 @@ impl<S: SessionRepository, U: UserRepository> SessionService<S, U> {
         self.repo.delete_session_for_user(id, user_id).await
     }
 
+    #[instrument(level = "debug", err, skip(self))]
     pub async fn get_sessions_by_user_id(&self, user_id: &str) -> Result<Vec<Session>, AppError> {
         self.repo.get_sessions_by_user_id(user_id).await
     }
 
+    #[instrument(level = "debug", err, skip(self))]
     pub async fn validate_session_and_update_metrics(
         &self,
         id: &str,
@@ -60,6 +77,7 @@ impl<S: SessionRepository, U: UserRepository> SessionService<S, U> {
     }
 
     /// Look up a user by ID and create a session for them with the given TTL.
+    #[instrument(level = "debug", err, skip(self))]
     pub async fn create_session_for_user_by_id(
         &self,
         user_id: &str,

--- a/backend/src/resources/user/session/surreal_repo.rs
+++ b/backend/src/resources/user/session/surreal_repo.rs
@@ -114,9 +114,9 @@ impl SessionRepository for SurrealSessionRepo {
             )
             .bind(("id", id.to_owned()))
             .await
-            .map_err(AppError::database)?
+            .map_err(|e| crate::log_and_convert!(AppError::database, "session.validate.query", e))?
             .take::<Option<SessionRecord>>(3)
-            .map_err(AppError::database)?
+            .map_err(|e| crate::log_and_convert!(AppError::database, "session.validate.take", e))?
             .map(SessionRecord::into_session))
     }
 }

--- a/backend/src/resources/user/surreal_repo.rs
+++ b/backend/src/resources/user/surreal_repo.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use shared::api::ListQuery;
 use shared::user::User;
 
-use crate::database::Database;
+use crate::database::{Database, surreal_take_errors};
 use crate::error::AppError;
 
 use super::model::{UserRecord, user_resource};
@@ -146,7 +146,7 @@ impl UserRepository for SurrealUserRepo {
         user_id: &str,
         collection_id: &str,
     ) -> Result<(), AppError> {
-        let _ = self
+        let mut response = self
             .inner()
             .db
             .query("UPDATE $user SET default_collection = $collection")
@@ -156,18 +156,26 @@ impl UserRepository for SurrealUserRepo {
                 Thing::from(("collection".to_owned(), collection_id.to_owned())),
             ))
             .await?;
+        surreal_take_errors("user.set_default_collection", &mut response)?;
+        let _ = response.check().map_err(|e| {
+            crate::log_and_convert!(AppError::database, "user.set_default_collection.check", e)
+        })?;
         Ok(())
     }
 }
 
 impl SurrealUserRepo {
     pub async fn clear_default_collection(&self, user_id: &str) -> Result<(), AppError> {
-        let _ = self
+        let mut response = self
             .inner()
             .db
             .query("UPDATE $user SET default_collection = NONE")
             .bind(("user", Thing::from(("user".to_owned(), user_id.to_owned()))))
             .await?;
+        surreal_take_errors("user.clear_default_collection", &mut response)?;
+        let _ = response.check().map_err(|e| {
+            crate::log_and_convert!(AppError::database, "user.clear_default_collection.check", e)
+        })?;
         Ok(())
     }
 }

--- a/docs/architecture/backend-request-flow.md
+++ b/docs/architecture/backend-request-flow.md
@@ -397,3 +397,27 @@ teams on user registration.
 | **Team-scoped** | yes | yes | yes | yes | own ACL | no | no |
 | **Extra files** | `storage.rs` | `liked.rs` | — | — | `resolver.rs`, `invitation_model.rs`, `invitation_repository.rs`, `invitation_surreal_repo.rs` | — | — |
 | **Extra dependencies** | `BlobStorage` | `LikedSongIds`, `CollectionRepo`, `UserCollectionUpdater` | `LikedSongIds` | `LikedSongIds` | `TeamResolver` | `TeamRepository` | `UserRepository` |
+
+---
+
+## Audit event catalog
+
+Structured audit lines use `tracing` with **`audit = true`** and a stable **`event`** name (macro `audit!` in [backend/src/observability.rs](../../backend/src/observability.rs)). Field names follow [docs/logging-review.md](../logging-review.md) §5.
+
+| `event` | Where emitted | Typical fields |
+|---------|---------------|----------------|
+| `audit.auth.login.success` | OIDC callback success, OTP verify success | `provider`, `user_id`, `session_id` |
+| `audit.auth.login.failure` | OIDC / OTP error paths | `provider`, `reason`, `email_hash` (no raw email) |
+| `audit.auth.otp.requested` | After OTP mail send succeeds | `email_domain`, `delivered` |
+| `audit.auth.logout` | `/auth/logout` | `session_id`, `had_cookie` |
+| `audit.session.created` | `SessionService::create_session` | `session_id`, `user_id`, `ttl_seconds` |
+| `audit.session.revoked` | Logout, session DELETE handlers | `session_id`, `user_id`, `actor_user_id` |
+| `audit.user.created` | `UserService::create_user` | `user_id`, `email`, `role` |
+| `audit.user.deleted` | Admin delete user | `user_id`, `actor_user_id` |
+| `audit.team.role.changed` | Team member list update with role diff | `team_id`, `target_user_id`, `old_role`, `new_role`, `actor_user_id` |
+| `audit.team.invitation.accepted` | Invitation accept success | `team_id`, `invitation_id`, `user_id` |
+| `audit.rate_limit.rejected` | `AuditRateLimit429` middleware on HTTP 429 | `route`, `client_ip`, optional `user_id` |
+
+**Startup / OIDC registration (not audit-flagged):** `event = "startup"` in `main.rs`; `event = "oidc.provider.registered"` per provider in `auth/oidc/client.rs`.
+
+**Request correlation:** HTTP handling uses `tracing-actix-web` + request ID middleware; logs inherit `request_id` and (when authenticated) `user_id` on the root span.


### PR DESCRIPTION
## Summary

Stacks three related backend observability PRs on `main`:

1. **Foundation** — `tracing` subscriber module, JSON/compact `LOG_FORMAT`, `tracing-log` bridge, request correlation via `tracing-actix-web` + `WorshipRootSpan`, redacted `Settings::Debug`.
2. **Error paths** — `log_error_chain` / `log_and_convert!`, Surreal `take_errors` hygiene, blob delete logging, middleware debug reasons.
3. **Bundle C** — `audit!` macro + catalog, `#[tracing::instrument]` on services/auth/mail/DB/resolver, RFC 7807 JSON for rate limits + `audit.rate_limit.rejected`, startup + OIDC registration events, docs audit table.

## Validation

- `cargo fmt`, `cargo clippy --all-targets`, `cargo test` (287 tests) on `backend`.

## References

- [docs/logging-review.md](docs/logging-review.md) Bundles A–C and action plan.

Made with [Cursor](https://cursor.com)