### PR TITLE
feat(db): migrate SurrealQL idioms for 3.x compatibility

### DIFF
--- a/backend/db-migrations/20260418130000_surrealql_idiom_v3_compat.surql
+++ b/backend/db-migrations/20260418130000_surrealql_idiom_v3_compat.surql
@@ -1,0 +1,92 @@
+-- SurrealQL idiom fixes for 2.6.x semantics that remain valid on 3.x:
+-- - Replace array filters using $this + record id comparisons with recursive helpers (no $this in events).
+-- - Replace INSIDE songs.*.id with $before.id INSIDE array::map(songs, |$e| $e.id) (no .* chain).
+-- - Use DEFINE FUNCTION helpers for link/array filtering (array::filter closures do not capture params/locals here).
+-- - Replace search_content VALUE / backfill logic that used data.sections.*.lines / .*.parts / .*.languages
+--   with explicit array::map + array::flatten (no all-idiom chains on arrays).
+--
+-- Note: DEFINE FIELD ... songs.*.id and data.sections.*... schema paths are unchanged; 3.x warnings
+-- for those refer mainly to evaluation of .* chains in expressions, not the field-definition syntax.
+
+DEFINE FUNCTION OVERWRITE fn::blob_array_without_id($blobs: array, $rid: any) {
+    IF array::len($blobs) = 0 {
+        RETURN [];
+    };
+    LET $head = array::first($blobs);
+    LET $n = array::len($blobs);
+    LET $tail = IF $n > 1 {
+        array::slice($blobs, 1, $n - 1)
+    } ELSE {
+        []
+    };
+    LET $rest = fn::blob_array_without_id($tail, $rid);
+    IF $head = $rid {
+        RETURN $rest;
+    };
+    RETURN array::concat([$head], $rest);
+};
+
+DEFINE FUNCTION OVERWRITE fn::song_link_array_without_song($links: array, $song_id: any) {
+    IF array::len($links) = 0 {
+        RETURN [];
+    };
+    LET $head = array::first($links);
+    LET $n = array::len($links);
+    LET $tail = IF $n > 1 {
+        array::slice($links, 1, $n - 1)
+    } ELSE {
+        []
+    };
+    LET $rest = fn::song_link_array_without_song($tail, $song_id);
+    IF $head.id = $song_id {
+        RETURN $rest;
+    };
+    RETURN array::concat([$head], $rest);
+};
+
+DEFINE FUNCTION OVERWRITE fn::song_search_content_from_data($data: object) {
+    LET $tokens = array::flatten(
+        array::map($data.sections ?? [], |$sec|
+            array::flatten(
+                array::map($sec.lines ?? [], |$line|
+                    array::flatten(
+                        array::map($line.parts ?? [], |$part|
+                            $part.languages ?? []
+                        )
+                    )
+                )
+            )
+        )
+    );
+    RETURN string::join(' ', $tokens ?? []);
+};
+
+DEFINE FIELD OVERWRITE search_content ON song TYPE string
+    DEFAULT ''
+    VALUE fn::song_search_content_from_data(data);
+
+DEFINE EVENT OVERWRITE song_blob_remove ON blob
+    WHEN $event = "DELETE"
+    THEN (
+        UPDATE song
+            SET blobs = fn::blob_array_without_id(blobs, $before.id)
+            WHERE $before.id INSIDE blobs
+    );
+
+DEFINE EVENT OVERWRITE collection_song_remove ON song
+    WHEN $event = "DELETE"
+    THEN (
+        UPDATE collection
+            SET songs = fn::song_link_array_without_song(songs, $before.id)
+            WHERE $before.id INSIDE array::map(songs, |$e| $e.id)
+    );
+
+DEFINE EVENT OVERWRITE setlist_song_remove ON song
+    WHEN $event = "DELETE"
+    THEN (
+        UPDATE setlist
+            SET songs = fn::song_link_array_without_song(songs, $before.id)
+            WHERE $before.id INSIDE array::map(songs, |$e| $e.id)
+    );
+
+UPDATE song SET search_content = fn::song_search_content_from_data(data);

--- a/backend/src/resources/collection/surreal_repo.rs
+++ b/backend/src/resources/collection/surreal_repo.rs
@@ -121,7 +121,7 @@ impl CollectionRepository for SurrealCollectionRepo {
         let resource = resource_id("collection", id)?;
         let mut response = db
             .db
-            .query("SELECT owner, songs FROM collection WHERE id = $id FETCH songs.*.id")
+            .query("SELECT owner, songs FROM collection WHERE id = $id FETCH songs.id")
             .bind(("id", Thing::from(resource.clone())))
             .await?;
 

--- a/backend/src/resources/common.rs
+++ b/backend/src/resources/common.rs
@@ -97,7 +97,7 @@ impl From<SongLink> for SongLinkRecord {
     }
 }
 
-/// A fully-fetched song record returned when querying setlist / collection songs via `FETCH`.
+/// A fully-fetched song record returned when querying setlist / collection songs via `FETCH songs.id`.
 ///
 /// The `id` field holds the fetched [`SongRecord`]; the other fields come from the link itself.
 #[derive(Deserialize)]

--- a/backend/src/resources/setlist/surreal_repo.rs
+++ b/backend/src/resources/setlist/surreal_repo.rs
@@ -117,7 +117,7 @@ impl SetlistRepository for SurrealSetlistRepo {
         let resource = resource_id("setlist", id)?;
         let mut response = db
             .db
-            .query("SELECT owner, songs FROM setlist WHERE id = $id FETCH songs.*.id")
+            .query("SELECT owner, songs FROM setlist WHERE id = $id FETCH songs.id")
             .bind(("id", Thing::from(resource.clone())))
             .await?;
 


### PR DESCRIPTION
Add migration to replace risky .* / $this patterns in events and search_content,
recursive helpers for blob/song link filtering, and FETCH songs.id in repos.

Made-with: Cursor
