### PR TITLE
chore: rename worship-viewer identifiers to worshipviewer

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -84,7 +84,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: xilefmusics/worship-viewer
+          images: xilefmusics/worshipviewer
           tags: |
             type=ref,event=tag
             type=raw,value=main,enable={{is_default_branch}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ SHELL ["/bin/sh", "-c"]
 
 COPY --from=builder /usr/local/bin/venom /usr/local/bin/venom
 COPY --from=builder /wrk/backend/tests /app/tests
-COPY --from=builder /wrk/backend/target/release/backend /app/worship_viewer
+COPY --from=builder /wrk/backend/target/release/backend /app/worshipviewer
 COPY --from=builder /wrk/backend/db-migrations /app/db-migrations
 COPY --from=builder /wrk/frontend/dist/ /app/static
 
@@ -58,7 +58,7 @@ ENV INITIAL_ADMIN_USER_EMAIL="admin@example.com" \
     INITIAL_ADMIN_USER_TEST_SESSION=true
 
 RUN set -eux; \
-    ./worship_viewer & \
+    ./worshipviewer & \
     backend_pid=$!; \
     trap "kill $backend_pid 2>/dev/null || true" EXIT; \
     sleep 5; \
@@ -82,10 +82,10 @@ COPY --from=builder /usr/lib/x86_64-linux-gnu/libzstd.so.1 /usr/lib/x86_64-linux
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /usr/lib/x86_64-linux-gnu/libstdc++.so.6
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-COPY --from=tester /app/worship_viewer /app/worship_viewer
+COPY --from=tester /app/worshipviewer /app/worshipviewer
 COPY --from=builder /wrk/backend/db-migrations/ /app/db-migrations
 COPY --from=builder /wrk/frontend/dist/ /app/static
 
 EXPOSE 8080
 WORKDIR /app
-ENTRYPOINT ["/app/worship_viewer"]
+ENTRYPOINT ["/app/worshipviewer"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Worship Viewer
 
 A tool to help you lead worship — then step aside when the Spirit takes over.  
-Its main job is to manage and display digital sheet music; planned work and ideas are tracked in [GitHub issues](https://github.com/xilefmusics/worship_viewer/issues).
+Its main job is to manage and display digital sheet music; planned work and ideas are tracked in [GitHub issues](https://github.com/xilefmusics/worshipviewer/issues).
 
 ## Table of contents
 
@@ -26,13 +26,13 @@ Create your free account at [app.worshipviewer.com](https://app.worshipviewer.co
 Or run the published image locally (see [Local development](#local-development) to build from source):
 
 ```bash
-docker run --rm -p 8080:8080 xilefmusics/worship-viewer:latest
+docker run --rm -p 8080:8080 xilefmusics/worshipviewer:latest
 ```
 
 **Platform:** The image on Docker Hub is **linux/amd64**. On Apple Silicon or other **arm64** hosts, Docker may report *no matching manifest*; use emulation when needed:
 
 ```bash
-docker run --rm -p 8080:8080 --platform linux/amd64 xilefmusics/worship-viewer:latest
+docker run --rm -p 8080:8080 --platform linux/amd64 xilefmusics/worshipviewer:latest
 ```
 
 ## Local development
@@ -164,7 +164,7 @@ For authentication behavior (OTP, sessions, and constraints), see [`docs/busines
 
 ## Command-line interface (CLI)
 
-You can talk to the Worship Viewer REST API from the terminal with the AI-oriented CLI `worship-viewer`. It uses the same API as the frontend and is easy to script.
+You can talk to the Worship Viewer REST API from the terminal with the AI-oriented CLI `worshipviewer`. It uses the same API as the frontend and is easy to script.
 
 ### Installation
 
@@ -175,7 +175,7 @@ You can talk to the Worship Viewer REST API from the terminal with the AI-orient
 cargo install --path cli
 ```
 
-This installs a `worship-viewer` binary on your `$PATH`.
+This installs a `worshipviewer` binary on your `$PATH`.
 
 ### Configuration
 
@@ -193,14 +193,14 @@ The CLI can use flags, environment variables, or a config file. Precedence:
   ```
 - **Base URL** (backend address)
   - Flag: `--base-url`
-  - Env: `WORSHIP_VIEWER_BASE_URL`
+  - Env: `WORSHIPVIEWER_BASE_URL`
   - Config: `base_url`
   - Default: `http://127.0.0.1:8080`
 - **Authentication**
-  - Cookie (typical for local dev): `--sso-session`, env `WORSHIP_VIEWER_SSO_SESSION`, config `sso_session`. Sends `Cookie: sso_session=<value>` (backend cookie name is configurable; default matches).
-  - Bearer: `--bearer-token`, env `WORSHIP_VIEWER_BEARER_TOKEN` → `Authorization: Bearer …`.
-- **Timeout:** env `WORSHIP_VIEWER_TIMEOUT_SECS`, flag `--timeout-secs`.
-- **Output format:** global `--output auto|json|pretty|ndjson` or env **`WORSHIP_VIEWER_OUTPUT`** (same values).
+  - Cookie (typical for local dev): `--sso-session`, env `WORSHIPVIEWER_SSO_SESSION`, config `sso_session`. Sends `Cookie: sso_session=<value>` (backend cookie name is configurable; default matches).
+  - Bearer: `--bearer-token`, env `WORSHIPVIEWER_BEARER_TOKEN` → `Authorization: Bearer …`.
+- **Timeout:** env `WORSHIPVIEWER_TIMEOUT_SECS`, flag `--timeout-secs`.
+- **Output format:** global `--output auto|json|pretty|ndjson` or env **`WORSHIPVIEWER_OUTPUT`** (same values).
 
 ### Output and AI-friendly behavior
 
@@ -219,21 +219,21 @@ For scripts and agents, prefer `--output json` or `--output ndjson`.
 Inspect the API schema:
 
 ```bash
-worship-viewer schema --output json
-worship-viewer schema --path-prefix /api/v1/songs --output json
+worshipviewer schema --output json
+worshipviewer schema --path-prefix /api/v1/songs --output json
 ```
 
 List and get songs:
 
 ```bash
-worship-viewer songs list --output ndjson
-worship-viewer songs get --id <song_id> --output json
+worshipviewer songs list --output ndjson
+worshipviewer songs get --id <song_id> --output json
 ```
 
 Create or update with raw JSON:
 
 ```bash
-worship-viewer songs create \
+worshipviewer songs create \
   --json '{"not_a_song":false,"blobs":[],"data":{...}}' \
   --output json
 ```
@@ -241,7 +241,7 @@ worship-viewer songs create \
 Dry-run a mutating request:
 
 ```bash
-worship-viewer songs update \
+worshipviewer songs update \
   --id <song_id> \
   --json '{...}' \
   --dry-run \
@@ -262,14 +262,14 @@ sso_session = "admin"
 Then:
 
 ```bash
-worship-viewer songs list --output json
+worshipviewer songs list --output json
 ```
 
 ## Contribute
 
 This app is from worshippers for worshippers. Contributions are welcome — coding can be worship too.
 
-Use `cargo fmt` and `cargo clippy` on the crates you touch; open issues and pull requests on [GitHub](https://github.com/xilefmusics/worship_viewer).
+Use `cargo fmt` and `cargo clippy` on the crates you touch; open issues and pull requests on [GitHub](https://github.com/xilefmusics/worshipviewer).
 
 ## License
 

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -8179,7 +8179,7 @@
       "description": "OAuth/OIDC login, OTP email codes, and logout. Session cookies are set on successful auth (see authentication BLC).",
       "externalDocs": {
         "description": "Business logic constraints (markdown in repository).",
-        "url": "https://github.com/xilefmusics/worship_viewer/blob/main/docs/business-logic-constraints/authentication.md"
+        "url": "https://github.com/xilefmusics/worshipviewer/blob/main/docs/business-logic-constraints/authentication.md"
       },
       "name": "Auth"
     },
@@ -8187,7 +8187,7 @@
       "description": "Admin-only operational metrics and request audit listings under `/monitoring/`.",
       "externalDocs": {
         "description": "Business logic constraints (markdown in repository).",
-        "url": "https://github.com/xilefmusics/worship_viewer/blob/main/docs/business-logic-constraints/monitoring.md"
+        "url": "https://github.com/xilefmusics/worshipviewer/blob/main/docs/business-logic-constraints/monitoring.md"
       },
       "name": "Monitoring"
     },
@@ -8195,7 +8195,7 @@
       "description": "Current user (`/users/me`), directory listing, sessions (own and admin), and admin user lifecycle.",
       "externalDocs": {
         "description": "Business logic constraints (markdown in repository).",
-        "url": "https://github.com/xilefmusics/worship_viewer/blob/main/docs/business-logic-constraints/user.md"
+        "url": "https://github.com/xilefmusics/worshipviewer/blob/main/docs/business-logic-constraints/user.md"
       },
       "name": "Users"
     },
@@ -8203,7 +8203,7 @@
       "description": "Song CRUD, player JSON, likes, search/sort listing.",
       "externalDocs": {
         "description": "Business logic constraints (markdown in repository).",
-        "url": "https://github.com/xilefmusics/worship_viewer/blob/main/docs/business-logic-constraints/song.md"
+        "url": "https://github.com/xilefmusics/worshipviewer/blob/main/docs/business-logic-constraints/song.md"
       },
       "name": "Songs"
     },
@@ -8211,7 +8211,7 @@
       "description": "Owned song collections, nested songs, and player views.",
       "externalDocs": {
         "description": "Business logic constraints (markdown in repository).",
-        "url": "https://github.com/xilefmusics/worship_viewer/blob/main/docs/business-logic-constraints/collection.md"
+        "url": "https://github.com/xilefmusics/worshipviewer/blob/main/docs/business-logic-constraints/collection.md"
       },
       "name": "Collections"
     },
@@ -8219,7 +8219,7 @@
       "description": "Binary image assets: metadata, byte upload/download with cache headers.",
       "externalDocs": {
         "description": "Business logic constraints (markdown in repository).",
-        "url": "https://github.com/xilefmusics/worship_viewer/blob/main/docs/business-logic-constraints/blob.md"
+        "url": "https://github.com/xilefmusics/worshipviewer/blob/main/docs/business-logic-constraints/blob.md"
       },
       "name": "Blobs"
     },
@@ -8227,7 +8227,7 @@
       "description": "Ordered sets of songs and player payloads for services.",
       "externalDocs": {
         "description": "Business logic constraints (markdown in repository).",
-        "url": "https://github.com/xilefmusics/worship_viewer/blob/main/docs/business-logic-constraints/setlist.md"
+        "url": "https://github.com/xilefmusics/worshipviewer/blob/main/docs/business-logic-constraints/setlist.md"
       },
       "name": "Setlists"
     },
@@ -8235,7 +8235,7 @@
       "description": "Team membership, roles, and invitations (nested under `/teams/{id}/invitations`).",
       "externalDocs": {
         "description": "Business logic constraints (markdown in repository).",
-        "url": "https://github.com/xilefmusics/worship_viewer/blob/main/docs/business-logic-constraints/team.md"
+        "url": "https://github.com/xilefmusics/worshipviewer/blob/main/docs/business-logic-constraints/team.md"
       },
       "name": "Teams"
     }

--- a/backend/src/docs.rs
+++ b/backend/src/docs.rs
@@ -55,7 +55,7 @@ pub fn openapi_document(settings: &Settings) -> utoipa::openapi::OpenApi {
 }
 
 const BLC_GITHUB_BASE: &str =
-    "https://github.com/xilefmusics/worship_viewer/blob/main/docs/business-logic-constraints/";
+    "https://github.com/xilefmusics/worshipviewer/blob/main/docs/business-logic-constraints/";
 
 fn apply_openapi_runtime_metadata(doc: &mut utoipa::openapi::OpenApi, settings: &Settings) {
     let tag_docs: &[(&str, &str)] = &[

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -43,7 +43,7 @@ pub fn json_config() -> JsonConfig {
             .get::<crate::request_id::ApiRequestTarget>()
             .map(|t| t.0.clone());
         let problem = Problem::new(
-            "https://worship-viewer.invalid/problems/invalid_request".into(),
+            "https://worshipviewer.invalid/problems/invalid_request".into(),
             "Bad Request".into(),
             400,
             "invalid_request",
@@ -197,7 +197,7 @@ impl AppError {
     }
 
     fn problem_type_uri(&self) -> String {
-        format!("https://worship-viewer.invalid/problems/{}", self.code())
+        format!("https://worshipviewer.invalid/problems/{}", self.code())
     }
 
     fn detail_message(&self) -> String {

--- a/backend/src/governor_audit.rs
+++ b/backend/src/governor_audit.rs
@@ -24,7 +24,7 @@ pub fn rate_limit_problem_response(
         .as_secs();
     let detail = format!("rate limit exceeded; retry after {wait_time}s");
     let problem = Problem::new(
-        "https://worship-viewer.invalid/problems/too_many_requests".into(),
+        "https://worshipviewer.invalid/problems/too_many_requests".into(),
         "Too Many Requests".into(),
         429,
         "too_many_requests",

--- a/backend/src/http_tests.rs
+++ b/backend/src/http_tests.rs
@@ -60,7 +60,7 @@ pub(crate) fn build_app(
 
     // Use a throwaway temp path for blob storage; blobs are not written in these tests.
     let blob_dir = std::env::temp_dir()
-        .join("worship_viewer_http_tests_blobs")
+        .join("worshipviewer_http_tests_blobs")
         .to_string_lossy()
         .into_owned();
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "worship-viewer-cli"
+name = "worshipviewer-cli"
 version = "0.1.0"
 edition = "2021"
 
 [[bin]]
-name = "worship-viewer"
+name = "worshipviewer"
 path = "src/main.rs"
 
 [dependencies]

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -4,7 +4,7 @@ use crate::output::OutputFormat;
 
 #[derive(Debug, Parser)]
 #[command(
-    name = "worship-viewer",
+    name = "worshipviewer",
     version,
     about = "CLI for the Worship Viewer REST API"
 )]
@@ -15,12 +15,12 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub sso_session: Option<String>,
 
-    #[arg(long, env = "WORSHIP_VIEWER_BEARER_TOKEN", global = true)]
+    #[arg(long, env = "WORSHIPVIEWER_BEARER_TOKEN", global = true)]
     pub bearer_token: Option<String>,
 
     #[arg(
         long,
-        env = "WORSHIP_VIEWER_OUTPUT",
+        env = "WORSHIPVIEWER_OUTPUT",
         default_value = "auto",
         global = true
     )]
@@ -29,7 +29,7 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub dry_run: bool,
 
-    #[arg(long, env = "WORSHIP_VIEWER_TIMEOUT_SECS", global = true)]
+    #[arg(long, env = "WORSHIPVIEWER_TIMEOUT_SECS", global = true)]
     pub timeout_secs: Option<u64>,
 
     #[command(subcommand)]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -67,7 +67,7 @@ pub fn load_file_config() -> Result<FileConfig, Box<dyn std::error::Error>> {
 }
 
 fn resolve_base_url(cli_base: Option<String>, file_cfg: &FileConfig) -> String {
-    let env_base = env::var("WORSHIP_VIEWER_BASE_URL").ok();
+    let env_base = env::var("WORSHIPVIEWER_BASE_URL").ok();
     cli_base
         .or(env_base)
         .or(file_cfg.base_url.clone())
@@ -75,7 +75,7 @@ fn resolve_base_url(cli_base: Option<String>, file_cfg: &FileConfig) -> String {
 }
 
 fn resolve_sso_session(cli_sso: Option<String>, file_cfg: &FileConfig) -> Option<String> {
-    let env_sso = env::var("WORSHIP_VIEWER_SSO_SESSION").ok();
+    let env_sso = env::var("WORSHIPVIEWER_SSO_SESSION").ok();
     cli_sso.or(env_sso).or(file_cfg.sso_session.clone())
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -27,7 +27,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         if let Ok(mut f) = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
-            .open("/Users/xilef/Git/worship_viewer/.cursor/debug-3dd3ca.log")
+            .open("/Users/xilef/Git/worshipviewer/.cursor/debug-3dd3ca.log")
         {
             let _ = writeln!(
                 f,

--- a/docs/reviews/2026-04-18-architecture-review.md
+++ b/docs/reviews/2026-04-18-architecture-review.md
@@ -14,7 +14,7 @@ These items are real in code or delivery pipelines but are **absent** from `docs
 
 | Item | Where it lives | Notes |
 |------|----------------|-------|
-| **Docker Hub image** `xilefmusics/worship-viewer` | `.github/workflows/backend-ci.yml` (`docker-publish` job), `README.md` | Multi-stage build + push on `main` and tags; not depicted in architecture docs. |
+| **Docker Hub image** `xilefmusics/worshipviewer` | `.github/workflows/backend-ci.yml` (`docker-publish` job), `README.md` | Multi-stage build + push on `main` and tags; not depicted in architecture docs. |
 | **Venom** HTTP black-box tests | `Dockerfile` `tester` stage | Downloads Venom binary; runs `backend/tests/*.yml` against a spawned process before the final image. |
 | **Trunk** WASM build | `Dockerfile`, `README.md` | Frontend is compiled in CI image build; architecture docs do not mention the WASM toolchain. |
 

--- a/docs/reviews/2026-04-18-readme-review.md
+++ b/docs/reviews/2026-04-18-readme-review.md
@@ -24,7 +24,7 @@ Review of the repository root [`README.md`](../../README.md) against the current
 
 - **Single-origin frontend:** The Yew app uses `window.location.origin` as the API base ([`frontend/src/api/provider.rs`](../../frontend/src/api/provider.rs)). Running **only** `trunk serve` on port 8081 while the API listens on 8080 sends browser requests to `http://localhost:8081/...`, not the backend, unless a reverse proxy (e.g. Caddy) or Trunk proxy is configured. The README lists backend, then frontend, then Caddy as optional—**the minimal two-process flow is misleading** without Caddy or without building the SPA into `STATIC_DIR` and running a single backend process.
 - **`wasm32` target:** Required for `trunk build` / `trunk serve`; README mentions adding the target (good). No note that the repo’s [Dockerfile](../../Dockerfile) pins Rust **1.94.1** and Trunk **0.21.14** for reproducible builds.
-- **CLI:** [`WORSHIP_VIEWER_OUTPUT`](../../cli/src/commands.rs) exists as an environment variable for the global `--output` flag; README documents flags only, not this env var. The CLI’s [`load_file_config`](../../cli/src/config.rs) may **create** `~/.worshipviewer/config.toml` with defaults on first access—worth a one-line note for onboarding.
+- **CLI:** [`WORSHIPVIEWER_OUTPUT`](../../cli/src/commands.rs) exists as an environment variable for the global `--output` flag; README documents flags only, not this env var. The CLI’s [`load_file_config`](../../cli/src/config.rs) may **create** `~/.worshipviewer/config.toml` with defaults on first access—worth a one-line note for onboarding.
 
 ### Prerequisites
 
@@ -33,7 +33,7 @@ Review of the repository root [`README.md`](../../README.md) against the current
 ## 2. Documented but stale, inaccurate, or mismatched
 
 - **CLI section:** “see the steps in **Install Prerequisites** below” — that section is **above** the CLI block, not below (wording error).
-- **Docker quick start:** `docker run ... xilefmusics/worship-viewer:latest` — on **Apple Silicon (linux/arm64)** Docker reported *no matching manifest* for this image (image appears **amd64-only**). README should state platform requirements or `docker run --platform linux/amd64` where appropriate.
+- **Docker quick start:** `docker run ... xilefmusics/worshipviewer:latest` — on **Apple Silicon (linux/arm64)** Docker reported *no matching manifest* for this image (image appears **amd64-only**). README should state platform requirements or `docker run --platform linux/amd64` where appropriate.
 - **Typos in README (quality / trust):** e.g. “slieds”, “Spirt”, “worhip”, “spontanious”, “helps you lead” → grammar (“help”).
 - **“A lot more to come”** under the tagline is vague; either remove or point to issues/roadmap if one exists.
 
@@ -50,9 +50,9 @@ Review of the repository root [`README.md`](../../README.md) against the current
 | Backend: `cd backend` + `INITIAL_ADMIN_USER_EMAIL=...` `INITIAL_ADMIN_USER_TEST_SESSION=true` `cargo build` | **Succeeded** |
 | Backend: short `cargo run` | Process started (`target/debug/backend`); terminated after a few seconds for the test |
 | Frontend: `trunk build` in `frontend/` | **Failed** with `NO_COLOR=1` in the environment (`invalid value '1' for '--no-color'`). **Succeeded** after `env -u NO_COLOR trunk build` |
-| CLI: `cargo install --path cli` from repo root | **Succeeded**; installs binary `worship-viewer` (crate name `worship-viewer-cli`) |
+| CLI: `cargo install --path cli` from repo root | **Succeeded**; installs binary `worshipviewer` (crate name `worshipviewer-cli`) |
 | `https://app.worshipviewer.com` | **Reached** (HTTP fetch returned page content) |
-| `docker pull xilefmusics/worship-viewer:latest` | **Failed on arm64** (no manifest for `linux/arm64/v8`) |
+| `docker pull xilefmusics/worshipviewer:latest` | **Failed on arm64** (no manifest for `linux/arm64/v8`) |
 
 **Not executed here:** Full `caddy run` with the pasted JSON (Caddy not verified in this run). The config shape matches Caddy 2 JSON apps style; still worth a maintainer re-check on their installed Caddy version.
 
@@ -79,7 +79,7 @@ Aligned with common “Standard README” / “Awesome README” expectations:
 1. Fix the **frontend + API origin** story in README (Caddy as default dev path, or document `STATIC_DIR` + `trunk build` output copied into `backend/static`, or Trunk `[build.proxy]` if adopted).
 2. Document **Docker platform** (amd64 vs arm64) and optional `--platform linux/amd64`.
 3. Add a concise **environment variable** subsection or link to `Settings` / internal ops doc.
-4. Correct **CLI “below”** → “above”, document **`WORSHIP_VIEWER_OUTPUT`**, and mention **auto-created** `~/.worshipviewer/config.toml`.
+4. Correct **CLI “below”** → “above”, document **`WORSHIPVIEWER_OUTPUT`**, and mention **auto-created** `~/.worshipviewer/config.toml`.
 5. Note **`NO_COLOR=1`** + Trunk incompatibility or upstream tracking issue.
 6. Proofread typos; add **CONTRIBUTING** (or link) if the project welcomes PRs.
 

--- a/frontend/src/components/presenter/slide_sync.rs
+++ b/frontend/src/components/presenter/slide_sync.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use wasm_bindgen::prelude::*;
 use web_sys::window;
 
-const STORAGE_KEY: &str = "worship_viewer_slide_data";
+const STORAGE_KEY: &str = "worshipviewer_slide_data";
 
 pub struct SlideSync {
     _closure: Rc<RefCell<Option<Closure<dyn FnMut(web_sys::StorageEvent)>>>>,


### PR DESCRIPTION
- CLI crate/binary worshipviewer-cli / worshipviewer; WORSHIPVIEWER_* env vars
- Docker image and container binary path; CI docker-publish image name
- RFC 7807 problem URIs, OpenAPI external docs, presenter localStorage key
- Docs and README aligned; HTTP test temp dir prefix

Made-with: Cursor
