### PR TITLE
chore(db): SurrealDB 2.6 schema alignment migrations

### DIFF
--- a/backend/db-migrations/20260420120000_user_schema_align_team_model.surql
+++ b/backend/db-migrations/20260420120000_user_schema_align_team_model.surql
@@ -1,0 +1,38 @@
+-- Align `user` with the team-based authorization model: drop legacy ACL columns
+-- (`read` / `write`, including `read.*` / `write.*` exports) and redefine the
+-- remaining fields to match `UserRecord`. Uses the same SurrealQL helpers as
+-- `20240301000009_user.surql` (`string::is::email`, `type::is::none`) for
+-- compatibility with SurrealDB 2.6.x; after upgrading to 3.x, apply the renames
+-- from `docs/surrealdb-3.0-upgrade.md` if the server requires them.
+--
+-- Safe only after `20260413130000_team_personal_backfill` has been applied (ACL
+-- data copied into teams). `REMOVE FIELD` drops only the schema; clear stored
+-- values first with `UNSET` (see SurrealDB REMOVE FIELD docs).
+
+UPDATE user UNSET read, write;
+
+REMOVE FIELD IF EXISTS read ON user;
+REMOVE FIELD IF EXISTS write ON user;
+
+DEFINE FIELD OVERWRITE email ON user TYPE string
+    VALUE string::lowercase(string::trim($value))
+    ASSERT string::is::email($value);
+
+DEFINE FIELD OVERWRITE role ON user TYPE string
+    VALUE string::lowercase(($value ?? $before) ?? "default")
+    ASSERT $value INSIDE ["default", "admin"];
+
+DEFINE FIELD OVERWRITE default_collection ON user TYPE option<record<collection>>
+    VALUE IF type::is::none($value) THEN NONE ELSE ($value ?? $before) ?? NONE END;
+
+DEFINE FIELD OVERWRITE created_at ON user TYPE datetime
+    VALUE $before ?? time::now()
+    READONLY;
+
+DEFINE FIELD OVERWRITE last_login_at ON user TYPE option<datetime>
+    VALUE ($value ?? $before) ?? NONE;
+
+DEFINE FIELD OVERWRITE request_count ON user TYPE int
+    VALUE ($value ?? $before) ?? 0;
+
+DEFINE INDEX OVERWRITE user_email_unique ON user COLUMNS email UNIQUE;

--- a/backend/db-migrations/20260420123000_team_schema_align.surql
+++ b/backend/db-migrations/20260420123000_team_schema_align.surql
@@ -1,0 +1,44 @@
+-- Align `team` with the repo schema (personal vs shared teams, content `owner` =
+-- record<team>). Normalizes field definitions and cascade events for databases
+-- exported from SurrealDB 3.x (`TYPE NORMAL`, `type::is_none`, parenthesized
+-- `THEN` blocks) onto the same SurrealQL as `20260413120000_team.surql`,
+-- `20260413160000_resource_owner_rename_from_teamowner.surql`, and
+-- `20260413170000_team_invitation.surql` — using `type::is::none` for
+-- SurrealDB 2.6.x (see `docs/surrealdb-3.0-upgrade.md` when on 3.x only).
+
+DEFINE FIELD OVERWRITE name ON team TYPE string
+    ASSERT string::len(string::trim($value)) > 0;
+
+DEFINE FIELD OVERWRITE owner ON team TYPE option<record<user>>
+    VALUE IF type::is::none($value) THEN NONE ELSE $value ?? $before ?? NONE END;
+
+DEFINE FIELD OVERWRITE members ON team TYPE array<object>
+    VALUE $value ?? $before ?? [];
+
+DEFINE FIELD OVERWRITE members.* ON team TYPE object;
+
+DEFINE FIELD OVERWRITE members.*.user ON team TYPE record<user>
+    ASSERT $value != NONE;
+
+DEFINE FIELD OVERWRITE members.*.role ON team TYPE string
+    ASSERT $value INSIDE ["guest", "content_maintainer", "admin"];
+
+DEFINE EVENT OVERWRITE team_invitation_team_cascade ON team
+    WHEN $event = "DELETE"
+    THEN DELETE team_invitation WHERE team = $before.id;
+
+DEFINE EVENT OVERWRITE team_personal_blob_cascade ON team
+    WHEN $event = "DELETE" AND $before.owner IS NOT NONE
+    THEN DELETE blob WHERE owner = $before.id;
+
+DEFINE EVENT OVERWRITE team_personal_song_cascade ON team
+    WHEN $event = "DELETE" AND $before.owner IS NOT NONE
+    THEN DELETE song WHERE owner = $before.id;
+
+DEFINE EVENT OVERWRITE team_personal_collection_cascade ON team
+    WHEN $event = "DELETE" AND $before.owner IS NOT NONE
+    THEN DELETE collection WHERE owner = $before.id;
+
+DEFINE EVENT OVERWRITE team_personal_setlist_cascade ON team
+    WHEN $event = "DELETE" AND $before.owner IS NOT NONE
+    THEN DELETE setlist WHERE owner = $before.id;

--- a/backend/db-migrations/20260420124500_team_invitation_schema_align.surql
+++ b/backend/db-migrations/20260420124500_team_invitation_schema_align.surql
@@ -1,0 +1,17 @@
+-- Align `team_invitation` with `20260413170000_team_invitation.surql` for databases
+-- exported from SurrealDB 3.x (`FIELDS` index syntax, `TYPE NORMAL`, parenthesized
+-- ASSERT). Uses `COLUMNS` for the index so SurrealDB 2.6.x matches the rest of
+-- `backend/db-migrations/`.
+
+DEFINE FIELD OVERWRITE team ON team_invitation TYPE record<team>
+    ASSERT $value != NONE;
+
+DEFINE FIELD OVERWRITE created_by ON team_invitation TYPE record<user>
+    ASSERT $value != NONE;
+
+DEFINE FIELD OVERWRITE created_at ON team_invitation TYPE datetime
+    DEFAULT time::now()
+    VALUE $before ?? $value
+    READONLY;
+
+DEFINE INDEX OVERWRITE team_invitation_team_idx ON team_invitation COLUMNS team;

--- a/backend/db-migrations/20260420130000_song_schema_align.surql
+++ b/backend/db-migrations/20260420130000_song_schema_align.surql
@@ -1,0 +1,160 @@
+-- Align `song` with the repo schema for SurrealDB 2.6.x: normalize 3.x exports
+-- (`FULLTEXT ANALYZER`, `BM25(k,b)`, parenthesized ASSERT, `($before).id`,
+-- typed closure params) onto the same definitions as `20240301000008_song.surql`,
+-- `20260410140000_song_chordlib08_drop_scalar_metadata.surql`,
+-- `20260413160000_resource_owner_rename_from_teamowner.surql`, and
+-- `20260418130000_surrealql_idiom_v3_compat.surql`.
+--
+-- Requires prior migrations that define `fn::song_normalize_metadata_array`,
+-- `fn::song_nonempty_strs`, `fn::song_search_content_from_data`,
+-- `fn::song_link_array_without_song`, and analyzer `text_search`.
+--
+-- Drop legacy `teamowner` document keys before schema fields: `REMOVE FIELD` alone
+-- does not delete stored values (SurrealDB docs).
+
+UPDATE song UNSET teamowner;
+REMOVE FIELD IF EXISTS teamowner ON song;
+
+DEFINE FIELD OVERWRITE blobs ON song TYPE array<record<blob>>
+    VALUE $value ?? $before ?? [];
+
+DEFINE FIELD OVERWRITE blobs.* ON song TYPE record<blob>;
+
+DEFINE FIELD OVERWRITE data ON song TYPE object
+    ASSERT $value != NONE;
+
+DEFINE FIELD OVERWRITE data.artists ON song TYPE array<string>
+    DEFAULT ALWAYS []
+    VALUE fn::song_normalize_metadata_array($value, $before)
+    ASSERT array::len($value) > 0;
+
+DEFINE FIELD OVERWRITE data.artists.* ON song TYPE string;
+
+DEFINE FIELD OVERWRITE data.copyright ON song TYPE option<string>;
+
+DEFINE FIELD OVERWRITE data.key ON song TYPE option<object>;
+
+DEFINE FIELD OVERWRITE data.key.level ON song TYPE int
+    ASSERT $value >= 0 AND $value < 12;
+
+DEFINE FIELD OVERWRITE data.languages ON song TYPE array<string>
+    DEFAULT ALWAYS []
+    VALUE fn::song_normalize_metadata_array($value, $before)
+    ASSERT array::len($value) > 0;
+
+DEFINE FIELD OVERWRITE data.languages.* ON song TYPE string;
+
+DEFINE FIELD OVERWRITE data.sections ON song TYPE array<object>
+    VALUE $value ?? $before ?? [];
+
+DEFINE FIELD OVERWRITE data.sections.* ON song TYPE object;
+
+DEFINE FIELD OVERWRITE data.sections.*.lines ON song TYPE array<object>
+    VALUE $value ?? $before ?? [];
+
+DEFINE FIELD OVERWRITE data.sections.*.lines.* ON song TYPE object;
+
+DEFINE FIELD OVERWRITE data.sections.*.lines.*.parts ON song TYPE array<object>
+    VALUE $value ?? $before ?? [];
+
+DEFINE FIELD OVERWRITE data.sections.*.lines.*.parts.* ON song TYPE object;
+
+DEFINE FIELD OVERWRITE data.sections.*.lines.*.parts.*.chord ON song TYPE option<object>;
+
+DEFINE FIELD OVERWRITE data.sections.*.lines.*.parts.*.chord.base ON song TYPE option<object>;
+
+DEFINE FIELD OVERWRITE data.sections.*.lines.*.parts.*.chord.base.level ON song TYPE int
+    ASSERT $value >= 0 AND $value < 12;
+
+DEFINE FIELD OVERWRITE data.sections.*.lines.*.parts.*.chord.duration ON song TYPE option<int>
+    ASSERT $value = NONE OR $value >= 0;
+
+DEFINE FIELD OVERWRITE data.sections.*.lines.*.parts.*.chord.kind ON song TYPE string
+    ASSERT $value INSIDE ["Major", "Minor", "Diminished", "Augmented", "Suspended2", "Suspended4"];
+
+DEFINE FIELD OVERWRITE data.sections.*.lines.*.parts.*.chord.main ON song TYPE object;
+
+DEFINE FIELD OVERWRITE data.sections.*.lines.*.parts.*.chord.main.level ON song TYPE int
+    ASSERT $value >= 0 AND $value < 12;
+
+DEFINE FIELD OVERWRITE data.sections.*.lines.*.parts.*.chord.optional ON song TYPE bool
+    VALUE $value ?? $before ?? false;
+
+DEFINE FIELD OVERWRITE data.sections.*.lines.*.parts.*.chord.var ON song TYPE string
+    VALUE $value ?? $before ?? "";
+
+DEFINE FIELD OVERWRITE data.sections.*.lines.*.parts.*.comment ON song TYPE bool
+    VALUE $value ?? $before ?? false;
+
+DEFINE FIELD OVERWRITE data.sections.*.lines.*.parts.*.languages ON song TYPE array<string>
+    VALUE $value ?? $before ?? [];
+
+DEFINE FIELD OVERWRITE data.sections.*.lines.*.parts.*.languages.* ON song TYPE string;
+
+DEFINE FIELD OVERWRITE data.sections.*.repeat_count ON song TYPE int
+    VALUE $value ?? $before ?? 1
+    ASSERT $value >= 1;
+
+DEFINE FIELD OVERWRITE data.sections.*.title ON song TYPE string;
+
+DEFINE FIELD OVERWRITE data.subtitle ON song TYPE option<string>;
+
+DEFINE FIELD OVERWRITE data.tags ON song TYPE option<object>;
+
+DEFINE FIELD OVERWRITE data.tags.* ON song TYPE string;
+
+DEFINE FIELD OVERWRITE data.tempo ON song TYPE option<int>
+    ASSERT $value = NONE OR $value >= 0;
+
+DEFINE FIELD OVERWRITE data.time ON song TYPE option<array<int>>
+    ASSERT $value = NONE OR array::len($value) = 2;
+
+DEFINE FIELD OVERWRITE data.time.* ON song TYPE int;
+
+DEFINE FIELD OVERWRITE data.titles ON song TYPE array<string>
+    DEFAULT ALWAYS []
+    VALUE fn::song_normalize_metadata_array($value, $before)
+    ASSERT array::len($value) > 0;
+
+DEFINE FIELD OVERWRITE data.titles.* ON song TYPE string;
+
+DEFINE FIELD OVERWRITE not_a_song ON song TYPE bool
+    VALUE $value ?? $before ?? false;
+
+DEFINE FIELD OVERWRITE owner ON song TYPE record<team>
+    ASSERT $value != NONE;
+
+DEFINE FIELD OVERWRITE search_content ON song TYPE string
+    DEFAULT ''
+    VALUE fn::song_search_content_from_data(data);
+
+DEFINE INDEX OVERWRITE song_content_search_idx ON song
+    FIELDS search_content SEARCH ANALYZER text_search BM25;
+
+DEFINE INDEX OVERWRITE song_data_artists_search_idx ON song
+    FIELDS data.artists SEARCH ANALYZER text_search BM25;
+
+DEFINE INDEX OVERWRITE song_data_titles_search_idx ON song
+    FIELDS data.titles SEARCH ANALYZER text_search BM25;
+
+DEFINE EVENT OVERWRITE collection_song_remove ON song
+    WHEN $event = "DELETE"
+    THEN (
+        UPDATE collection
+            SET songs = fn::song_link_array_without_song(songs, $before.id)
+            WHERE $before.id INSIDE array::map(songs, |$e| $e.id)
+    );
+
+DEFINE EVENT OVERWRITE like_song_cascade ON song
+    WHEN $event = "DELETE"
+    THEN DELETE like WHERE song = $before.id;
+
+DEFINE EVENT OVERWRITE setlist_song_remove ON song
+    WHEN $event = "DELETE"
+    THEN (
+        UPDATE setlist
+            SET songs = fn::song_link_array_without_song(songs, $before.id)
+            WHERE $before.id INSIDE array::map(songs, |$e| $e.id)
+    );
+
+UPDATE song SET search_content = fn::song_search_content_from_data(data);

--- a/backend/db-migrations/20260420131500_setlist_schema_align.surql
+++ b/backend/db-migrations/20260420131500_setlist_schema_align.surql
@@ -1,0 +1,34 @@
+-- Align `setlist` with the repo schema for SurrealDB 2.6.x: `record<team>` owner,
+-- nested `songs` entries, and full-text index using `SEARCH ANALYZER text_search BM25`
+-- (`20240301000007_setlist.surql`, `20260413160000_resource_owner_rename_from_teamowner.surql`,
+-- `20260328000002_fulltext_search.surql`). Normalizes 3.x exports (`FULLTEXT`,
+-- `BM25(k,b)`, parenthesized ASSERT).
+--
+-- Legacy `teamowner`: clear document data, then remove field definition if present.
+
+UPDATE setlist UNSET teamowner;
+REMOVE FIELD IF EXISTS teamowner ON setlist;
+
+DEFINE FIELD OVERWRITE owner ON setlist TYPE record<team>
+    ASSERT $value != NONE;
+
+DEFINE FIELD OVERWRITE title ON setlist TYPE string
+    ASSERT string::len(string::trim($value)) > 0;
+
+DEFINE FIELD OVERWRITE songs ON setlist TYPE array<object>
+    VALUE $value ?? $before ?? [];
+
+DEFINE FIELD OVERWRITE songs.* ON setlist TYPE object;
+
+DEFINE FIELD OVERWRITE songs.*.id ON setlist TYPE record<song>
+    ASSERT $value != NONE;
+
+DEFINE FIELD OVERWRITE songs.*.nr ON setlist TYPE option<string>;
+
+DEFINE FIELD OVERWRITE songs.*.key ON setlist TYPE option<object>;
+
+DEFINE FIELD OVERWRITE songs.*.key.level ON setlist TYPE int
+    ASSERT $value >= 0 AND $value < 12;
+
+DEFINE INDEX OVERWRITE setlist_title_search_idx ON setlist
+    FIELDS title SEARCH ANALYZER text_search BM25;

--- a/backend/db-migrations/20260420141500_session_schema_align.surql
+++ b/backend/db-migrations/20260420141500_session_schema_align.surql
@@ -1,0 +1,20 @@
+-- Align `session` with `20240301000006_session.surql` and
+-- `20260418120000_http_request_audit.surql` for SurrealDB 2.6.x (`COLUMNS` index,
+-- unparenthesized ASSERT / WHERE). Normalizes 3.x exports (`FIELDS`, `($before).id`,
+-- `TYPE NORMAL`).
+
+DEFINE FIELD OVERWRITE user ON session TYPE record<user>
+    ASSERT $value != NONE;
+
+DEFINE FIELD OVERWRITE created_at ON session TYPE datetime
+    DEFAULT time::now()
+    VALUE $before ?? $value
+    READONLY;
+
+DEFINE FIELD OVERWRITE expires_at ON session TYPE datetime;
+
+DEFINE INDEX OVERWRITE session_user_idx ON session COLUMNS user;
+
+DEFINE EVENT OVERWRITE http_request_audit_session_clear ON session
+    WHEN $event = "DELETE"
+    THEN UPDATE http_request_audit SET session = NONE WHERE session = $before.id;

--- a/backend/db-migrations/20260420143000_otp_schema_align.surql
+++ b/backend/db-migrations/20260420143000_otp_schema_align.surql
@@ -1,0 +1,14 @@
+-- Align `otp` with `20240301000004_otp.surql` and `20260417000000_otp_failed_attempts.surql`
+-- for SurrealDB 2.6.x (`COLUMNS` index). Normalizes 3.x exports (`FIELDS`, `TYPE NORMAL`).
+
+DEFINE FIELD OVERWRITE code ON otp TYPE string;
+
+DEFINE FIELD OVERWRITE created_at ON otp TYPE datetime
+    VALUE $before ?? time::now()
+    READONLY;
+
+DEFINE FIELD OVERWRITE expires_at ON otp TYPE datetime;
+
+DEFINE FIELD OVERWRITE failed_attempts ON otp TYPE int DEFAULT 0;
+
+DEFINE INDEX OVERWRITE otp_expires_idx ON otp COLUMNS expires_at;

--- a/backend/db-migrations/20260420144500_migration_script_schema_align.surql
+++ b/backend/db-migrations/20260420144500_migration_script_schema_align.surql
@@ -1,0 +1,11 @@
+-- Align `migration_script` with `20260320000000_change_db_migration_mechanism.surql` and
+-- `migrations::ensure_migration_table` for SurrealDB 2.6.x (`COLUMNS` index). Normalizes
+-- 3.x exports (`FIELDS`, `TYPE NORMAL`, `READONLY VALUE` ordering).
+
+DEFINE FIELD OVERWRITE script_name ON migration_script TYPE string;
+
+DEFINE FIELD OVERWRITE checksum ON migration_script TYPE string;
+
+DEFINE FIELD OVERWRITE executed_at ON migration_script TYPE datetime VALUE time::now() READONLY;
+
+DEFINE INDEX OVERWRITE migration_script_script_name_unique ON migration_script COLUMNS script_name UNIQUE;

--- a/backend/db-migrations/20260420150000_like_schema_align.surql
+++ b/backend/db-migrations/20260420150000_like_schema_align.surql
@@ -1,0 +1,16 @@
+-- Align `like` with `20240301000002_like.surql` for SurrealDB 2.6.x (`COLUMNS` unique index).
+-- Normalizes 3.x exports (`FIELDS`, `TYPE NORMAL`, parenthesized ASSERT / VALUE).
+-- Cascade events (`like_user_cascade`, `like_song_cascade`) stay on `user` / `song`.
+
+DEFINE FIELD OVERWRITE owner ON like TYPE record<user>
+    ASSERT $value != NONE;
+
+DEFINE FIELD OVERWRITE song ON like TYPE record<song>
+    ASSERT $value != NONE;
+
+DEFINE FIELD OVERWRITE created_at ON like TYPE datetime
+    DEFAULT time::now()
+    VALUE $before ?? $value
+    READONLY;
+
+DEFINE INDEX OVERWRITE like_owner_song_unique ON like COLUMNS owner, song UNIQUE;

--- a/backend/db-migrations/20260420151500_oidc_state_schema_align.surql
+++ b/backend/db-migrations/20260420151500_oidc_state_schema_align.surql
@@ -1,0 +1,16 @@
+-- Align `oidc_state` with `20240301000003_oidc_state.surql` for SurrealDB 2.6.x
+-- (`COLUMNS` index). Normalizes 3.x exports (`FIELDS`, `TYPE NORMAL`, parenthesized VALUE).
+
+DEFINE FIELD OVERWRITE pkce_verifier ON oidc_state TYPE string;
+
+DEFINE FIELD OVERWRITE nonce ON oidc_state TYPE string;
+
+DEFINE FIELD OVERWRITE redirect_to ON oidc_state TYPE option<string>;
+
+DEFINE FIELD OVERWRITE created_at ON oidc_state TYPE datetime
+    VALUE $before ?? time::now()
+    READONLY;
+
+DEFINE FIELD OVERWRITE expires_at ON oidc_state TYPE datetime;
+
+DEFINE INDEX OVERWRITE oidc_state_expires_idx ON oidc_state COLUMNS expires_at;

--- a/backend/db-migrations/20260420153000_http_request_audit_schema_align.surql
+++ b/backend/db-migrations/20260420153000_http_request_audit_schema_align.surql
@@ -1,0 +1,36 @@
+-- Align `http_request_audit` with `20260418120000_http_request_audit.surql` for SurrealDB 2.6.x
+-- (`type::is::none`, `COLUMNS` indexes). Normalizes 3.x exports (`type::is_none`, `FIELDS`,
+-- parenthesized ASSERT / VALUE).
+
+DEFINE FIELD OVERWRITE request_id ON http_request_audit TYPE string ASSERT $value != NONE;
+
+DEFINE FIELD OVERWRITE method ON http_request_audit TYPE string ASSERT $value != NONE;
+
+DEFINE FIELD OVERWRITE path ON http_request_audit TYPE string ASSERT $value != NONE;
+
+DEFINE FIELD OVERWRITE status_code ON http_request_audit TYPE int ASSERT $value != NONE;
+
+DEFINE FIELD OVERWRITE duration_ms ON http_request_audit TYPE int ASSERT $value != NONE;
+
+DEFINE FIELD OVERWRITE user ON http_request_audit TYPE option<record<user>>
+    VALUE IF type::is::none($value) THEN NONE ELSE $value ?? $before ?? NONE END;
+
+DEFINE FIELD OVERWRITE session ON http_request_audit TYPE option<record<session>>
+    VALUE IF type::is::none($value) THEN NONE ELSE $value ?? $before ?? NONE END;
+
+DEFINE FIELD OVERWRITE created_at ON http_request_audit TYPE datetime
+    DEFAULT time::now()
+    VALUE $before ?? $value
+    READONLY;
+
+DEFINE INDEX OVERWRITE http_request_audit_created_at_idx ON http_request_audit COLUMNS created_at;
+
+DEFINE INDEX OVERWRITE http_request_audit_user_idx ON http_request_audit COLUMNS user;
+
+DEFINE EVENT OVERWRITE http_request_audit_user_clear ON user
+    WHEN $event = "DELETE"
+    THEN UPDATE http_request_audit SET user = NONE WHERE user = $before.id;
+
+DEFINE EVENT OVERWRITE http_request_audit_session_clear ON session
+    WHEN $event = "DELETE"
+    THEN UPDATE http_request_audit SET session = NONE WHERE session = $before.id;

--- a/backend/db-migrations/20260420154500_collection_schema_align.surql
+++ b/backend/db-migrations/20260420154500_collection_schema_align.surql
@@ -1,0 +1,43 @@
+-- Align `collection` with `20240301000001_collection.surql`, `20260328000002_fulltext_search.surql`,
+-- and `20260413160000_resource_owner_rename_from_teamowner.surql` for SurrealDB 2.6.x.
+-- Normalizes 3.x exports (`FULLTEXT`, `BM25(k,b)`, `FIELDS`-only index spelling is kept as
+-- `FIELDS … SEARCH ANALYZER … BM25` like other repo migrations).
+--
+-- Legacy `teamowner`: clear document data, then remove field definition if present.
+
+UPDATE collection UNSET teamowner;
+REMOVE FIELD IF EXISTS teamowner ON collection;
+
+DEFINE FIELD OVERWRITE owner ON collection TYPE record<team>
+    ASSERT $value != NONE;
+
+DEFINE FIELD OVERWRITE title ON collection TYPE string
+    ASSERT string::len(string::trim($value)) > 0;
+
+DEFINE FIELD OVERWRITE cover ON collection TYPE option<record<blob>>;
+
+DEFINE FIELD OVERWRITE songs ON collection TYPE array<object>
+    VALUE $value ?? $before ?? [];
+
+DEFINE FIELD OVERWRITE songs.* ON collection TYPE object;
+
+DEFINE FIELD OVERWRITE songs.*.id ON collection TYPE record<song>
+    ASSERT $value != NONE;
+
+DEFINE FIELD OVERWRITE songs.*.nr ON collection TYPE option<string>;
+
+DEFINE FIELD OVERWRITE songs.*.key ON collection TYPE option<object>;
+
+DEFINE FIELD OVERWRITE songs.*.key.level ON collection TYPE int
+    ASSERT $value >= 0 AND $value < 12;
+
+DEFINE INDEX OVERWRITE collection_title_search_idx ON collection
+    FIELDS title SEARCH ANALYZER text_search BM25;
+
+DEFINE EVENT OVERWRITE collection_default_collection_unset ON collection
+    WHEN $event = "DELETE"
+    THEN (
+        UPDATE user
+            SET default_collection = NONE
+            WHERE default_collection = $before.id
+    );

--- a/backend/db-migrations/20260420160000_blob_schema_align.surql
+++ b/backend/db-migrations/20260420160000_blob_schema_align.surql
@@ -1,0 +1,41 @@
+-- Align `blob` with `20240301000000_blob.surql`, `20260418080000_blob_svg_xml_mime.surql`,
+-- and `20260413160000_resource_owner_rename_from_teamowner.surql` (`owner` = record<team>),
+-- plus blob events from `20240301000001_collection.surql` and
+-- `20260418130000_surrealql_idiom_v3_compat.surql`. Normalizes 3.x exports (`TYPE NORMAL`,
+-- parenthesized ASSERT / VALUE / WHERE).
+--
+-- Legacy `teamowner`: clear document data, then remove field definition if present.
+
+UPDATE blob UNSET teamowner;
+REMOVE FIELD IF EXISTS teamowner ON blob;
+
+DEFINE FIELD OVERWRITE owner ON blob TYPE record<team>
+    ASSERT $value != NONE;
+
+DEFINE FIELD OVERWRITE file_type ON blob TYPE string
+    ASSERT $value INSIDE ["image/png", "image/jpeg", "image/svg", "image/svg+xml"];
+
+DEFINE FIELD OVERWRITE width ON blob TYPE int
+    ASSERT $value >= 0;
+
+DEFINE FIELD OVERWRITE height ON blob TYPE int
+    ASSERT $value >= 0;
+
+DEFINE FIELD OVERWRITE ocr ON blob TYPE string
+    VALUE $value ?? $before ?? "";
+
+DEFINE FIELD OVERWRITE created_at ON blob TYPE datetime
+    VALUE $before ?? time::now()
+    READONLY;
+
+DEFINE EVENT OVERWRITE collection_cover_blob_cascade ON blob
+    WHEN $event = "DELETE"
+    THEN DELETE collection WHERE cover = $before.id;
+
+DEFINE EVENT OVERWRITE song_blob_remove ON blob
+    WHEN $event = "DELETE"
+    THEN (
+        UPDATE song
+            SET blobs = fn::blob_array_without_id(blobs, $before.id)
+            WHERE $before.id INSIDE blobs
+    );


### PR DESCRIPTION
## Summary

Adds thirteen dated `.surql` migrations (2026-04-20) so databases exported from SurrealDB 3.x (or partially migrated) can be normalized to the same SurrealQL the app and existing migration chain expect on **SurrealDB 2.6.x** (e.g. `COLUMNS` vs `FIELDS` where applicable, `SEARCH ANALYZER`, `type::is::none`, event bodies matching `20260418130000`).

## Included

- **user** — drop legacy `read` / `write` after `UPDATE user UNSET read, write` (REMOVE FIELD does not delete row data).
- **team**, **team_invitation**, **song**, **setlist**, **session**, **otp**, **migration_script**, **like**, **oidc_state**, **http_request_audit**, **collection**, **blob** — field/index/event OVERWRITE to match repo definitions.
- **song / setlist / collection / blob** — `UPDATE … UNSET teamowner` then `REMOVE FIELD IF EXISTS teamowner` (standalone drop migration removed; cleanup lives in each table’s align script).

## Testing

- `cargo test smoke_create_and_read_setlist` and targeted service tests during development.

## Ops note

If a database already recorded a removed migration filename (e.g. a one-off `drop_legacy_teamowner` script), reconcile `migration_script` checksums locally before deploying.

Made with [Cursor](https://cursor.com)