### PR TITLE
feat(backend): finish logging review remainder

### DIFF
--- a/backend/src/auth/middleware.rs
+++ b/backend/src/auth/middleware.rs
@@ -150,6 +150,21 @@ where
                 .unwrap_or(false);
 
             if !is_admin {
+                match req.extensions().get::<User>() {
+                    Some(user) => {
+                        debug!(
+                            reason = "require_admin_forbidden",
+                            user_id = %user.id,
+                            "forbidden: admin role required"
+                        );
+                    }
+                    None => {
+                        debug!(
+                            reason = "require_admin_forbidden",
+                            "forbidden: admin role required (no user in extensions)"
+                        );
+                    }
+                }
                 return Err(AppError::forbidden().into());
             }
 

--- a/backend/src/auth/oidc/client.rs
+++ b/backend/src/auth/oidc/client.rs
@@ -72,6 +72,11 @@ impl OidcClients {
     pub fn default_provider(&self) -> OidcProvider {
         OidcProvider::Google
     }
+
+    /// Short names of OIDC providers with clients in this process (keep in sync with [`build_clients`]).
+    pub fn registered_provider_ids(&self) -> Vec<&'static str> {
+        vec![OidcProvider::Google.as_str()]
+    }
 }
 
 pub async fn build_clients(settings: &Settings) -> AnyResult<OidcClients> {

--- a/backend/src/database/migrations.rs
+++ b/backend/src/database/migrations.rs
@@ -9,7 +9,7 @@ use ring::digest::{SHA256, digest};
 use serde::Deserialize;
 use surrealdb::Surreal;
 use surrealdb::engine::any::Any;
-use tracing::{error, info};
+use tracing::info;
 
 #[derive(Debug, Deserialize)]
 struct AppliedMigration {
@@ -95,17 +95,6 @@ async fn load_applied_migrations(db: &Surreal<Any>) -> AnyResult<HashMap<String,
     Ok(out)
 }
 
-fn log_surreal_error_chain(migration: &str, statement_index: usize, err: &surrealdb::Error) {
-    error!(
-        migration = %migration,
-        statement_index = statement_index,
-        error = %err,
-        error_source_chain = %crate::observability::error_source_chain_string(err),
-        error_debug = ?err,
-        "SurrealDB query statement failed"
-    );
-}
-
 fn ensure_no_statement_errors(
     migration: &str,
     context: &str,
@@ -121,7 +110,7 @@ fn ensure_no_statement_errors(
 
     let mut summary = Vec::with_capacity(pairs.len());
     for (idx, err) in &pairs {
-        log_surreal_error_chain(migration, *idx, err);
+        crate::observability::log_surreal_statement_error_migration(migration, *idx, err);
         summary.push(format!("[statement {idx}] {err}"));
     }
 

--- a/backend/src/database/mod.rs
+++ b/backend/src/database/mod.rs
@@ -25,14 +25,7 @@ pub(crate) fn surreal_take_errors(
 
     let mut summary = Vec::with_capacity(pairs.len());
     for (idx, err) in pairs {
-        tracing::error!(
-            context = context,
-            statement_index = idx,
-            error = %err,
-            error_source_chain = %crate::observability::error_source_chain_string(&err),
-            error_debug = ?err,
-            "SurrealDB query statement failed"
-        );
+        crate::observability::log_surreal_statement_error_context(context, idx, &err);
         summary.push(format!("[statement {idx}] {err}"));
     }
 

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -108,6 +108,15 @@ impl AppError {
     pub fn precondition_failed() -> Self {
         Self::PreconditionFailed
     }
+
+    /// Log full error chain at an I/O boundary, then return [`Internal`](Self::Internal).
+    pub fn internal_from_err<E: std::error::Error + 'static>(
+        target: &'static str,
+        err: E,
+    ) -> Self {
+        observability::log_error_chain(target, &err);
+        Self::Internal(err.to_string())
+    }
 }
 
 /// Map [`shared::api::ListQuery::validate`] / [`shared::api::SongListQuery::validate`] failures to the right `AppError` (`invalid_page_size` vs `invalid_request`).

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -110,10 +110,7 @@ impl AppError {
     }
 
     /// Log full error chain at an I/O boundary, then return [`Internal`](Self::Internal).
-    pub fn internal_from_err<E: std::error::Error + 'static>(
-        target: &'static str,
-        err: E,
-    ) -> Self {
+    pub fn internal_from_err<E: std::error::Error + 'static>(target: &'static str, err: E) -> Self {
         observability::log_error_chain(target, &err);
         Self::Internal(err.to_string())
     }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -120,7 +120,9 @@ async fn main() -> AnyResult<()> {
         }
     }
 
-    let oidc_clients = Data::new(Arc::new(oidc::build_clients(&settings).await?));
+    let oidc_clients_arc = Arc::new(oidc::build_clients(&settings).await?);
+    let oidc_provider_ids = oidc_clients_arc.registered_provider_ids();
+    let oidc_clients = Data::new(oidc_clients_arc);
 
     info!(
         event = "startup",
@@ -139,7 +141,7 @@ async fn main() -> AnyResult<()> {
         blob_dir = %settings.blob_dir,
         production = production,
         static_dir = %static_dir,
-        oidc_providers = ?["google"],
+        oidc_providers = ?oidc_provider_ids,
         "backend starting"
     );
 

--- a/backend/src/observability.rs
+++ b/backend/src/observability.rs
@@ -2,6 +2,7 @@
 
 use hex;
 use ring::digest;
+use surrealdb::Error as SurrealError;
 use tracing_subscriber::EnvFilter;
 
 /// Compile-time guard: audit [`crate::audit!`] events must use the `audit.` prefix.
@@ -137,6 +138,38 @@ pub fn log_error_chain(target: &'static str, err: &(dyn std::error::Error + 'sta
         error_source_chain = %error_source_chain_string(err),
         error_debug = ?err,
         "I/O boundary error"
+    );
+}
+
+/// SurrealDB statement failure during migrations (`migration` field preserved for log compatibility).
+pub fn log_surreal_statement_error_migration(
+    migration: &str,
+    statement_index: usize,
+    err: &SurrealError,
+) {
+    tracing::error!(
+        migration = %migration,
+        statement_index = statement_index,
+        error = %err,
+        error_source_chain = %error_source_chain_string(err),
+        error_debug = ?err,
+        "SurrealDB query statement failed"
+    );
+}
+
+/// SurrealDB statement failure in application queries (`context` field).
+pub fn log_surreal_statement_error_context(
+    context: &'static str,
+    statement_index: usize,
+    err: &SurrealError,
+) {
+    tracing::error!(
+        context = context,
+        statement_index = statement_index,
+        error = %err,
+        error_source_chain = %error_source_chain_string(err),
+        error_debug = ?err,
+        "SurrealDB query statement failed"
     );
 }
 

--- a/backend/src/resources/blob/rest.rs
+++ b/backend/src/resources/blob/rest.rs
@@ -320,7 +320,8 @@ async fn download_blob_image(
         .file_name()
         .unwrap_or_else(|| format!("blob-{}", blob.id));
     let path = file.path().to_path_buf();
-    let bytes = std::fs::read(&path).map_err(|e| AppError::internal_from_err("blob.rest.read_data", e))?;
+    let bytes =
+        std::fs::read(&path).map_err(|e| AppError::internal_from_err("blob.rest.read_data", e))?;
     let etag = weak_etag_from_bytes(&bytes);
     if if_none_match_matches(&req, &etag) {
         return Ok(HttpResponse::NotModified()

--- a/backend/src/resources/blob/rest.rs
+++ b/backend/src/resources/blob/rest.rs
@@ -121,7 +121,7 @@ async fn get_blob(
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let blob = svc.get_blob_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&blob).map_err(|e| AppError::Internal(e.to_string()))?;
+    let etag = weak_etag_json(&blob).map_err(|e| AppError::internal_from_err("blob.rest", e))?;
     if if_none_match_matches(&req, &etag) {
         return Ok(HttpResponse::NotModified()
             .insert_header((header::ETAG, etag))
@@ -195,7 +195,7 @@ async fn update_blob(
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let id = id.into_inner();
     let blob = svc.get_blob_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&blob).map_err(|e| AppError::Internal(e.to_string()))?;
+    let etag = weak_etag_json(&blob).map_err(|e| AppError::internal_from_err("blob.rest", e))?;
     check_if_match(&req, &etag)?;
     let payload = CreateBlob::from(payload.into_inner());
     Ok(HttpResponse::Ok().json(svc.update_blob_for_user(&perms, &id, payload).await?))
@@ -234,7 +234,7 @@ async fn patch_blob(
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let id = id.into_inner();
     let blob = svc.get_blob_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&blob).map_err(|e| AppError::Internal(e.to_string()))?;
+    let etag = weak_etag_json(&blob).map_err(|e| AppError::internal_from_err("blob.rest", e))?;
     check_if_match(&req, &etag)?;
     Ok(HttpResponse::Ok().json(
         svc.patch_blob_for_user(&perms, &id, payload.into_inner())
@@ -273,7 +273,7 @@ async fn delete_blob(
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let id = id.into_inner();
     let blob = svc.get_blob_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&blob).map_err(|e| AppError::Internal(e.to_string()))?;
+    let etag = weak_etag_json(&blob).map_err(|e| AppError::internal_from_err("blob.rest", e))?;
     check_if_match(&req, &etag)?;
     svc.delete_blob_for_user(&perms, &id).await?;
     Ok(HttpResponse::NoContent().finish())
@@ -320,7 +320,7 @@ async fn download_blob_image(
         .file_name()
         .unwrap_or_else(|| format!("blob-{}", blob.id));
     let path = file.path().to_path_buf();
-    let bytes = std::fs::read(&path).map_err(|e| AppError::Internal(e.to_string()))?;
+    let bytes = std::fs::read(&path).map_err(|e| AppError::internal_from_err("blob.rest.read_data", e))?;
     let etag = weak_etag_from_bytes(&bytes);
     if if_none_match_matches(&req, &etag) {
         return Ok(HttpResponse::NotModified()
@@ -336,7 +336,7 @@ async fn download_blob_image(
         "attachment; filename=\"{}\"",
         filename.replace('\\', "\\\\").replace('"', "\\\"")
     ))
-    .map_err(|e| AppError::Internal(e.to_string()))?;
+    .map_err(|e| AppError::internal_from_err("blob.rest.content_disposition_header", e))?;
     Ok(HttpResponse::Ok()
         .insert_header((header::ETAG, etag))
         .insert_header((header::CONTENT_TYPE, ct))
@@ -387,7 +387,7 @@ async fn upload_blob_data(
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let id = id.into_inner();
     let blob = svc.get_blob_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&blob).map_err(|e| AppError::Internal(e.to_string()))?;
+    let etag = weak_etag_json(&blob).map_err(|e| AppError::internal_from_err("blob.rest", e))?;
     check_if_match(&req, &etag)?;
     svc.upload_blob_data_for_user(&perms, &id, &body).await?;
     Ok(HttpResponse::NoContent().finish())

--- a/backend/src/resources/blob/storage.rs
+++ b/backend/src/resources/blob/storage.rs
@@ -38,9 +38,10 @@ impl BlobStorage for FsBlobStorage {
             .ok_or_else(|| AppError::Internal("blob has no id".into()))?;
         let path = Path::new(&self.blob_dir).join(file_name);
         if let Some(dir) = path.parent() {
-            std::fs::create_dir_all(dir).map_err(|e| AppError::Internal(e.to_string()))?;
+            std::fs::create_dir_all(dir)
+                .map_err(|e| AppError::internal_from_err("blob.storage.create_dir_all", e))?;
         }
-        std::fs::write(&path, data).map_err(|e| AppError::Internal(e.to_string()))
+        std::fs::write(&path, data).map_err(|e| AppError::internal_from_err("blob.storage.write", e))
     }
 
     fn delete_blob_file(&self, blob: &Blob) {
@@ -72,6 +73,6 @@ impl BlobStorage for FsBlobStorage {
             .file_name()
             .ok_or_else(|| AppError::NotFound("blob has no id".into()))?;
         NamedFile::open(Path::new(&self.blob_dir).join(PathBuf::from(file_name)))
-            .map_err(|err| AppError::Internal(format!("{}", err)))
+            .map_err(|err| AppError::internal_from_err("blob.storage.open", err))
     }
 }

--- a/backend/src/resources/blob/storage.rs
+++ b/backend/src/resources/blob/storage.rs
@@ -41,7 +41,8 @@ impl BlobStorage for FsBlobStorage {
             std::fs::create_dir_all(dir)
                 .map_err(|e| AppError::internal_from_err("blob.storage.create_dir_all", e))?;
         }
-        std::fs::write(&path, data).map_err(|e| AppError::internal_from_err("blob.storage.write", e))
+        std::fs::write(&path, data)
+            .map_err(|e| AppError::internal_from_err("blob.storage.write", e))
     }
 
     fn delete_blob_file(&self, blob: &Blob) {

--- a/backend/src/resources/collection/rest.rs
+++ b/backend/src/resources/collection/rest.rs
@@ -123,7 +123,7 @@ async fn get_collection(
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let collection = svc.get_collection_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&collection).map_err(|e| AppError::Internal(e.to_string()))?;
+    let etag = weak_etag_json(&collection).map_err(|e| AppError::internal_from_err("collection.rest", e))?;
     if if_none_match_matches(&req, &etag) {
         return Ok(HttpResponse::NotModified()
             .insert_header((header::ETAG, etag))
@@ -293,7 +293,7 @@ async fn update_collection(
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let id = id.into_inner();
     let collection = svc.get_collection_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&collection).map_err(|e| AppError::Internal(e.to_string()))?;
+    let etag = weak_etag_json(&collection).map_err(|e| AppError::internal_from_err("collection.rest", e))?;
     check_if_match(&req, &etag)?;
     let payload = CreateCollection::from(payload.into_inner());
     Ok(HttpResponse::Ok().json(svc.update_collection_for_user(&perms, &id, payload).await?))
@@ -332,7 +332,7 @@ async fn patch_collection(
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let id = id.into_inner();
     let collection = svc.get_collection_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&collection).map_err(|e| AppError::Internal(e.to_string()))?;
+    let etag = weak_etag_json(&collection).map_err(|e| AppError::internal_from_err("collection.rest", e))?;
     check_if_match(&req, &etag)?;
     Ok(HttpResponse::Ok().json(
         svc.patch_collection_for_user(&perms, &id, payload.into_inner())
@@ -371,7 +371,7 @@ async fn delete_collection(
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let id = id.into_inner();
     let collection = svc.get_collection_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&collection).map_err(|e| AppError::Internal(e.to_string()))?;
+    let etag = weak_etag_json(&collection).map_err(|e| AppError::internal_from_err("collection.rest", e))?;
     check_if_match(&req, &etag)?;
     svc.delete_collection_for_user(&perms, &id).await?;
     Ok(HttpResponse::NoContent().finish())

--- a/backend/src/resources/collection/rest.rs
+++ b/backend/src/resources/collection/rest.rs
@@ -123,7 +123,8 @@ async fn get_collection(
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let collection = svc.get_collection_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&collection).map_err(|e| AppError::internal_from_err("collection.rest", e))?;
+    let etag = weak_etag_json(&collection)
+        .map_err(|e| AppError::internal_from_err("collection.rest", e))?;
     if if_none_match_matches(&req, &etag) {
         return Ok(HttpResponse::NotModified()
             .insert_header((header::ETAG, etag))
@@ -293,7 +294,8 @@ async fn update_collection(
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let id = id.into_inner();
     let collection = svc.get_collection_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&collection).map_err(|e| AppError::internal_from_err("collection.rest", e))?;
+    let etag = weak_etag_json(&collection)
+        .map_err(|e| AppError::internal_from_err("collection.rest", e))?;
     check_if_match(&req, &etag)?;
     let payload = CreateCollection::from(payload.into_inner());
     Ok(HttpResponse::Ok().json(svc.update_collection_for_user(&perms, &id, payload).await?))
@@ -332,7 +334,8 @@ async fn patch_collection(
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let id = id.into_inner();
     let collection = svc.get_collection_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&collection).map_err(|e| AppError::internal_from_err("collection.rest", e))?;
+    let etag = weak_etag_json(&collection)
+        .map_err(|e| AppError::internal_from_err("collection.rest", e))?;
     check_if_match(&req, &etag)?;
     Ok(HttpResponse::Ok().json(
         svc.patch_collection_for_user(&perms, &id, payload.into_inner())
@@ -371,7 +374,8 @@ async fn delete_collection(
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let id = id.into_inner();
     let collection = svc.get_collection_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&collection).map_err(|e| AppError::internal_from_err("collection.rest", e))?;
+    let etag = weak_etag_json(&collection)
+        .map_err(|e| AppError::internal_from_err("collection.rest", e))?;
     check_if_match(&req, &etag)?;
     svc.delete_collection_for_user(&perms, &id).await?;
     Ok(HttpResponse::NoContent().finish())

--- a/backend/src/resources/setlist/rest.rs
+++ b/backend/src/resources/setlist/rest.rs
@@ -123,7 +123,8 @@ async fn get_setlist(
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let setlist = svc.get_setlist_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&setlist).map_err(|e| AppError::internal_from_err("setlist.rest", e))?;
+    let etag =
+        weak_etag_json(&setlist).map_err(|e| AppError::internal_from_err("setlist.rest", e))?;
     if if_none_match_matches(&req, &etag) {
         return Ok(HttpResponse::NotModified()
             .insert_header((header::ETAG, etag))
@@ -293,7 +294,8 @@ async fn update_setlist(
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let id = id.into_inner();
     let setlist = svc.get_setlist_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&setlist).map_err(|e| AppError::internal_from_err("setlist.rest", e))?;
+    let etag =
+        weak_etag_json(&setlist).map_err(|e| AppError::internal_from_err("setlist.rest", e))?;
     check_if_match(&req, &etag)?;
     let payload = CreateSetlist::from(payload.into_inner());
     Ok(HttpResponse::Ok().json(svc.update_setlist_for_user(&perms, &id, payload).await?))
@@ -332,7 +334,8 @@ async fn patch_setlist(
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let id = id.into_inner();
     let setlist = svc.get_setlist_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&setlist).map_err(|e| AppError::internal_from_err("setlist.rest", e))?;
+    let etag =
+        weak_etag_json(&setlist).map_err(|e| AppError::internal_from_err("setlist.rest", e))?;
     check_if_match(&req, &etag)?;
     Ok(HttpResponse::Ok().json(
         svc.patch_setlist_for_user(&perms, &id, payload.into_inner())
@@ -371,7 +374,8 @@ async fn delete_setlist(
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let id = id.into_inner();
     let setlist = svc.get_setlist_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&setlist).map_err(|e| AppError::internal_from_err("setlist.rest", e))?;
+    let etag =
+        weak_etag_json(&setlist).map_err(|e| AppError::internal_from_err("setlist.rest", e))?;
     check_if_match(&req, &etag)?;
     svc.delete_setlist_for_user(&perms, &id).await?;
     Ok(HttpResponse::NoContent().finish())

--- a/backend/src/resources/setlist/rest.rs
+++ b/backend/src/resources/setlist/rest.rs
@@ -123,7 +123,7 @@ async fn get_setlist(
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let setlist = svc.get_setlist_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&setlist).map_err(|e| AppError::Internal(e.to_string()))?;
+    let etag = weak_etag_json(&setlist).map_err(|e| AppError::internal_from_err("setlist.rest", e))?;
     if if_none_match_matches(&req, &etag) {
         return Ok(HttpResponse::NotModified()
             .insert_header((header::ETAG, etag))
@@ -293,7 +293,7 @@ async fn update_setlist(
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let id = id.into_inner();
     let setlist = svc.get_setlist_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&setlist).map_err(|e| AppError::Internal(e.to_string()))?;
+    let etag = weak_etag_json(&setlist).map_err(|e| AppError::internal_from_err("setlist.rest", e))?;
     check_if_match(&req, &etag)?;
     let payload = CreateSetlist::from(payload.into_inner());
     Ok(HttpResponse::Ok().json(svc.update_setlist_for_user(&perms, &id, payload).await?))
@@ -332,7 +332,7 @@ async fn patch_setlist(
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let id = id.into_inner();
     let setlist = svc.get_setlist_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&setlist).map_err(|e| AppError::Internal(e.to_string()))?;
+    let etag = weak_etag_json(&setlist).map_err(|e| AppError::internal_from_err("setlist.rest", e))?;
     check_if_match(&req, &etag)?;
     Ok(HttpResponse::Ok().json(
         svc.patch_setlist_for_user(&perms, &id, payload.into_inner())
@@ -371,7 +371,7 @@ async fn delete_setlist(
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let id = id.into_inner();
     let setlist = svc.get_setlist_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&setlist).map_err(|e| AppError::Internal(e.to_string()))?;
+    let etag = weak_etag_json(&setlist).map_err(|e| AppError::internal_from_err("setlist.rest", e))?;
     check_if_match(&req, &etag)?;
     svc.delete_setlist_for_user(&perms, &id).await?;
     Ok(HttpResponse::NoContent().finish())

--- a/backend/src/resources/song/rest.rs
+++ b/backend/src/resources/song/rest.rs
@@ -239,7 +239,8 @@ async fn update_song(
     let id = id.into_inner();
     match svc.get_song_for_user(&perms, &id).await {
         Ok(song) => {
-            let etag = weak_etag_json(&song).map_err(|e| AppError::internal_from_err("song.rest", e))?;
+            let etag =
+                weak_etag_json(&song).map_err(|e| AppError::internal_from_err("song.rest", e))?;
             check_if_match(&req, &etag)?;
         }
         Err(AppError::NotFound(_)) => {}

--- a/backend/src/resources/song/rest.rs
+++ b/backend/src/resources/song/rest.rs
@@ -124,7 +124,7 @@ async fn get_song(
 ) -> Result<HttpResponse, AppError> {
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let song = svc.get_song_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&song).map_err(|e| AppError::Internal(e.to_string()))?;
+    let etag = weak_etag_json(&song).map_err(|e| AppError::internal_from_err("song.rest", e))?;
     if if_none_match_matches(&req, &etag) {
         return Ok(HttpResponse::NotModified()
             .insert_header((header::ETAG, etag))
@@ -239,7 +239,7 @@ async fn update_song(
     let id = id.into_inner();
     match svc.get_song_for_user(&perms, &id).await {
         Ok(song) => {
-            let etag = weak_etag_json(&song).map_err(|e| AppError::Internal(e.to_string()))?;
+            let etag = weak_etag_json(&song).map_err(|e| AppError::internal_from_err("song.rest", e))?;
             check_if_match(&req, &etag)?;
         }
         Err(AppError::NotFound(_)) => {}
@@ -286,7 +286,7 @@ async fn patch_song(
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let id = id.into_inner();
     let song = svc.get_song_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&song).map_err(|e| AppError::Internal(e.to_string()))?;
+    let etag = weak_etag_json(&song).map_err(|e| AppError::internal_from_err("song.rest", e))?;
     check_if_match(&req, &etag)?;
     Ok(HttpResponse::Ok().json(
         svc.patch_song_for_user(&perms, &id, payload.into_inner())
@@ -325,7 +325,7 @@ async fn delete_song(
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let id = id.into_inner();
     let song = svc.get_song_for_user(&perms, &id).await?;
-    let etag = weak_etag_json(&song).map_err(|e| AppError::Internal(e.to_string()))?;
+    let etag = weak_etag_json(&song).map_err(|e| AppError::internal_from_err("song.rest", e))?;
     check_if_match(&req, &etag)?;
     svc.delete_song_for_user(&perms, &id).await?;
     Ok(HttpResponse::NoContent().finish())

--- a/docs/architecture/backend-request-flow.md
+++ b/docs/architecture/backend-request-flow.md
@@ -21,6 +21,28 @@ Subscriber setup lives in [`backend/src/observability.rs`](../../backend/src/obs
 
 **Regression tests:** Canary tests in [`backend/src/audit_events_tests.rs`](../../backend/src/audit_events_tests.rs) (using [`tracing-test`](https://docs.rs/tracing-test)) assert that each catalogued `audit.*` event still appears when the corresponding code path runs.
 
+### Canonical log fields
+
+Use these names on new spans and structured log lines so aggregators and grep stay consistent (see also [logging-review.md §5](../logging-review.md)):
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `request_id` | string | UUID or W3C `traceparent` span id; set on the root HTTP span. |
+| `user_id` | string | Authenticated user id; recorded after session validation. |
+| `session_id` | string | Session id being created, validated, or revoked. |
+| `team_id` | string | Resolved team context for the request or mutation. |
+| `route` | string | Matched Actix route pattern (e.g. `/api/v1/songs/{id}`). |
+| `method` | string | HTTP method. |
+| `status` | u16 | HTTP response status code. |
+| `latency_ms` | u64 | Total request latency in milliseconds. |
+| `event` | string | Stable event name (`startup`, `oidc.provider.registered`, or `audit.*`). |
+| `audit` | bool | `true` on audit lines emitted via `audit!`. |
+| `error` | Display | Primary error message (`%err`). |
+| `error_debug` | Debug | Developer-oriented detail (`?err`). |
+| `error_source_chain` | string | `Error::source` chain joined with ` <- `. |
+| `target` | string | Logical I/O boundary tag for `log_error_chain` (e.g. `mail.transport_send`). |
+| `context` / `migration` | string | Surreal per-statement failures: app repo context vs migration script name. |
+
 ---
 
 ## Overview
@@ -420,7 +442,7 @@ teams on user registration.
 
 ## Audit event catalog
 
-Structured audit lines use `tracing` with **`audit = true`** and a stable **`event`** name (macro `audit!` in [backend/src/observability.rs](../../backend/src/observability.rs)). Field names follow [docs/logging-review.md](../logging-review.md) §5.
+Structured audit lines use `tracing` with **`audit = true`** and a stable **`event`** name (macro `audit!` in [backend/src/observability.rs](../../backend/src/observability.rs)). Field names follow the [canonical log fields](#canonical-log-fields) table above.
 
 | `event` | Where emitted | Typical fields |
 |---------|---------------|----------------|


### PR DESCRIPTION
Rebased onto `main` and resolves conflicts from overlapping logging work.

## Changes
- Centralize Surreal per-statement error logging in `observability` (`log_surreal_statement_error_*`)
- Startup `oidc_providers` from `OidcClients::registered_provider_ids`
- `RequireAdmin`: `debug!` on forbidden with optional `user_id`
- `AppError::internal_from_err` for REST ETag / blob storage I/O boundaries
- Docs: canonical log fields table in `backend-request-flow.md`

## Validation
- `cargo fmt`, `cargo test`, `cargo clippy --all-targets` in `backend/`

Made with [Cursor](https://cursor.com)