### PR TITLE
feat(backend): audit tracing tests and logging docs (bundle D)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Notes:
   - Cookie: sso_session
   - Bearer token
 
+**Logs:** The backend uses [`tracing`](https://docs.rs/tracing). Set [`RUST_LOG`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) to control verbosity (for example `RUST_LOG=backend=debug,surrealdb=info`). Use `LOG_FORMAT=json` for newline-delimited JSON on stdout (this is also the default when `WORSHIP_PRODUCTION=true` or `RUST_ENV=production`). Incoming `traceparent` may supply the span id used as `X-Request-Id` and the `request_id` field on the per-request span. See `docs/architecture/backend-request-flow.md` for the full logging and audit-event notes.
+
 ### Start the Frontend
 
 ```bash

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -54,6 +54,7 @@ zip = "6.0.0"
 anyhow = "1"
 criterion = { version = "0.5", features = ["html_reports"] }
 tempfile = "3"
+tracing-test = "0.2.6"
 
 [[bench]]
 name = "repo_perf"

--- a/backend/src/audit_events_tests.rs
+++ b/backend/src/audit_events_tests.rs
@@ -1,0 +1,314 @@
+//! Canary tests for structured audit log lines (`audit!`, `event = "audit.*"`, `audit = true`).
+//!
+//! See [docs/logging-review.md](../../docs/logging-review.md) bundle D and
+//! [docs/architecture/backend-request-flow.md](../../docs/architecture/backend-request-flow.md).
+
+use std::sync::Arc;
+
+use actix_governor::{Governor, GovernorConfigBuilder};
+use actix_web::http::StatusCode;
+use actix_web::middleware::Compat;
+use actix_web::web::{Data, self};
+use actix_web::{App, test};
+use serde_json::json;
+use shared::team::{TeamMemberInput, TeamRole, TeamUserRef, UpdateTeam};
+use shared::user::{Role, Session, User};
+use tracing_test::traced_test;
+
+use crate::auth::otp::Model;
+use crate::database::Database;
+use crate::governor_audit::AuditRateLimit429;
+use crate::governor_peer::PeerOrFallbackIpKeyExtractor;
+use crate::mail::MailService;
+use crate::request_id::WorshipRootSpan;
+use crate::settings::{CookieConfig, OtpConfig};
+use crate::test_helpers::{
+    TeamFixture, create_user, invitation_service, session_service, team_service, test_db,
+    user_service,
+};
+use crate::{auth, http_tests};
+
+fn auth_scope_otp_logout(auth_rate_limit_rps: u64, auth_rate_limit_burst: u32) -> actix_web::Scope {
+    let governor_conf = GovernorConfigBuilder::default()
+        .requests_per_second(auth_rate_limit_rps)
+        .burst_size(auth_rate_limit_burst)
+        .key_extractor(PeerOrFallbackIpKeyExtractor)
+        .finish()
+        .expect("valid rate-limit configuration");
+
+    web::scope("/auth").service(
+        web::scope("")
+            .wrap(Governor::new(&governor_conf))
+            .wrap(AuditRateLimit429)
+            .service(auth::otp::rest::otp_request)
+            .service(auth::otp::rest::otp_verify)
+            .service(auth::rest::logout),
+    )
+}
+
+fn build_auth_app(db: Arc<Database>, auth_rps: u64, auth_burst: u32) -> App<
+    impl actix_web::dev::ServiceFactory<
+        actix_web::dev::ServiceRequest,
+        Config = (),
+        Response = actix_web::dev::ServiceResponse,
+        Error = actix_web::Error,
+        InitError = (),
+    >,
+> {
+    let cookie_cfg = Data::new(CookieConfig {
+        name: "sso_session".into(),
+        secure: false,
+        session_ttl_seconds: 3600,
+        post_login_path: "/".into(),
+    });
+    let otp_cfg = Data::new(OtpConfig {
+        ttl_seconds: 300,
+        pepper: "audit-test-pepper".into(),
+        max_attempts: 5,
+        allow_self_signup: true,
+    });
+
+    App::new()
+        .wrap(crate::request_id::RequestId)
+        .wrap(Compat::new(tracing_actix_web::TracingLogger::<
+            WorshipRootSpan,
+        >::new()))
+        .app_data(Data::from(db.clone()))
+        .app_data(Data::new(MailService::noop_for_tests(
+            "audit-test@local".into(),
+        )))
+        .app_data(Data::new(user_service(&db)))
+        .app_data(Data::new(session_service(&db)))
+        .app_data(cookie_cfg)
+        .app_data(otp_cfg)
+        .app_data(crate::error::json_config())
+        .service(auth_scope_otp_logout(auth_rps, auth_burst))
+}
+
+#[tokio::test]
+#[traced_test]
+async fn audit_session_created_emits_event() {
+    let db = test_db().await.expect("db");
+    let user = create_user(&db, "audit-sess-create@test.local")
+        .await
+        .expect("user");
+    session_service(&db)
+        .create_session(Session::new(user, 3600))
+        .await
+        .expect("session");
+    assert!(logs_contain("audit.session.created"));
+}
+
+#[tokio::test]
+#[traced_test]
+async fn audit_user_created_emits_event() {
+    let db = test_db().await.expect("db");
+    let _ = create_user(&db, "audit-user-new@test.local")
+        .await
+        .expect("user");
+    assert!(logs_contain("audit.user.created"));
+}
+
+#[tokio::test]
+#[traced_test]
+async fn audit_user_deleted_emits_event() {
+    let db = test_db().await.expect("db");
+    let mut admin_raw = User::new("audit-admin-del@test.local");
+    admin_raw.role = Role::Admin;
+    let admin = user_service(&db)
+        .create_user(admin_raw)
+        .await
+        .expect("admin");
+    let target = create_user(&db, "audit-target-del@test.local")
+        .await
+        .expect("target");
+    let token = session_service(&db)
+        .create_session(Session::new(admin, 3600))
+        .await
+        .expect("session")
+        .id;
+
+    let app = test::init_service(http_tests::build_app(db)).await;
+    let req = test::TestRequest::delete()
+        .uri(&format!("/api/v1/users/{}", target.id))
+        .insert_header(("Authorization", format!("Bearer {token}")))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert!(logs_contain("audit.user.deleted"));
+}
+
+#[tokio::test]
+#[traced_test]
+async fn audit_team_role_changed_emits_event() {
+    let db = test_db().await.expect("db");
+    let fx = TeamFixture::build(&db).await.expect("fixture");
+    team_service(&db)
+        .update_team_for_user(
+            &fx.admin_user,
+            &fx.shared_team_id,
+            UpdateTeam {
+                name: "Fixture Shared Team".into(),
+                members: Some(vec![
+                    TeamMemberInput {
+                        user: TeamUserRef {
+                            id: fx.admin_user.id.clone(),
+                        },
+                        role: TeamRole::Admin,
+                    },
+                    TeamMemberInput {
+                        user: TeamUserRef {
+                            id: fx.writer.id.clone(),
+                        },
+                        role: TeamRole::ContentMaintainer,
+                    },
+                    TeamMemberInput {
+                        user: TeamUserRef {
+                            id: fx.guest.id.clone(),
+                        },
+                        role: TeamRole::ContentMaintainer,
+                    },
+                ]),
+            },
+        )
+        .await
+        .expect("update");
+    assert!(logs_contain("audit.team.role.changed"));
+}
+
+#[tokio::test]
+#[traced_test]
+async fn audit_invitation_accepted_emits_event() {
+    let db = test_db().await.expect("db");
+    let fx = TeamFixture::build(&db).await.expect("fixture");
+    let inv = invitation_service(&db)
+        .create_invitation_for_user(&fx.admin_user, &fx.shared_team_id)
+        .await
+        .expect("invitation");
+    let invitee = create_user(&db, "audit-invitee@test.local")
+        .await
+        .expect("invitee");
+    invitation_service(&db)
+        .accept_invitation_for_user(&invitee, &inv.id)
+        .await
+        .expect("accept");
+    assert!(logs_contain("audit.team.invitation.accepted"));
+}
+
+#[tokio::test]
+#[traced_test]
+async fn audit_auth_otp_requested_emits_event() {
+    let db = test_db().await.expect("db");
+    let app = test::init_service(build_auth_app(db, 50, 200)).await;
+    let req = test::TestRequest::post()
+        .uri("/auth/otp/request")
+        .insert_header(("Content-Type", "application/json"))
+        .set_payload(json!({ "email": "otp-audit@test.local" }).to_string())
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert!(logs_contain("audit.auth.otp.requested"));
+}
+
+#[tokio::test]
+#[traced_test]
+async fn audit_auth_login_success_emits_event() {
+    let db = test_db().await.expect("db");
+    let email = "otp-login-ok@test.local";
+    let code = "424242";
+    db.remember_otp(email, code, "audit-test-pepper", 300)
+        .await
+        .expect("seed otp");
+
+    let app = test::init_service(build_auth_app(db, 50, 200)).await;
+    let req = test::TestRequest::post()
+        .uri("/auth/otp/verify")
+        .insert_header(("Content-Type", "application/json"))
+        .set_payload(
+            json!({ "email": email, "code": code })
+                .to_string(),
+        )
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(logs_contain("audit.auth.login.success"));
+}
+
+#[tokio::test]
+#[traced_test]
+async fn audit_auth_login_failure_emits_event() {
+    let db = test_db().await.expect("db");
+    let email = "otp-login-bad@test.local";
+    db.remember_otp(email, "111111", "audit-test-pepper", 300)
+        .await
+        .expect("seed otp");
+
+    let app = test::init_service(build_auth_app(db, 50, 200)).await;
+    let req = test::TestRequest::post()
+        .uri("/auth/otp/verify")
+        .insert_header(("Content-Type", "application/json"))
+        .set_payload(
+            json!({ "email": email, "code": "999999" })
+                .to_string(),
+        )
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    assert!(logs_contain("audit.auth.login.failure"));
+}
+
+#[tokio::test]
+#[traced_test]
+async fn audit_auth_logout_and_session_revoked_emit_events() {
+    let db = test_db().await.expect("db");
+    let user = create_user(&db, "audit-logout@test.local")
+        .await
+        .expect("user");
+    let session = session_service(&db)
+        .create_session(Session::new(user, 3600))
+        .await
+        .expect("session");
+
+    let cookie_cfg = CookieConfig {
+        name: "sso_session".into(),
+        secure: false,
+        session_ttl_seconds: 3600,
+        post_login_path: "/".into(),
+    };
+
+    let app = test::init_service(build_auth_app(db, 50, 200)).await;
+    let req = test::TestRequest::post()
+        .uri("/auth/logout")
+        .cookie(
+            actix_web::cookie::Cookie::build(cookie_cfg.name.clone(), session.id.clone())
+                .path("/")
+                .finish(),
+        )
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert!(logs_contain("audit.auth.logout"));
+    assert!(logs_contain("audit.session.revoked"));
+}
+
+#[tokio::test]
+#[traced_test]
+async fn audit_rate_limit_rejected_emits_event() {
+    let db = test_db().await.expect("db");
+    let app = test::init_service(build_auth_app(db, 1, 1)).await;
+
+    let mk_req = || {
+        test::TestRequest::post()
+            .uri("/auth/otp/request")
+            .insert_header(("Content-Type", "application/json"))
+            .set_payload(json!({ "email": "rl-audit@test.local" }).to_string())
+            .to_request()
+    };
+
+    let first = test::call_service(&app, mk_req()).await;
+    assert_eq!(first.status(), StatusCode::NO_CONTENT);
+
+    let second = test::call_service(&app, mk_req()).await;
+    assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert!(logs_contain("audit.rate_limit.rejected"));
+}

--- a/backend/src/audit_events_tests.rs
+++ b/backend/src/audit_events_tests.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use actix_governor::{Governor, GovernorConfigBuilder};
 use actix_web::http::StatusCode;
 use actix_web::middleware::Compat;
-use actix_web::web::{Data, self};
+use actix_web::web::{self, Data};
 use actix_web::{App, test};
 use serde_json::json;
 use shared::team::{TeamMemberInput, TeamRole, TeamUserRef, UpdateTeam};
@@ -46,7 +46,11 @@ fn auth_scope_otp_logout(auth_rate_limit_rps: u64, auth_rate_limit_burst: u32) -
     )
 }
 
-fn build_auth_app(db: Arc<Database>, auth_rps: u64, auth_burst: u32) -> App<
+fn build_auth_app(
+    db: Arc<Database>,
+    auth_rps: u64,
+    auth_burst: u32,
+) -> App<
     impl actix_web::dev::ServiceFactory<
         actix_web::dev::ServiceRequest,
         Config = (),
@@ -224,10 +228,7 @@ async fn audit_auth_login_success_emits_event() {
     let req = test::TestRequest::post()
         .uri("/auth/otp/verify")
         .insert_header(("Content-Type", "application/json"))
-        .set_payload(
-            json!({ "email": email, "code": code })
-                .to_string(),
-        )
+        .set_payload(json!({ "email": email, "code": code }).to_string())
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), StatusCode::OK);
@@ -247,10 +248,7 @@ async fn audit_auth_login_failure_emits_event() {
     let req = test::TestRequest::post()
         .uri("/auth/otp/verify")
         .insert_header(("Content-Type", "application/json"))
-        .set_payload(
-            json!({ "email": email, "code": "999999" })
-                .to_string(),
-        )
+        .set_payload(json!({ "email": email, "code": "999999" }).to_string())
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);

--- a/backend/src/auth/otp/rest.rs
+++ b/backend/src/auth/otp/rest.rs
@@ -35,7 +35,7 @@ use tracing::instrument;
 )]
 #[instrument(level = "debug", err, skip_all, fields(provider = "otp"))]
 #[post("/otp/request")]
-async fn otp_request(
+pub(crate) async fn otp_request(
     db: Data<Database>,
     mail: Data<MailService>,
     otp_cfg: Data<OtpConfig>,
@@ -83,7 +83,7 @@ async fn otp_request(
 )]
 #[instrument(level = "debug", err, skip_all, fields(provider = "otp"))]
 #[post("/otp/verify")]
-async fn otp_verify(
+pub(crate) async fn otp_verify(
     db: Data<Database>,
     user_svc: Data<UserServiceHandle>,
     session_svc: Data<SessionServiceHandle>,

--- a/backend/src/auth/rest.rs
+++ b/backend/src/auth/rest.rs
@@ -49,7 +49,7 @@ pub fn scope(auth_rate_limit_rps: u64, auth_rate_limit_burst: u32) -> actix_web:
     )
 )]
 #[post("/logout")]
-async fn logout(
+pub(crate) async fn logout(
     svc: Data<SessionServiceHandle>,
     cookie_cfg: Data<CookieConfig>,
     req: HttpRequest,

--- a/backend/src/http_tests.rs
+++ b/backend/src/http_tests.rs
@@ -41,7 +41,7 @@ use crate::test_helpers::{create_song_with_title, create_user, session_service, 
 ///
 /// The app does **not** include `auth::rest::scope()` (needs OIDC clients) or
 /// `frontend::rest::scope()` (needs a static file directory on disk).
-fn build_app(
+pub(crate) fn build_app(
     db: Arc<Database>,
 ) -> App<
     impl actix_web::dev::ServiceFactory<

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -22,3 +22,6 @@ mod test_helpers;
 
 #[cfg(test)]
 mod http_tests;
+
+#[cfg(test)]
+mod audit_events_tests;

--- a/backend/src/mail.rs
+++ b/backend/src/mail.rs
@@ -67,15 +67,17 @@ impl MailService {
                         .map_err(|e| crate::log_and_convert!(AppError::mail, "mail.parse_to", e))?)
                     .subject(subject)
                     .body(body.to_owned())
-                    .map_err(|e| crate::log_and_convert!(AppError::mail, "mail.build_message", e))?;
+                    .map_err(|e| {
+                        crate::log_and_convert!(AppError::mail, "mail.build_message", e)
+                    })?;
 
-                let response = transport
-                    .send(message)
-                    .await
-                    .map_err(|e| crate::log_and_convert!(AppError::mail, "mail.transport_send", e))?;
+                let response = transport.send(message).await.map_err(|e| {
+                    crate::log_and_convert!(AppError::mail, "mail.transport_send", e)
+                })?;
 
                 if !response.is_positive() {
-                    tracing::Span::current().record("transport_ok", tracing::field::display(&false));
+                    tracing::Span::current()
+                        .record("transport_ok", tracing::field::display(&false));
                     tracing::warn!(
                         target = "mail.transport",
                         ?response,

--- a/backend/src/mail.rs
+++ b/backend/src/mail.rs
@@ -5,8 +5,15 @@ use tracing::instrument;
 use crate::error::AppError;
 
 #[derive(Clone)]
+enum MailTransport {
+    Smtp(AsyncSmtpTransport<Tokio1Executor>),
+    #[cfg(test)]
+    Noop,
+}
+
+#[derive(Clone)]
 pub struct MailService {
-    transport: AsyncSmtpTransport<Tokio1Executor>,
+    transport: MailTransport,
     from: String,
 }
 
@@ -17,7 +24,19 @@ impl MailService {
             .map_err(|e| crate::log_and_convert!(AppError::mail, "mail.smtp_relay", e))?
             .credentials(credentials)
             .build();
-        Ok(Self { transport, from })
+        Ok(Self {
+            transport: MailTransport::Smtp(transport),
+            from,
+        })
+    }
+
+    /// Test helper: [`MailService::send`] succeeds without SMTP I/O (for OTP / audit tests).
+    #[cfg(test)]
+    pub fn noop_for_tests(from: String) -> Self {
+        Self {
+            transport: MailTransport::Noop,
+            from,
+        }
     }
 
     #[instrument(
@@ -31,35 +50,42 @@ impl MailService {
         )
     )]
     pub async fn send(&self, to: &str, subject: &str, body: &str) -> Result<(), AppError> {
-        let message = Message::builder()
-            .from(
-                self.from
-                    .parse()
-                    .map_err(|e| crate::log_and_convert!(AppError::mail, "mail.parse_from", e))?,
-            )
-            .to(to
-                .parse()
-                .map_err(|e| crate::log_and_convert!(AppError::mail, "mail.parse_to", e))?)
-            .subject(subject)
-            .body(body.to_owned())
-            .map_err(|e| crate::log_and_convert!(AppError::mail, "mail.build_message", e))?;
+        match &self.transport {
+            #[cfg(test)]
+            MailTransport::Noop => {
+                let _ = (to, subject, body);
+                tracing::Span::current().record("transport_ok", tracing::field::display(&true));
+                Ok(())
+            }
+            MailTransport::Smtp(transport) => {
+                let message = Message::builder()
+                    .from(self.from.parse().map_err(|e| {
+                        crate::log_and_convert!(AppError::mail, "mail.parse_from", e)
+                    })?)
+                    .to(to
+                        .parse()
+                        .map_err(|e| crate::log_and_convert!(AppError::mail, "mail.parse_to", e))?)
+                    .subject(subject)
+                    .body(body.to_owned())
+                    .map_err(|e| crate::log_and_convert!(AppError::mail, "mail.build_message", e))?;
 
-        let response = self
-            .transport
-            .send(message)
-            .await
-            .map_err(|e| crate::log_and_convert!(AppError::mail, "mail.transport_send", e))?;
+                let response = transport
+                    .send(message)
+                    .await
+                    .map_err(|e| crate::log_and_convert!(AppError::mail, "mail.transport_send", e))?;
 
-        if !response.is_positive() {
-            tracing::Span::current().record("transport_ok", tracing::field::display(&false));
-            tracing::warn!(
-                target = "mail.transport",
-                ?response,
-                "sending the mail was not positive"
-            );
-            return Err(AppError::mail("sending the mail was not positive"));
+                if !response.is_positive() {
+                    tracing::Span::current().record("transport_ok", tracing::field::display(&false));
+                    tracing::warn!(
+                        target = "mail.transport",
+                        ?response,
+                        "sending the mail was not positive"
+                    );
+                    return Err(AppError::mail("sending the mail was not positive"));
+                }
+                tracing::Span::current().record("transport_ok", tracing::field::display(&true));
+                Ok(())
+            }
         }
-        tracing::Span::current().record("transport_ok", tracing::field::display(&true));
-        Ok(())
     }
 }

--- a/docs/architecture/backend-request-flow.md
+++ b/docs/architecture/backend-request-flow.md
@@ -5,6 +5,24 @@ entry point to SurrealDB and back.
 
 ---
 
+## Logging and observability
+
+Subscriber setup lives in [`backend/src/observability.rs`](../../backend/src/observability.rs): `observability::init()` runs once from `main`, installs `tracing-subscriber` with an [`EnvFilter`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) (default `info`, overridable with **`RUST_LOG`**), and enables the **`tracing-log`** bridge so crates that use the `log` facade (Actix, SurrealDB, lettre, etc.) emit into the same sink.
+
+**Output format:** With **`LOG_FORMAT=json`**, **`LOG_FORMAT=compact`**, or **`LOG_FORMAT=pretty`**, operators force a formatter regardless of environment. If `LOG_FORMAT` is unset, JSON is used when **`WORSHIP_PRODUCTION`** is truthy or **`RUST_ENV=production`**, otherwise compact (human-friendly) lines.
+
+**`RUST_LOG` examples:**
+
+- `RUST_LOG=info` — default.
+- `RUST_LOG=backend=debug,info` — debug for this crate only.
+- `RUST_LOG=backend::auth=trace,surrealdb=info` — verbose auth, quieter database logs.
+
+**Request correlation:** [`tracing-actix-web`](https://docs.rs/tracing-actix-web) builds a root span per HTTP request via [`WorshipRootSpan`](../../backend/src/request_id.rs). The request-id middleware stores the same id in request extensions (for Problem Details `instance`) and echoes it as **`X-Request-Id`**. If the client sends a W3C **`traceparent`** header, its span id is preferred as the request id; otherwise a UUID is generated. Authenticated requests record **`user_id`** on the current span from [`RequireUser`](../../backend/src/auth/middleware.rs). Log lines emitted while handling a request inherit those fields.
+
+**Regression tests:** Canary tests in [`backend/src/audit_events_tests.rs`](../../backend/src/audit_events_tests.rs) (using [`tracing-test`](https://docs.rs/tracing-test)) assert that each catalogued `audit.*` event still appears when the corresponding code path runs.
+
+---
+
 ## Overview
 
 ```


### PR DESCRIPTION
## Summary

Implements **Bundle D** from `docs/logging-review.md` (Phase 8): tracing-based regression tests for audit events and contributor-facing logging documentation.

## Changes

- Add `tracing-test` and `backend/src/audit_events_tests.rs` with one canary per catalogued `audit.*` event (service and HTTP paths).
- Add `MailService::noop_for_tests` and `pub(crate)` OTP/logout handlers so tests can mount auth routes without OIDC discovery or SMTP.
- Use `PeerOrFallbackIpKeyExtractor` in those tests so actix-governor works when `peer_addr` is missing.
- Expose `http_tests::build_app` for the admin user-delete audit test.
- Document `RUST_LOG`, `LOG_FORMAT`, and request correlation in `README.md` and `docs/architecture/backend-request-flow.md`.

## Verification

- `cargo fmt`, `cargo test -p backend`, `cargo clippy -p backend --all-targets -- -D warnings`


Made with [Cursor](https://cursor.com)