### PR TITLE
feat(api): optional owner on create and POST move for library resources

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -164,6 +164,7 @@
           "file_type": "image/png",
           "height": 800,
           "ocr": "",
+          "owner": "team_example_id",
           "width": 1200
         },
         "properties": {
@@ -177,6 +178,11 @@
           },
           "ocr": {
             "description": "OCR or extracted text used for search (may be empty).",
+            "type": "string"
+          },
+          "owner": {
+            "description": "Owning team id (same format as `Blob.owner` in responses). Omit to create under the caller's personal team.",
+            "nullable": true,
             "type": "string"
           },
           "width": {
@@ -197,6 +203,7 @@
         "additionalProperties": false,
         "example": {
           "cover": "",
+          "owner": "team_example_id",
           "songs": [
             {
               "id": "song_example",
@@ -208,6 +215,11 @@
         },
         "properties": {
           "cover": {
+            "type": "string"
+          },
+          "owner": {
+            "description": "Owning team id (`team` record id, same format as `Collection.owner` in responses). Omit to create under the caller's personal team.",
+            "nullable": true,
             "type": "string"
           },
           "songs": {
@@ -230,6 +242,7 @@
       "CreateSetlist": {
         "additionalProperties": false,
         "example": {
+          "owner": "team_example_id",
           "songs": [
             {
               "id": "song_example",
@@ -240,6 +253,11 @@
           "title": "Easter Sunday"
         },
         "properties": {
+          "owner": {
+            "description": "Owning team id (same format as `Setlist.owner` in responses). Omit to create under the caller's personal team.",
+            "nullable": true,
+            "type": "string"
+          },
           "songs": {
             "items": {
               "$ref": "#/components/schemas/SongLink"
@@ -266,7 +284,8 @@
               "Example Hymn"
             ]
           },
-          "not_a_song": false
+          "not_a_song": false,
+          "owner": "team_example_id"
         },
         "properties": {
           "blobs": {
@@ -280,6 +299,11 @@
           },
           "not_a_song": {
             "type": "boolean"
+          },
+          "owner": {
+            "description": "Owning team id (same format as `Song.owner` in responses). Omit to create under the caller's personal team (and apply default-collection rules).",
+            "nullable": true,
+            "type": "string"
           }
         },
         "required": [
@@ -758,6 +782,22 @@
           "engagement",
           "admin_monitoring",
           "probing"
+        ],
+        "type": "object"
+      },
+      "MoveOwner": {
+        "additionalProperties": false,
+        "description": "Target owning team for a library resource move (`owner` string matches GET responses).",
+        "example": {
+          "owner": "team_target_id"
+        },
+        "properties": {
+          "owner": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner"
         ],
         "type": "object"
       },
@@ -2231,7 +2271,7 @@
                 }
               }
             },
-            "description": "Create a new blob"
+            "description": "Create a new blob metadata record. Optional `owner` is a team id; omit for the caller's personal team. Library edit access is required on the target team."
           },
           "400": {
             "content": {
@@ -2252,6 +2292,16 @@
               }
             },
             "description": "Authentication required"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Target team not found or caller cannot edit that team's library"
           },
           "429": {
             "content": {
@@ -2888,6 +2938,105 @@
         ]
       }
     },
+    "/api/v1/blobs/{id}/move": {
+      "post": {
+        "operationId": "move_blob",
+        "parameters": [
+          {
+            "description": "Blob identifier",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveOwner"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Blob"
+                }
+              }
+            },
+            "description": "Blob moved to the target team, or unchanged when already owned by that team (idempotent)."
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Invalid `owner` team id"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Blob not found, target team not found, or caller lacks library write access on the current or destination team"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Failed to move blob"
+          }
+        },
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "SessionToken": []
+          }
+        ],
+        "tags": [
+          "Blobs"
+        ]
+      }
+    },
     "/api/v1/collections": {
       "get": {
         "operationId": "get_collections",
@@ -3017,7 +3166,7 @@
                 }
               }
             },
-            "description": "Create a new collection"
+            "description": "Create a new collection. Optional request field `owner` is a team id (same format as `Collection.owner`); omit to create under the caller's personal team. Library edit access is required on the target team."
           },
           "400": {
             "content": {
@@ -3038,6 +3187,16 @@
               }
             },
             "description": "Authentication required"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Target team not found or caller cannot edit that team's library"
           },
           "429": {
             "content": {
@@ -3454,6 +3613,105 @@
               }
             },
             "description": "Failed to update collection"
+          }
+        },
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "SessionToken": []
+          }
+        ],
+        "tags": [
+          "Collections"
+        ]
+      }
+    },
+    "/api/v1/collections/{id}/move": {
+      "post": {
+        "operationId": "move_collection",
+        "parameters": [
+          {
+            "description": "Collection identifier",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveOwner"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Collection"
+                }
+              }
+            },
+            "description": "Collection moved to the target team, or unchanged when already owned by that team (idempotent)."
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Invalid `owner` team id"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Collection not found, target team not found, or caller lacks library write access on the current or destination team"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Failed to move collection"
           }
         },
         "security": [
@@ -4103,7 +4361,7 @@
                 }
               }
             },
-            "description": "Create a new setlist"
+            "description": "Create a new setlist. Optional `owner` is a team id; omit for the caller's personal team. Library edit access is required on the target team."
           },
           "400": {
             "content": {
@@ -4124,6 +4382,16 @@
               }
             },
             "description": "Authentication required"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Target team not found or caller cannot edit that team's library"
           },
           "429": {
             "content": {
@@ -4555,6 +4823,105 @@
         ]
       }
     },
+    "/api/v1/setlists/{id}/move": {
+      "post": {
+        "operationId": "move_setlist",
+        "parameters": [
+          {
+            "description": "Setlist identifier",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveOwner"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Setlist"
+                }
+              }
+            },
+            "description": "Setlist moved to the target team, or unchanged when already owned by that team (idempotent)."
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Invalid `owner` team id"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Setlist not found, target team not found, or caller lacks library write access on the current or destination team"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Failed to move setlist"
+          }
+        },
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "SessionToken": []
+          }
+        ],
+        "tags": [
+          "Setlists"
+        ]
+      }
+    },
     "/api/v1/setlists/{id}/player": {
       "get": {
         "operationId": "get_setlist_player",
@@ -4931,7 +5298,7 @@
                 }
               }
             },
-            "description": "Create a new song. If the user has no default collection yet, the server may create a system \"Default\" collection and set it as `user.default_collection` (BLC-SONG-010)."
+            "description": "Create a new song. Optional `owner` is a team id; omit for the caller's personal team. When the effective target is the personal team, default-collection behavior may apply (BLC-SONG-010). When `owner` names a different team the song is created there without that default-collection side effect. Library edit access is required on the target team."
           },
           "400": {
             "content": {
@@ -4952,6 +5319,16 @@
               }
             },
             "description": "Authentication required"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Target team not found or caller cannot edit that team's library"
           },
           "429": {
             "content": {
@@ -5627,6 +6004,105 @@
               }
             },
             "description": "Failed to update like status for a song"
+          }
+        },
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "SessionToken": []
+          }
+        ],
+        "tags": [
+          "Songs"
+        ]
+      }
+    },
+    "/api/v1/songs/{id}/move": {
+      "post": {
+        "operationId": "move_song",
+        "parameters": [
+          {
+            "description": "Song identifier",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveOwner"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Song"
+                }
+              }
+            },
+            "description": "Song moved to the target team, or unchanged when already owned by that team (idempotent). Moving does not add or remove the song from collections."
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Invalid `owner` team id"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Song not found, target team not found, or caller lacks library write access on the current or destination team"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Failed to move song"
           }
         },
         "security": [

--- a/backend/src/docs.rs
+++ b/backend/src/docs.rs
@@ -21,6 +21,7 @@ use crate::resources::{
     Blob, Collection, CreateBlob, CreateCollection, CreateSetlist, CreateSong, CreateUser, Setlist,
     Song, UpdateBlob, UpdateCollection, UpdateSetlist, UpdateSong, User,
 };
+use shared::MoveOwner;
 use shared::api::SongListQuery;
 use shared::auth::otp::{OtpRequest, OtpVerify};
 use shared::blob::{BlobLink, FileType};
@@ -137,6 +138,7 @@ fn apply_openapi_runtime_metadata(doc: &mut utoipa::openapi::OpenApi, settings: 
         crate::resources::song::rest::create_song,
         crate::resources::song::rest::update_song,
         crate::resources::song::rest::patch_song,
+        crate::resources::song::rest::move_song,
         crate::resources::song::rest::delete_song,
         crate::resources::song::rest::get_song_like_status,
         crate::resources::song::rest::put_song_like,
@@ -148,12 +150,14 @@ fn apply_openapi_runtime_metadata(doc: &mut utoipa::openapi::OpenApi, settings: 
         crate::resources::collection::rest::create_collection,
         crate::resources::collection::rest::update_collection,
         crate::resources::collection::rest::patch_collection,
+        crate::resources::collection::rest::move_collection,
         crate::resources::collection::rest::delete_collection,
         crate::resources::blob::rest::get_blobs,
         crate::resources::blob::rest::get_blob,
         crate::resources::blob::rest::create_blob,
         crate::resources::blob::rest::update_blob,
         crate::resources::blob::rest::patch_blob,
+        crate::resources::blob::rest::move_blob,
         crate::resources::blob::rest::delete_blob,
         crate::resources::blob::rest::download_blob_image,
         crate::resources::blob::rest::upload_blob_data,
@@ -164,6 +168,7 @@ fn apply_openapi_runtime_metadata(doc: &mut utoipa::openapi::OpenApi, settings: 
         crate::resources::setlist::rest::create_setlist,
         crate::resources::setlist::rest::update_setlist,
         crate::resources::setlist::rest::patch_setlist,
+        crate::resources::setlist::rest::move_setlist,
         crate::resources::setlist::rest::delete_setlist,
         crate::resources::team::rest::get_teams,
         crate::resources::team::rest::get_team,
@@ -193,6 +198,7 @@ fn apply_openapi_runtime_metadata(doc: &mut utoipa::openapi::OpenApi, settings: 
             Problem,
             ErrorResponse,
             ProblemDetails,
+            MoveOwner,
             Song,
             CreateSong,
             UpdateSong,

--- a/backend/src/resources/blob/model.rs
+++ b/backend/src/resources/blob/model.rs
@@ -64,13 +64,20 @@ impl BlobRecord {
         created_at: Option<Datetime>,
         blob: CreateBlob,
     ) -> Self {
+        let CreateBlob {
+            file_type,
+            width,
+            height,
+            ocr,
+            ..
+        } = blob;
         Self {
             id,
             owner,
-            file_type: FileTypeField(blob.file_type),
-            width: blob.width,
-            height: blob.height,
-            ocr: blob.ocr,
+            file_type: FileTypeField(file_type),
+            width,
+            height,
+            ocr,
             created_at,
         }
     }
@@ -89,6 +96,7 @@ mod tests {
             Some(owner.clone()),
             None,
             CreateBlob {
+                owner: None,
                 file_type: FileType::SVG,
                 width: 640,
                 height: 480,

--- a/backend/src/resources/blob/repository.rs
+++ b/backend/src/resources/blob/repository.rs
@@ -24,7 +24,7 @@ pub trait BlobRepository: Send + Sync {
 
     async fn get_blob(&self, read_teams: &[RecordId], id: &str) -> Result<Blob, AppError>;
 
-    async fn create_blob(&self, owner: &str, blob: CreateBlob) -> Result<Blob, AppError>;
+    async fn create_blob(&self, owner: RecordId, blob: CreateBlob) -> Result<Blob, AppError>;
 
     async fn update_blob(
         &self,
@@ -34,4 +34,11 @@ pub trait BlobRepository: Send + Sync {
     ) -> Result<Blob, AppError>;
 
     async fn delete_blob(&self, write_teams: &[RecordId], id: &str) -> Result<Blob, AppError>;
+
+    async fn move_blob_owner(
+        &self,
+        write_teams: &[RecordId],
+        id: &str,
+        new_owner: RecordId,
+    ) -> Result<Blob, AppError>;
 }

--- a/backend/src/resources/blob/rest.rs
+++ b/backend/src/resources/blob/rest.rs
@@ -17,6 +17,7 @@ use crate::resources::blob::PatchBlob;
 use crate::resources::blob::service::BlobServiceHandle;
 use crate::resources::blob::{CreateBlob, UpdateBlob};
 use crate::resources::team::UserPermissions;
+use shared::MoveOwner;
 use shared::api::{ListQuery, PAGE_SIZE_DEFAULT};
 
 pub fn scope(blob_upload_max_bytes: usize) -> Scope {
@@ -26,6 +27,7 @@ pub fn scope(blob_upload_max_bytes: usize) -> Scope {
         .service(create_blob)
         .service(update_blob)
         .service(patch_blob)
+        .service(move_blob)
         .service(delete_blob)
         .service(download_blob_image)
         .service(
@@ -137,9 +139,10 @@ async fn get_blob(
     path = "/api/v1/blobs",
     request_body = CreateBlob,
     responses(
-        (status = 201, description = "Create a new blob", body = Blob),
+        (status = 201, description = "Create a new blob metadata record. Optional `owner` is a team id; omit for the caller's personal team. Library edit access is required on the target team.", body = Blob),
         (status = 400, description = "Invalid blob payload", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 404, description = "Target team not found or caller cannot edit that team's library", body = Problem, content_type = "application/problem+json"),
         (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to create blob", body = Problem, content_type = "application/problem+json")
     ),
@@ -238,6 +241,41 @@ async fn patch_blob(
     check_if_match(&req, &etag)?;
     Ok(HttpResponse::Ok().json(
         svc.patch_blob_for_user(&perms, &id, payload.into_inner())
+            .await?,
+    ))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/blobs/{id}/move",
+    params(
+        ("id" = String, Path, description = "Blob identifier")
+    ),
+    request_body = MoveOwner,
+    responses(
+        (status = 200, description = "Blob moved to the target team, or unchanged when already owned by that team (idempotent).", body = Blob),
+        (status = 400, description = "Invalid `owner` team id", body = Problem, content_type = "application/problem+json"),
+        (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
+        (status = 404, description = "Blob not found, target team not found, or caller lacks library write access on the current or destination team", body = Problem, content_type = "application/problem+json"),
+        (status = 500, description = "Failed to move blob", body = Problem, content_type = "application/problem+json")
+    ),
+    tag = "Blobs",
+    security(
+        ("SessionCookie" = []),
+        ("SessionToken" = [])
+    )
+)]
+#[post("/{id}/move")]
+async fn move_blob(
+    svc: Data<BlobServiceHandle>,
+    user: ReqData<User>,
+    id: PathParam<String>,
+    payload: Json<MoveOwner>,
+) -> Result<HttpResponse, AppError> {
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
+    Ok(HttpResponse::Ok().json(
+        svc.move_blob_for_user(&perms, &id.into_inner(), payload.into_inner())
             .await?,
     ))
 }

--- a/backend/src/resources/blob/service.rs
+++ b/backend/src/resources/blob/service.rs
@@ -3,12 +3,15 @@ use std::sync::Arc;
 use actix_files::NamedFile;
 use tracing::instrument;
 
+use shared::MoveOwner;
 use shared::api::ListQuery;
 use shared::blob::{Blob, CreateBlob, PatchBlob};
 
 use crate::database::Database;
 use crate::error::AppError;
-use crate::resources::team::{TeamResolver, UserPermissions};
+use crate::resources::team::{
+    TeamResolver, UserPermissions, parse_owner_record_id, thing_record_key,
+};
 
 use super::repository::BlobRepository;
 use super::storage::BlobStorage;
@@ -68,9 +71,17 @@ impl<R: BlobRepository, T: TeamResolver, S: BlobStorage> BlobService<R, T, S> {
     pub async fn create_blob_for_user(
         &self,
         perms: &UserPermissions<T>,
-        blob: CreateBlob,
+        mut blob: CreateBlob,
     ) -> Result<Blob, AppError> {
-        let created = self.repo.create_blob(&perms.user().id, blob).await?;
+        let owner = match blob.owner.take() {
+            None => perms.personal_team().await?,
+            Some(ref s) => {
+                let rid = parse_owner_record_id(s)?;
+                perms.require_write_access_to_owner(&rid).await?;
+                rid
+            }
+        };
+        let created = self.repo.create_blob(owner, blob).await?;
         self.storage.write_blob_file(&created)?;
         Ok(created)
     }
@@ -97,12 +108,32 @@ impl<R: BlobRepository, T: TeamResolver, S: BlobStorage> BlobService<R, T, S> {
     ) -> Result<Blob, AppError> {
         let current = self.get_blob_for_user(perms, id).await?;
         let merged = CreateBlob {
+            owner: None,
             file_type: patch.file_type.unwrap_or(current.file_type),
             width: patch.width.unwrap_or(current.width),
             height: patch.height.unwrap_or(current.height),
             ocr: patch.ocr.unwrap_or(current.ocr),
         };
         self.update_blob_for_user(perms, id, merged).await
+    }
+
+    #[instrument(level = "debug", err, skip(self, perms, payload))]
+    pub async fn move_blob_for_user(
+        &self,
+        perms: &UserPermissions<T>,
+        id: &str,
+        payload: MoveOwner,
+    ) -> Result<Blob, AppError> {
+        let blob = self.get_blob_for_user(perms, id).await?;
+        let current = parse_owner_record_id(&blob.owner)?;
+        let dest = parse_owner_record_id(&payload.owner)?;
+        if thing_record_key(&current) == thing_record_key(&dest) {
+            return Ok(blob);
+        }
+        perms.require_write_access_to_owner(&current).await?;
+        perms.require_write_access_to_owner(&dest).await?;
+        let write_teams = perms.write_teams().await?;
+        self.repo.move_blob_owner(write_teams, id, dest).await
     }
 
     #[instrument(level = "debug", err, skip(self, perms))]
@@ -221,7 +252,7 @@ mod tests {
                 .ok_or_else(|| AppError::NotFound("blob not found".into()))
         }
 
-        async fn create_blob(&self, _owner: &str, blob: CreateBlob) -> Result<Blob, AppError> {
+        async fn create_blob(&self, _owner: RecordId, blob: CreateBlob) -> Result<Blob, AppError> {
             Ok(Blob {
                 id: "new".into(),
                 owner: "team".into(),
@@ -254,6 +285,15 @@ mod tests {
                 .cloned()
                 .ok_or_else(|| AppError::NotFound("blob not found".into()))
         }
+
+        async fn move_blob_owner(
+            &self,
+            _write_teams: &[RecordId],
+            _id: &str,
+            _new_owner: RecordId,
+        ) -> Result<Blob, AppError> {
+            unreachable!("not used in these tests")
+        }
     }
 
     struct MockTeams;
@@ -266,8 +306,8 @@ mod tests {
         async fn content_write_teams(&self, _user: &User) -> Result<Vec<RecordId>, AppError> {
             Ok(vec![])
         }
-        async fn personal_team(&self, _user_id: &str) -> Result<RecordId, AppError> {
-            Err(AppError::database("unused"))
+        async fn personal_team(&self, user_id: &str) -> Result<RecordId, AppError> {
+            Ok(RecordId::new("team", user_id.to_owned()))
         }
     }
 
@@ -316,6 +356,7 @@ mod tests {
             .create_blob_for_user(
                 &perms,
                 CreateBlob {
+                    owner: None,
                     file_type: FileType::PNG,
                     width: 1,
                     height: 1,
@@ -370,6 +411,7 @@ mod tests {
             .create_blob_for_user(
                 &owner_perms,
                 CreateBlob {
+                    owner: None,
                     file_type: FileType::PNG,
                     width: 10,
                     height: 10,
@@ -453,6 +495,7 @@ mod tests {
             .create_blob_for_user(
                 &owner_p,
                 CreateBlob {
+                    owner: None,
                     file_type: FileType::PNG,
                     width: 1,
                     height: 1,
@@ -478,6 +521,7 @@ mod tests {
             .create_blob_for_user(
                 &owner_p,
                 CreateBlob {
+                    owner: None,
                     file_type: FileType::PNG,
                     width: 1,
                     height: 1,
@@ -490,6 +534,7 @@ mod tests {
             &cm_p,
             &b.id,
             CreateBlob {
+                owner: None,
                 file_type: FileType::JPEG,
                 width: 2,
                 height: 2,
@@ -513,6 +558,7 @@ mod tests {
             .create_blob_for_user(
                 &owner_p,
                 CreateBlob {
+                    owner: None,
                     file_type: FileType::PNG,
                     width: 1,
                     height: 1,
@@ -526,6 +572,7 @@ mod tests {
                 &guest_p,
                 &b.id,
                 CreateBlob {
+                    owner: None,
                     file_type: FileType::JPEG,
                     width: 2,
                     height: 2,
@@ -549,6 +596,7 @@ mod tests {
             .create_blob_for_user(
                 &owner_p,
                 CreateBlob {
+                    owner: None,
                     file_type: FileType::PNG,
                     width: 1,
                     height: 1,
@@ -573,6 +621,7 @@ mod tests {
             .create_blob_for_user(
                 &owner_p,
                 CreateBlob {
+                    owner: None,
                     file_type: FileType::PNG,
                     width: 1,
                     height: 1,
@@ -585,6 +634,7 @@ mod tests {
             &owner_p,
             &b.id,
             CreateBlob {
+                owner: None,
                 file_type: FileType::JPEG,
                 width: 5,
                 height: 5,
@@ -607,6 +657,7 @@ mod tests {
             .create_blob_for_user(
                 &owner_p,
                 CreateBlob {
+                    owner: None,
                     file_type: FileType::PNG,
                     width: 1,
                     height: 1,
@@ -621,6 +672,7 @@ mod tests {
                 &owner_p,
                 &b.id,
                 CreateBlob {
+                    owner: None,
                     file_type: FileType::JPEG,
                     width: 2,
                     height: 2,
@@ -644,6 +696,7 @@ mod tests {
             .create_blob_for_user(
                 &owner_p,
                 CreateBlob {
+                    owner: None,
                     file_type: FileType::PNG,
                     width: 1,
                     height: 1,
@@ -667,6 +720,7 @@ mod tests {
             .create_blob_for_user(
                 &owner_p,
                 CreateBlob {
+                    owner: None,
                     file_type: FileType::JPEG,
                     width: 1,
                     height: 1,
@@ -690,6 +744,7 @@ mod tests {
             .create_blob_for_user(
                 &owner_p,
                 CreateBlob {
+                    owner: None,
                     file_type: FileType::SVG,
                     width: 1,
                     height: 1,
@@ -715,6 +770,7 @@ mod tests {
             .create_blob_for_user(
                 &owner_p,
                 CreateBlob {
+                    owner: None,
                     file_type: FileType::PNG,
                     width: 1,
                     height: 1,
@@ -760,6 +816,7 @@ mod tests {
             .create_blob_for_user(
                 &owner_p,
                 CreateBlob {
+                    owner: None,
                     file_type: FileType::PNG,
                     width: 100,
                     height: 200,
@@ -841,6 +898,7 @@ mod tests {
                 .create_blob_for_user(
                     &perms,
                     CreateBlob {
+                        owner: None,
                         file_type: FileType::PNG,
                         width: 100,
                         height: 200,
@@ -887,5 +945,60 @@ mod tests {
             );
             assert_eq!(patched.ocr, expected_ocr, "mask={mask:04b}: ocr mismatch");
         }
+    }
+
+    /// BLC-BLOB-017–018: move between shared teams and idempotent same-owner.
+    #[tokio::test]
+    async fn blc_blob_017_move_between_teams_and_idempotent() {
+        use crate::test_helpers::{blob_service, create_user, test_db, two_shared_teams_for_user};
+        use shared::MoveOwner;
+
+        let blob_dir = tempfile::tempdir().expect("tempdir");
+        let db = test_db().await.expect("db");
+        let svc = blob_service(&db, blob_dir.path().to_string_lossy().into_owned());
+        let mover = create_user(&db, "blob-move@test.local")
+            .await
+            .expect("mover");
+        let (team_a, team_b) = two_shared_teams_for_user(&db, &mover).await.expect("teams");
+        let p = UserPermissions::from_ref(&mover, &svc.teams);
+
+        let b = svc
+            .create_blob_for_user(
+                &p,
+                CreateBlob {
+                    owner: Some(team_a.clone()),
+                    file_type: FileType::PNG,
+                    width: 1,
+                    height: 1,
+                    ocr: String::new(),
+                },
+            )
+            .await
+            .expect("create");
+        assert_eq!(b.owner, team_a);
+
+        let on_b = svc
+            .move_blob_for_user(
+                &p,
+                &b.id,
+                MoveOwner {
+                    owner: team_b.clone(),
+                },
+            )
+            .await
+            .expect("to B");
+        assert_eq!(on_b.owner, team_b);
+
+        let idem = svc
+            .move_blob_for_user(
+                &p,
+                &b.id,
+                MoveOwner {
+                    owner: team_b.clone(),
+                },
+            )
+            .await
+            .expect("idem");
+        assert_eq!(idem.owner, team_b);
     }
 }

--- a/backend/src/resources/blob/surreal_repo.rs
+++ b/backend/src/resources/blob/surreal_repo.rs
@@ -127,14 +127,13 @@ impl BlobRepository for SurrealBlobRepo {
         }
     }
 
-    async fn create_blob(&self, owner: &str, blob: CreateBlob) -> Result<Blob, AppError> {
+    async fn create_blob(&self, owner: RecordId, blob: CreateBlob) -> Result<Blob, AppError> {
         let db = self.inner();
-        let owner_team = db.personal_team_thing_for_user(owner).await?;
         db.db
             .create("blob")
             .content(BlobRecord::from_payload(
                 None,
-                Some(owner_team),
+                Some(owner),
                 Some(Utc::now().into()),
                 blob,
             ))
@@ -182,6 +181,32 @@ impl BlobRepository for SurrealBlobRepo {
             .query("DELETE FROM type::record($tb, $sid) WHERE owner IN $teams RETURN BEFORE")
             .bind(("tb", tb))
             .bind(("sid", sid))
+            .bind(("teams", write_teams.to_vec()))
+            .await?;
+
+        let rows: Vec<BlobRecord> = response.take(0)?;
+        rows.into_iter()
+            .next()
+            .map(BlobRecord::into_blob)
+            .ok_or_else(|| AppError::NotFound("blob not found".into()))
+    }
+
+    async fn move_blob_owner(
+        &self,
+        write_teams: &[RecordId],
+        id: &str,
+        new_owner: RecordId,
+    ) -> Result<Blob, AppError> {
+        let db = self.inner();
+        let (tb, sid) = resource_id("blob", id)?;
+        let mut response = db
+            .db
+            .query(
+                "UPDATE type::record($tb, $sid) SET owner = $new_owner WHERE owner IN $teams RETURN AFTER",
+            )
+            .bind(("tb", tb))
+            .bind(("sid", sid))
+            .bind(("new_owner", new_owner))
             .bind(("teams", write_teams.to_vec()))
             .await?;
 

--- a/backend/src/resources/collection/model.rs
+++ b/backend/src/resources/collection/model.rs
@@ -34,12 +34,18 @@ impl CollectionRecord {
         owner: Option<RecordId>,
         collection: CreateCollection,
     ) -> Self {
+        let CreateCollection {
+            title,
+            cover,
+            songs,
+            ..
+        } = collection;
         Self {
             id,
             owner,
-            title: collection.title,
-            cover: Some(blob_thing(&collection.cover)),
-            songs: collection.songs.into_iter().map(Into::into).collect(),
+            title,
+            cover: Some(blob_thing(&cover)),
+            songs: songs.into_iter().map(Into::into).collect(),
         }
     }
 }
@@ -58,6 +64,7 @@ mod tests {
             Some(id.clone()),
             Some(owner.clone()),
             CreateCollection {
+                owner: None,
                 title: "Hits".into(),
                 cover: "blob:cover1".into(),
                 songs: vec![SongLink {

--- a/backend/src/resources/collection/repository.rs
+++ b/backend/src/resources/collection/repository.rs
@@ -37,7 +37,7 @@ pub trait CollectionRepository: Send + Sync {
 
     async fn create_collection(
         &self,
-        owner: &str,
+        owner: RecordId,
         collection: CreateCollection,
     ) -> Result<Collection, AppError>;
 
@@ -52,6 +52,14 @@ pub trait CollectionRepository: Send + Sync {
         &self,
         write_teams: &[RecordId],
         id: &str,
+    ) -> Result<Collection, AppError>;
+
+    /// Sets `owner` when the row is currently owned by a team in `write_teams`.
+    async fn move_collection_owner(
+        &self,
+        write_teams: &[RecordId],
+        id: &str,
+        new_owner: RecordId,
     ) -> Result<Collection, AppError>;
 
     async fn add_song_to_collection(

--- a/backend/src/resources/collection/rest.rs
+++ b/backend/src/resources/collection/rest.rs
@@ -18,6 +18,7 @@ use crate::resources::collection::{CreateCollection, UpdateCollection};
 #[allow(unused_imports)]
 use crate::resources::song::Song;
 use crate::resources::team::UserPermissions;
+use shared::MoveOwner;
 use shared::api::{ListQuery, PAGE_SIZE_DEFAULT, PageQuery};
 #[allow(unused_imports)]
 use shared::player::Player;
@@ -31,6 +32,7 @@ pub fn scope() -> Scope {
         .service(create_collection)
         .service(update_collection)
         .service(patch_collection)
+        .service(move_collection)
         .service(delete_collection)
 }
 
@@ -236,9 +238,10 @@ async fn get_collection_songs(
     path = "/api/v1/collections",
     request_body = CreateCollection,
     responses(
-        (status = 201, description = "Create a new collection", body = Collection),
+        (status = 201, description = "Create a new collection. Optional request field `owner` is a team id (same format as `Collection.owner`); omit to create under the caller's personal team. Library edit access is required on the target team.", body = Collection),
         (status = 400, description = "Invalid collection payload", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 404, description = "Target team not found or caller cannot edit that team's library", body = Problem, content_type = "application/problem+json"),
         (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to create collection", body = Problem, content_type = "application/problem+json")
     ),
@@ -339,6 +342,41 @@ async fn patch_collection(
     check_if_match(&req, &etag)?;
     Ok(HttpResponse::Ok().json(
         svc.patch_collection_for_user(&perms, &id, payload.into_inner())
+            .await?,
+    ))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/collections/{id}/move",
+    params(
+        ("id" = String, Path, description = "Collection identifier")
+    ),
+    request_body = MoveOwner,
+    responses(
+        (status = 200, description = "Collection moved to the target team, or unchanged when already owned by that team (idempotent).", body = Collection),
+        (status = 400, description = "Invalid `owner` team id", body = Problem, content_type = "application/problem+json"),
+        (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
+        (status = 404, description = "Collection not found, target team not found, or caller lacks library write access on the current or destination team", body = Problem, content_type = "application/problem+json"),
+        (status = 500, description = "Failed to move collection", body = Problem, content_type = "application/problem+json")
+    ),
+    tag = "Collections",
+    security(
+        ("SessionCookie" = []),
+        ("SessionToken" = [])
+    )
+)]
+#[post("/{id}/move")]
+async fn move_collection(
+    svc: Data<CollectionServiceHandle>,
+    user: ReqData<User>,
+    id: Path<String>,
+    payload: Json<MoveOwner>,
+) -> Result<HttpResponse, AppError> {
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
+    Ok(HttpResponse::Ok().json(
+        svc.move_collection_for_user(&perms, &id.into_inner(), payload.into_inner())
             .await?,
     ))
 }

--- a/backend/src/resources/collection/service.rs
+++ b/backend/src/resources/collection/service.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use shared::MoveOwner;
 use shared::api::ListQuery;
 use shared::collection::{Collection, CreateCollection, PatchCollection};
 use shared::player::Player;
@@ -10,7 +11,9 @@ use crate::database::Database;
 use crate::error::AppError;
 use crate::resources::common::player_from_song_links;
 use crate::resources::song::LikedSongIds;
-use crate::resources::team::{TeamResolver, UserPermissions};
+use crate::resources::team::{
+    TeamResolver, UserPermissions, parse_owner_record_id, thing_record_key,
+};
 
 use super::repository::CollectionRepository;
 use super::surreal_repo::SurrealCollectionRepo;
@@ -103,11 +106,17 @@ impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionServic
     pub async fn create_collection_for_user(
         &self,
         perms: &UserPermissions<T>,
-        collection: CreateCollection,
+        mut collection: CreateCollection,
     ) -> Result<Collection, AppError> {
-        self.repo
-            .create_collection(&perms.user().id, collection)
-            .await
+        let owner = match collection.owner.take() {
+            None => perms.personal_team().await?,
+            Some(ref s) => {
+                let rid = parse_owner_record_id(s)?;
+                perms.require_write_access_to_owner(&rid).await?;
+                rid
+            }
+        };
+        self.repo.create_collection(owner, collection).await
     }
 
     #[instrument(level = "debug", err, skip(self, perms, collection))]
@@ -132,11 +141,31 @@ impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionServic
     ) -> Result<Collection, AppError> {
         let current = self.get_collection_for_user(perms, id).await?;
         let merged = CreateCollection {
+            owner: None,
             title: patch.title.unwrap_or(current.title),
             cover: patch.cover.unwrap_or(current.cover),
             songs: patch.songs.unwrap_or(current.songs),
         };
         self.update_collection_for_user(perms, id, merged).await
+    }
+
+    #[instrument(level = "debug", err, skip(self, perms, payload))]
+    pub async fn move_collection_for_user(
+        &self,
+        perms: &UserPermissions<T>,
+        id: &str,
+        payload: MoveOwner,
+    ) -> Result<Collection, AppError> {
+        let collection = self.get_collection_for_user(perms, id).await?;
+        let current = parse_owner_record_id(&collection.owner)?;
+        let dest = parse_owner_record_id(&payload.owner)?;
+        if thing_record_key(&current) == thing_record_key(&dest) {
+            return Ok(collection);
+        }
+        perms.require_write_access_to_owner(&current).await?;
+        perms.require_write_access_to_owner(&dest).await?;
+        let write_teams = perms.write_teams().await?;
+        self.repo.move_collection_owner(write_teams, id, dest).await
     }
 
     #[instrument(level = "debug", err, skip(self, perms))]
@@ -180,12 +209,13 @@ mod tests {
     use crate::error::AppError;
     use crate::resources::team::UserPermissions;
     use crate::test_helpers::{
-        configure_personal_team_members, create_song_with_title, create_user, personal_team_id,
-        test_db,
+        TeamFixture, configure_personal_team_members, create_song_with_title, create_user,
+        personal_team_id, team_service, test_db, two_shared_teams_for_user,
     };
+    use shared::MoveOwner;
     use shared::api::ListQuery;
     use shared::collection::CreateCollection;
-    use shared::team::TeamRole;
+    use shared::team::{TeamMemberInput, TeamRole, TeamUserRef, UpdateTeam};
 
     use super::CollectionServiceHandle;
 
@@ -217,6 +247,7 @@ mod tests {
             .create_collection_for_user(
                 &owner_perms,
                 CreateCollection {
+                    owner: None,
                     title: "My Collection".into(),
                     cover: "mysongs".into(),
                     songs: vec![SongLink {
@@ -246,6 +277,7 @@ mod tests {
                 &owner_perms,
                 &col.id,
                 CreateCollection {
+                    owner: None,
                     title: "Updated".into(),
                     cover: "mysongs".into(),
                     songs: vec![SongLink {
@@ -264,6 +296,7 @@ mod tests {
                 &guest_perms,
                 &col.id,
                 CreateCollection {
+                    owner: None,
                     title: "Nope".into(),
                     cover: "mysongs".into(),
                     songs: vec![],
@@ -316,6 +349,7 @@ mod tests {
 
     fn make_collection(title: &str) -> CreateCollection {
         CreateCollection {
+            owner: None,
             title: title.into(),
             cover: "mysongs".into(),
             songs: vec![],
@@ -437,6 +471,7 @@ mod tests {
             .create_collection_for_user(
                 &owner_p,
                 CreateCollection {
+                    owner: None,
                     title: "WithGhostSong".into(),
                     cover: "mysongs".into(),
                     songs: vec![shared::song::Link {
@@ -449,6 +484,42 @@ mod tests {
             .await
             .expect("non-existent song id accepted");
         assert!(!col.id.is_empty());
+    }
+
+    /// BLC-COLL-009: optional `owner` — content_maintainer can create on the team; guest cannot.
+    #[tokio::test]
+    async fn blc_coll_009_post_optional_owner_acl() {
+        let (db, _owner, cm, guest, _nm, tid) = four_user_coll_fixture().await;
+        let svc = CollectionServiceHandle::build(db.clone());
+        let cm_p = UserPermissions::from_ref(&cm, &svc.teams);
+        let guest_p = UserPermissions::from_ref(&guest, &svc.teams);
+
+        let col = svc
+            .create_collection_for_user(
+                &cm_p,
+                CreateCollection {
+                    owner: Some(tid.clone()),
+                    title: "OnTeam".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![],
+                },
+            )
+            .await
+            .expect("cm creates under team");
+        assert_eq!(col.owner, tid);
+
+        let r = svc
+            .create_collection_for_user(
+                &guest_p,
+                CreateCollection {
+                    owner: Some(tid.clone()),
+                    title: "GuestNo".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![],
+                },
+            )
+            .await;
+        assert!(matches!(r, Err(AppError::NotFound(_))));
     }
 
     /// BLC-COLL-005: list with `q` filter matches by title (single-token titles).
@@ -514,6 +585,7 @@ mod tests {
             .create_collection_for_user(
                 &owner_p,
                 CreateCollection {
+                    owner: None,
                     title: "SubTest".into(),
                     cover: "mysongs".into(),
                     songs: vec![shared::song::Link {
@@ -637,6 +709,7 @@ mod tests {
                 .create_collection_for_user(
                     &owner_p,
                     CreateCollection {
+                        owner: None,
                         title: "BaseTitle".into(),
                         cover: "mysongs".into(),
                         songs: vec![shared::song::Link {
@@ -712,6 +785,220 @@ mod tests {
             .expect("create");
         let r = svc
             .collection_songs_for_user(&nm_p, &col.id, ListQuery::default())
+            .await;
+        assert!(matches!(r, Err(AppError::NotFound(_))));
+    }
+
+    /// BLC-COLL-020–021: move between teams and idempotent same-owner.
+    #[tokio::test]
+    async fn blc_coll_020_move_between_teams_and_idempotent() {
+        let db = test_db().await.expect("db");
+        let mover = create_user(&db, "c-move-mover@test.local")
+            .await
+            .expect("mover");
+        let (team_a, team_b) = two_shared_teams_for_user(&db, &mover)
+            .await
+            .expect("two teams");
+
+        let svc = CollectionServiceHandle::build(db.clone());
+        let p = UserPermissions::from_ref(&mover, &svc.teams);
+
+        let col = svc
+            .create_collection_for_user(
+                &p,
+                CreateCollection {
+                    owner: Some(team_a.clone()),
+                    title: "OnA".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![],
+                },
+            )
+            .await
+            .expect("create");
+        assert_eq!(col.owner, team_a);
+
+        let on_b = svc
+            .move_collection_for_user(
+                &p,
+                &col.id,
+                MoveOwner {
+                    owner: team_b.clone(),
+                },
+            )
+            .await
+            .expect("move to B");
+        assert_eq!(on_b.owner, team_b);
+
+        let back = svc
+            .move_collection_for_user(
+                &p,
+                &col.id,
+                MoveOwner {
+                    owner: team_a.clone(),
+                },
+            )
+            .await
+            .expect("move to A");
+        assert_eq!(back.owner, team_a);
+
+        let idem = svc
+            .move_collection_for_user(
+                &p,
+                &col.id,
+                MoveOwner {
+                    owner: team_a.clone(),
+                },
+            )
+            .await
+            .expect("idem");
+        assert_eq!(idem.owner, team_a);
+    }
+
+    /// BLC-COLL-020: guest cannot move (no library write on source team).
+    #[tokio::test]
+    async fn blc_coll_021_move_guest_lacks_source_write() {
+        let db = test_db().await.expect("db");
+        let fx = TeamFixture::build(&db).await.expect("fx");
+        let svc = CollectionServiceHandle::build(db.clone());
+        let admin_p = UserPermissions::from_ref(&fx.admin_user, &svc.teams);
+        let guest_p = UserPermissions::from_ref(&fx.guest, &svc.teams);
+
+        let col = svc
+            .create_collection_for_user(
+                &admin_p,
+                CreateCollection {
+                    owner: Some(fx.shared_team_id.clone()),
+                    title: "OnShared".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![],
+                },
+            )
+            .await
+            .expect("create");
+
+        let dest = personal_team_id(&db, &fx.guest).await.expect("g personal");
+        let r = svc
+            .move_collection_for_user(&guest_p, &col.id, MoveOwner { owner: dest })
+            .await;
+        assert!(matches!(r, Err(AppError::NotFound(_))));
+    }
+
+    /// BLC-COLL-020: destination team requires library write.
+    #[tokio::test]
+    async fn blc_coll_022_move_lacks_dest_write() {
+        let db = test_db().await.expect("db");
+        let lead = create_user(&db, "c-lead@test.local").await.expect("lead");
+        let cm = create_user(&db, "c-cmonly@test.local").await.expect("cm");
+        let (team_a, team_b) = two_shared_teams_for_user(&db, &lead).await.expect("teams");
+
+        team_service(&db)
+            .update_team_for_user(
+                &lead,
+                &team_a,
+                UpdateTeam {
+                    name: "Team A".into(),
+                    members: Some(vec![
+                        TeamMemberInput {
+                            user: TeamUserRef {
+                                id: lead.id.clone(),
+                            },
+                            role: TeamRole::Admin,
+                        },
+                        TeamMemberInput {
+                            user: TeamUserRef { id: cm.id.clone() },
+                            role: TeamRole::ContentMaintainer,
+                        },
+                    ]),
+                },
+            )
+            .await
+            .expect("add cm to A");
+
+        let svc = CollectionServiceHandle::build(db.clone());
+        let cm_p = UserPermissions::from_ref(&cm, &svc.teams);
+
+        let col = svc
+            .create_collection_for_user(
+                &cm_p,
+                CreateCollection {
+                    owner: Some(team_a.clone()),
+                    title: "OnA".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![],
+                },
+            )
+            .await
+            .expect("create");
+
+        let r = svc
+            .move_collection_for_user(
+                &cm_p,
+                &col.id,
+                MoveOwner {
+                    owner: team_b.clone(),
+                },
+            )
+            .await;
+        assert!(matches!(r, Err(AppError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn blc_coll_023_move_empty_owner_bad_request() {
+        let db = test_db().await.expect("db");
+        let u = create_user(&db, "c-bad@test.local").await.expect("u");
+        let (a, _) = two_shared_teams_for_user(&db, &u).await.expect("teams");
+        let svc = CollectionServiceHandle::build(db.clone());
+        let p = UserPermissions::from_ref(&u, &svc.teams);
+        let col = svc
+            .create_collection_for_user(
+                &p,
+                CreateCollection {
+                    owner: Some(a),
+                    title: "X".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![],
+                },
+            )
+            .await
+            .expect("create");
+
+        let r = svc
+            .move_collection_for_user(
+                &p,
+                &col.id,
+                MoveOwner {
+                    owner: "   ".into(),
+                },
+            )
+            .await;
+        assert!(matches!(r, Err(AppError::InvalidRequest(_))));
+    }
+
+    /// BLC-COLL-020: platform admin does not gain move without library write.
+    #[tokio::test]
+    async fn blc_coll_024_platform_admin_move_requires_library_write() {
+        let db = test_db().await.expect("db");
+        let fx = TeamFixture::build(&db).await.expect("fx");
+        let svc = CollectionServiceHandle::build(db.clone());
+        let admin_p = UserPermissions::from_ref(&fx.admin_user, &svc.teams);
+        let pa_p = UserPermissions::from_ref(&fx.platform_admin, &svc.teams);
+
+        let col = svc
+            .create_collection_for_user(
+                &admin_p,
+                CreateCollection {
+                    owner: Some(fx.shared_team_id.clone()),
+                    title: "OnShared".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![],
+                },
+            )
+            .await
+            .expect("create");
+
+        let dest = personal_team_id(&db, &fx.admin_user).await.expect("dest");
+        let r = svc
+            .move_collection_for_user(&pa_p, &col.id, MoveOwner { owner: dest })
             .await;
         assert!(matches!(r, Err(AppError::NotFound(_))));
     }

--- a/backend/src/resources/collection/surreal_repo.rs
+++ b/backend/src/resources/collection/surreal_repo.rs
@@ -145,16 +145,15 @@ impl CollectionRepository for SurrealCollectionRepo {
 
     async fn create_collection(
         &self,
-        owner: &str,
+        owner: RecordId,
         collection: CreateCollection,
     ) -> Result<Collection, AppError> {
         let db = self.inner();
-        let owner_team = db.personal_team_thing_for_user(owner).await?;
         db.db
             .create("collection")
             .content(CollectionRecord::from_payload(
                 None,
-                Some(owner_team),
+                Some(owner),
                 collection,
             ))
             .await?
@@ -207,6 +206,32 @@ impl CollectionRepository for SurrealCollectionRepo {
             .query("DELETE FROM type::record($tb, $sid) WHERE owner IN $teams RETURN BEFORE")
             .bind(("tb", tb))
             .bind(("sid", sid))
+            .bind(("teams", write_teams.to_vec()))
+            .await?;
+
+        let rows: Vec<CollectionRecord> = response.take(0)?;
+        rows.into_iter()
+            .next()
+            .map(CollectionRecord::into_collection)
+            .ok_or_else(|| AppError::NotFound("collection not found".into()))
+    }
+
+    async fn move_collection_owner(
+        &self,
+        write_teams: &[RecordId],
+        id: &str,
+        new_owner: RecordId,
+    ) -> Result<Collection, AppError> {
+        let db = self.inner();
+        let (tb, sid) = resource_id("collection", id)?;
+        let mut response = db
+            .db
+            .query(
+                "UPDATE type::record($tb, $sid) SET owner = $new_owner WHERE owner IN $teams RETURN AFTER",
+            )
+            .bind(("tb", tb))
+            .bind(("sid", sid))
+            .bind(("new_owner", new_owner))
             .bind(("teams", write_teams.to_vec()))
             .await?;
 

--- a/backend/src/resources/setlist/model.rs
+++ b/backend/src/resources/setlist/model.rs
@@ -32,11 +32,12 @@ impl SetlistRecord {
         owner: Option<RecordId>,
         setlist: CreateSetlist,
     ) -> Self {
+        let CreateSetlist { title, songs, .. } = setlist;
         Self {
             id,
             owner,
-            title: setlist.title,
-            songs: setlist.songs.into_iter().map(Into::into).collect(),
+            title,
+            songs: songs.into_iter().map(Into::into).collect(),
         }
     }
 }
@@ -56,6 +57,7 @@ mod tests {
             Some(id.clone()),
             Some(owner.clone()),
             CreateSetlist {
+                owner: None,
                 title: "Sunday".into(),
                 songs: vec![SongLink {
                     id: "s1".into(),
@@ -89,6 +91,7 @@ mod tests {
             .create_setlist_for_user(
                 &perms,
                 CreateSetlist {
+                    owner: None,
                     title: "Smoke".to_string(),
                     songs: vec![],
                 },

--- a/backend/src/resources/setlist/repository.rs
+++ b/backend/src/resources/setlist/repository.rs
@@ -33,7 +33,7 @@ pub trait SetlistRepository: Send + Sync {
 
     async fn create_setlist(
         &self,
-        owner: &str,
+        owner: RecordId,
         setlist: CreateSetlist,
     ) -> Result<Setlist, AppError>;
 
@@ -46,4 +46,11 @@ pub trait SetlistRepository: Send + Sync {
 
     async fn delete_setlist(&self, write_teams: &[RecordId], id: &str)
     -> Result<Setlist, AppError>;
+
+    async fn move_setlist_owner(
+        &self,
+        write_teams: &[RecordId],
+        id: &str,
+        new_owner: RecordId,
+    ) -> Result<Setlist, AppError>;
 }

--- a/backend/src/resources/setlist/rest.rs
+++ b/backend/src/resources/setlist/rest.rs
@@ -18,6 +18,7 @@ use crate::resources::setlist::{CreateSetlist, UpdateSetlist};
 #[allow(unused_imports)]
 use crate::resources::song::Song;
 use crate::resources::team::UserPermissions;
+use shared::MoveOwner;
 use shared::api::{ListQuery, PAGE_SIZE_DEFAULT, PageQuery};
 #[allow(unused_imports)]
 use shared::player::Player;
@@ -31,6 +32,7 @@ pub fn scope() -> Scope {
         .service(create_setlist)
         .service(update_setlist)
         .service(patch_setlist)
+        .service(move_setlist)
         .service(delete_setlist)
 }
 
@@ -236,9 +238,10 @@ async fn get_setlist_songs(
     path = "/api/v1/setlists",
     request_body = CreateSetlist,
     responses(
-        (status = 201, description = "Create a new setlist", body = Setlist),
+        (status = 201, description = "Create a new setlist. Optional `owner` is a team id; omit for the caller's personal team. Library edit access is required on the target team.", body = Setlist),
         (status = 400, description = "Invalid setlist payload", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 404, description = "Target team not found or caller cannot edit that team's library", body = Problem, content_type = "application/problem+json"),
         (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to create setlist", body = Problem, content_type = "application/problem+json")
     ),
@@ -339,6 +342,41 @@ async fn patch_setlist(
     check_if_match(&req, &etag)?;
     Ok(HttpResponse::Ok().json(
         svc.patch_setlist_for_user(&perms, &id, payload.into_inner())
+            .await?,
+    ))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/setlists/{id}/move",
+    params(
+        ("id" = String, Path, description = "Setlist identifier")
+    ),
+    request_body = MoveOwner,
+    responses(
+        (status = 200, description = "Setlist moved to the target team, or unchanged when already owned by that team (idempotent).", body = Setlist),
+        (status = 400, description = "Invalid `owner` team id", body = Problem, content_type = "application/problem+json"),
+        (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
+        (status = 404, description = "Setlist not found, target team not found, or caller lacks library write access on the current or destination team", body = Problem, content_type = "application/problem+json"),
+        (status = 500, description = "Failed to move setlist", body = Problem, content_type = "application/problem+json")
+    ),
+    tag = "Setlists",
+    security(
+        ("SessionCookie" = []),
+        ("SessionToken" = [])
+    )
+)]
+#[post("/{id}/move")]
+async fn move_setlist(
+    svc: Data<SetlistServiceHandle>,
+    user: ReqData<User>,
+    id: Path<String>,
+    payload: Json<MoveOwner>,
+) -> Result<HttpResponse, AppError> {
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
+    Ok(HttpResponse::Ok().json(
+        svc.move_setlist_for_user(&perms, &id.into_inner(), payload.into_inner())
             .await?,
     ))
 }

--- a/backend/src/resources/setlist/service.rs
+++ b/backend/src/resources/setlist/service.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use shared::MoveOwner;
 use shared::api::ListQuery;
 use shared::player::Player;
 use shared::setlist::{CreateSetlist, PatchSetlist, Setlist};
@@ -8,7 +9,9 @@ use tracing::instrument;
 
 use crate::error::AppError;
 use crate::resources::song::LikedSongIds;
-use crate::resources::team::{TeamResolver, UserPermissions};
+use crate::resources::team::{
+    TeamResolver, UserPermissions, parse_owner_record_id, thing_record_key,
+};
 
 use super::repository::SetlistRepository;
 use crate::resources::common::player_from_song_links;
@@ -101,9 +104,17 @@ impl<R: SetlistRepository, T: TeamResolver, L: LikedSongIds> SetlistService<R, T
     pub async fn create_setlist_for_user(
         &self,
         perms: &UserPermissions<T>,
-        setlist: CreateSetlist,
+        mut setlist: CreateSetlist,
     ) -> Result<Setlist, AppError> {
-        self.repo.create_setlist(&perms.user().id, setlist).await
+        let owner = match setlist.owner.take() {
+            None => perms.personal_team().await?,
+            Some(ref s) => {
+                let rid = parse_owner_record_id(s)?;
+                perms.require_write_access_to_owner(&rid).await?;
+                rid
+            }
+        };
+        self.repo.create_setlist(owner, setlist).await
     }
 
     #[instrument(level = "debug", err, skip(self, perms, setlist))]
@@ -126,10 +137,30 @@ impl<R: SetlistRepository, T: TeamResolver, L: LikedSongIds> SetlistService<R, T
     ) -> Result<Setlist, AppError> {
         let current = self.get_setlist_for_user(perms, id).await?;
         let merged = CreateSetlist {
+            owner: None,
             title: patch.title.unwrap_or(current.title),
             songs: patch.songs.unwrap_or(current.songs),
         };
         self.update_setlist_for_user(perms, id, merged).await
+    }
+
+    #[instrument(level = "debug", err, skip(self, perms, payload))]
+    pub async fn move_setlist_for_user(
+        &self,
+        perms: &UserPermissions<T>,
+        id: &str,
+        payload: MoveOwner,
+    ) -> Result<Setlist, AppError> {
+        let setlist = self.get_setlist_for_user(perms, id).await?;
+        let current = parse_owner_record_id(&setlist.owner)?;
+        let dest = parse_owner_record_id(&payload.owner)?;
+        if thing_record_key(&current) == thing_record_key(&dest) {
+            return Ok(setlist);
+        }
+        perms.require_write_access_to_owner(&current).await?;
+        perms.require_write_access_to_owner(&dest).await?;
+        let write_teams = perms.write_teams().await?;
+        self.repo.move_setlist_owner(write_teams, id, dest).await
     }
 
     #[instrument(level = "debug", err, skip(self, perms))]
@@ -170,8 +201,9 @@ mod tests {
     use crate::resources::team::{TeamResolver, UserPermissions};
     use crate::test_helpers::{
         configure_personal_team_members, create_song_with_title, create_user, personal_team_id,
-        setlist_service, setlist_with_songs, test_db,
+        setlist_service, setlist_with_songs, test_db, two_shared_teams_for_user,
     };
+    use shared::MoveOwner;
 
     use super::{SetlistRepository, SetlistService};
 
@@ -219,7 +251,7 @@ mod tests {
 
         async fn create_setlist(
             &self,
-            _owner: &str,
+            _owner: RecordId,
             _setlist: CreateSetlist,
         ) -> Result<Setlist, AppError> {
             unreachable!("not used in these tests")
@@ -249,6 +281,15 @@ mod tests {
             _id: &str,
         ) -> Result<Setlist, AppError> {
             Err(AppError::NotFound("setlist not found".into()))
+        }
+
+        async fn move_setlist_owner(
+            &self,
+            _write_teams: &[RecordId],
+            _id: &str,
+            _new_owner: RecordId,
+        ) -> Result<Setlist, AppError> {
+            unreachable!("not used in these tests")
         }
     }
 
@@ -374,6 +415,7 @@ mod tests {
                 &perms,
                 "id",
                 CreateSetlist {
+                    owner: None,
                     title: "t".into(),
                     songs: vec![],
                 },
@@ -406,6 +448,7 @@ mod tests {
                 &perms,
                 "id",
                 CreateSetlist {
+                    owner: None,
                     title: "t".into(),
                     songs: vec![],
                 },
@@ -1067,5 +1110,53 @@ mod tests {
             .delete_setlist_for_user(&owner_p, &owner_setlist.id)
             .await;
         assert!(matches!(again, Err(AppError::NotFound(_))));
+    }
+
+    /// BLC-SETL-015–016: move between shared teams and idempotent same-owner.
+    #[tokio::test]
+    async fn blc_setl_015_move_between_teams_and_idempotent() {
+        let db = test_db().await.expect("db");
+        let mover = create_user(&db, "sl-move@test.local").await.expect("mover");
+        let (team_a, team_b) = two_shared_teams_for_user(&db, &mover).await.expect("teams");
+
+        let sl = setlist_service(&db);
+        let p = UserPermissions::from_ref(&mover, &sl.teams);
+
+        let s = sl
+            .create_setlist_for_user(
+                &p,
+                CreateSetlist {
+                    owner: Some(team_a.clone()),
+                    title: "OnA".into(),
+                    songs: vec![],
+                },
+            )
+            .await
+            .expect("create");
+        assert_eq!(s.owner, team_a);
+
+        let on_b = sl
+            .move_setlist_for_user(
+                &p,
+                &s.id,
+                MoveOwner {
+                    owner: team_b.clone(),
+                },
+            )
+            .await
+            .expect("to B");
+        assert_eq!(on_b.owner, team_b);
+
+        let idem = sl
+            .move_setlist_for_user(
+                &p,
+                &s.id,
+                MoveOwner {
+                    owner: team_b.clone(),
+                },
+            )
+            .await
+            .expect("idem");
+        assert_eq!(idem.owner, team_b);
     }
 }

--- a/backend/src/resources/setlist/surreal_repo.rs
+++ b/backend/src/resources/setlist/surreal_repo.rs
@@ -141,14 +141,13 @@ impl SetlistRepository for SurrealSetlistRepo {
 
     async fn create_setlist(
         &self,
-        owner: &str,
+        owner: RecordId,
         setlist: CreateSetlist,
     ) -> Result<Setlist, AppError> {
         let db = self.inner();
-        let owner_team = db.personal_team_thing_for_user(owner).await?;
         db.db
             .create("setlist")
-            .content(SetlistRecord::from_payload(None, Some(owner_team), setlist))
+            .content(SetlistRecord::from_payload(None, Some(owner), setlist))
             .await?
             .map(SetlistRecord::into_setlist)
             .ok_or_else(|| AppError::database("failed to create setlist"))
@@ -197,6 +196,32 @@ impl SetlistRepository for SurrealSetlistRepo {
             .query("DELETE FROM type::record($tb, $sid) WHERE owner IN $teams RETURN BEFORE")
             .bind(("tb", tb))
             .bind(("sid", sid))
+            .bind(("teams", write_teams.to_vec()))
+            .await?;
+
+        let rows: Vec<SetlistRecord> = response.take(0)?;
+        rows.into_iter()
+            .next()
+            .map(SetlistRecord::into_setlist)
+            .ok_or_else(|| AppError::NotFound("setlist not found".into()))
+    }
+
+    async fn move_setlist_owner(
+        &self,
+        write_teams: &[RecordId],
+        id: &str,
+        new_owner: RecordId,
+    ) -> Result<Setlist, AppError> {
+        let db = self.inner();
+        let (tb, sid) = resource_id("setlist", id)?;
+        let mut response = db
+            .db
+            .query(
+                "UPDATE type::record($tb, $sid) SET owner = $new_owner WHERE owner IN $teams RETURN AFTER",
+            )
+            .bind(("tb", tb))
+            .bind(("sid", sid))
+            .bind(("new_owner", new_owner))
             .bind(("teams", write_teams.to_vec()))
             .await?;
 

--- a/backend/src/resources/song/model.rs
+++ b/backend/src/resources/song/model.rs
@@ -102,17 +102,19 @@ impl SongRecord {
     }
 
     pub fn from_payload(id: Option<RecordId>, owner: Option<RecordId>, song: CreateSong) -> Self {
-        let search_content = search_content_from_song_data(&song.data);
+        let CreateSong {
+            not_a_song,
+            blobs,
+            data,
+            ..
+        } = song;
+        let search_content = search_content_from_song_data(&data);
         Self {
             id,
             owner,
-            not_a_song: song.not_a_song,
-            blobs: song
-                .blobs
-                .into_iter()
-                .map(|blob| blob_thing(&blob.id))
-                .collect(),
-            data: SongDataField(song.data),
+            not_a_song,
+            blobs: blobs.into_iter().map(|blob| blob_thing(&blob.id)).collect(),
+            data: SongDataField(data),
             search_content,
         }
     }
@@ -200,6 +202,7 @@ mod tests {
         )
         .expect("song data json");
         let create = CreateSong {
+            owner: None,
             not_a_song: false,
             blobs: vec![
                 BlobLink {

--- a/backend/src/resources/song/repository.rs
+++ b/backend/src/resources/song/repository.rs
@@ -34,7 +34,7 @@ pub trait SongRepository: Send + Sync {
 
     async fn get_song(&self, read_teams: &[RecordId], id: &str) -> Result<Song, AppError>;
 
-    async fn create_song(&self, owner: &str, song: CreateSong) -> Result<Song, AppError>;
+    async fn create_song(&self, owner: RecordId, song: CreateSong) -> Result<Song, AppError>;
 
     /// Update an existing song, or create it if it doesn't yet exist
     /// (upsert semantics). This supports import/sync workflows where the
@@ -56,6 +56,13 @@ pub trait SongRepository: Send + Sync {
     ) -> Result<SongUpsertOutcome, AppError>;
 
     async fn delete_song(&self, write_teams: &[RecordId], id: &str) -> Result<Song, AppError>;
+
+    async fn move_song_owner(
+        &self,
+        write_teams: &[RecordId],
+        id: &str,
+        new_owner: RecordId,
+    ) -> Result<Song, AppError>;
 
     /// Count songs matching the same filters as [`get_songs`](SongRepository::get_songs).
     async fn count_songs(

--- a/backend/src/resources/song/rest.rs
+++ b/backend/src/resources/song/rest.rs
@@ -17,6 +17,7 @@ use crate::resources::song::SongUpsertOutcome;
 use crate::resources::song::service::SongServiceHandle;
 use crate::resources::song::{CreateSong, UpdateSong};
 use crate::resources::team::UserPermissions;
+use shared::MoveOwner;
 use shared::api::{PAGE_SIZE_DEFAULT, SongListQuery};
 #[allow(unused_imports)]
 use shared::player::Player;
@@ -29,6 +30,7 @@ pub fn scope() -> Scope {
         .service(create_song)
         .service(update_song)
         .service(patch_song)
+        .service(move_song)
         .service(delete_song)
         .service(get_song_like_status)
         .service(put_song_like)
@@ -177,9 +179,10 @@ async fn get_song_player(
     path = "/api/v1/songs",
     request_body = CreateSong,
     responses(
-        (status = 201, description = "Create a new song. If the user has no default collection yet, the server may create a system \"Default\" collection and set it as `user.default_collection` (BLC-SONG-010).", body = Song),
+        (status = 201, description = "Create a new song. Optional `owner` is a team id; omit for the caller's personal team. When the effective target is the personal team, default-collection behavior may apply (BLC-SONG-010). When `owner` names a different team the song is created there without that default-collection side effect. Library edit access is required on the target team.", body = Song),
         (status = 400, description = "Invalid song payload", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 404, description = "Target team not found or caller cannot edit that team's library", body = Problem, content_type = "application/problem+json"),
         (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to create song", body = Problem, content_type = "application/problem+json")
     ),
@@ -291,6 +294,41 @@ async fn patch_song(
     check_if_match(&req, &etag)?;
     Ok(HttpResponse::Ok().json(
         svc.patch_song_for_user(&perms, &id, payload.into_inner())
+            .await?,
+    ))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/songs/{id}/move",
+    params(
+        ("id" = String, Path, description = "Song identifier")
+    ),
+    request_body = MoveOwner,
+    responses(
+        (status = 200, description = "Song moved to the target team, or unchanged when already owned by that team (idempotent). Moving does not add or remove the song from collections.", body = Song),
+        (status = 400, description = "Invalid `owner` team id", body = Problem, content_type = "application/problem+json"),
+        (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
+        (status = 404, description = "Song not found, target team not found, or caller lacks library write access on the current or destination team", body = Problem, content_type = "application/problem+json"),
+        (status = 500, description = "Failed to move song", body = Problem, content_type = "application/problem+json")
+    ),
+    tag = "Songs",
+    security(
+        ("SessionCookie" = []),
+        ("SessionToken" = [])
+    )
+)]
+#[post("/{id}/move")]
+async fn move_song(
+    svc: Data<SongServiceHandle>,
+    user: ReqData<User>,
+    id: Path<String>,
+    payload: Json<MoveOwner>,
+) -> Result<HttpResponse, AppError> {
+    let perms = UserPermissions::from_ref(&user, &svc.teams);
+    Ok(HttpResponse::Ok().json(
+        svc.move_song_for_user(&perms, &id.into_inner(), payload.into_inner())
             .await?,
     ))
 }

--- a/backend/src/resources/song/service.rs
+++ b/backend/src/resources/song/service.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
+use shared::MoveOwner;
 use shared::api::SongListQuery;
 use shared::like::LikeStatus;
 use shared::patch::Patch;
@@ -14,7 +15,9 @@ use crate::database::Database;
 use crate::error::AppError;
 use crate::resources::collection::CollectionRepository;
 
-use crate::resources::team::{TeamResolver, UserPermissions};
+use crate::resources::team::{
+    TeamResolver, UserPermissions, parse_owner_record_id, thing_record_key,
+};
 use crate::resources::user::SurrealUserRepo;
 use crate::resources::user::UserRepository;
 use shared::collection::CreateCollection;
@@ -197,9 +200,25 @@ impl<
     pub async fn create_song_for_user(
         &self,
         perms: &UserPermissions<T>,
-        song: CreateSong,
+        mut song: CreateSong,
     ) -> Result<Song, AppError> {
-        let created = self.repo.create_song(&perms.user().id, song).await?;
+        let personal = perms.personal_team().await?;
+        let (owner, use_default_collection_flow) = match song.owner.take() {
+            None => (personal.clone(), true),
+            Some(ref s) => {
+                let rid = parse_owner_record_id(s)?;
+                perms.require_write_access_to_owner(&rid).await?;
+                let same_as_personal = thing_record_key(&rid) == thing_record_key(&personal);
+                (rid, same_as_personal)
+            }
+        };
+
+        let created = self.repo.create_song(owner, song).await?;
+
+        if !use_default_collection_flow {
+            return Ok(created);
+        }
+
         let mut default_id = perms.user().default_collection.clone();
 
         loop {
@@ -231,8 +250,9 @@ impl<
                 let collection = self
                     .collections
                     .create_collection(
-                        &perms.user().id,
+                        personal.clone(),
                         CreateCollection {
+                            owner: None,
                             title: "Default".to_string(),
                             cover: "mysongs".to_string(),
                             songs: vec![SongLink {
@@ -275,6 +295,7 @@ impl<
     ) -> Result<Song, AppError> {
         let current = self.get_song_for_user(perms, id).await?;
         let merged = CreateSong {
+            owner: None,
             not_a_song: patch.not_a_song.unwrap_or(current.not_a_song),
             blobs: patch.blobs.unwrap_or(current.blobs),
             data: patch
@@ -285,6 +306,25 @@ impl<
         self.update_song_for_user(perms, id, merged)
             .await
             .map(SongUpsertOutcome::into_song)
+    }
+
+    #[instrument(level = "debug", err, skip(self, perms, payload))]
+    pub async fn move_song_for_user(
+        &self,
+        perms: &UserPermissions<T>,
+        id: &str,
+        payload: MoveOwner,
+    ) -> Result<Song, AppError> {
+        let song = self.get_song_for_user(perms, id).await?;
+        let current = parse_owner_record_id(&song.owner)?;
+        let dest = parse_owner_record_id(&payload.owner)?;
+        if thing_record_key(&current) == thing_record_key(&dest) {
+            return Ok(song);
+        }
+        perms.require_write_access_to_owner(&current).await?;
+        perms.require_write_access_to_owner(&dest).await?;
+        let write_teams = perms.write_teams().await?;
+        self.repo.move_song_owner(write_teams, id, dest).await
     }
 
     #[instrument(level = "debug", err, skip(self, perms))]
@@ -365,9 +405,11 @@ mod tests {
     use crate::resources::team::UserPermissions;
     use crate::test_helpers::{
         configure_personal_team_members, create_song_with_title, create_user, personal_team_id,
-        setlist_service, setlist_with_songs, test_db,
+        setlist_service, setlist_with_songs, test_db, two_shared_teams_for_user,
     };
+    use shared::MoveOwner;
     use shared::api::ListQuery;
+    use shared::song::CreateSong;
     use shared::team::TeamRole;
 
     use super::SongServiceHandle;
@@ -501,6 +543,7 @@ mod tests {
             .await
             .expect("song");
         let create = CreateSong {
+            owner: None,
             not_a_song: false,
             blobs: vec![],
             data: crate::test_helpers::minimal_song_data(),
@@ -541,6 +584,7 @@ mod tests {
         let mut data = crate::test_helpers::minimal_song_data();
         data.titles = vec!["UpdatedTitle".into()];
         let create = CreateSong {
+            owner: None,
             not_a_song: false,
             blobs: vec![],
             data,
@@ -564,6 +608,7 @@ mod tests {
         assert_eq!(song.owner, tid);
         let data = crate::test_helpers::minimal_song_data();
         let create = CreateSong {
+            owner: None,
             not_a_song: false,
             blobs: vec![],
             data,
@@ -588,6 +633,7 @@ mod tests {
         data_with_artist.titles = vec!["SongByArtist".into()];
         data_with_artist.artists = vec!["UniqueArtistZZZ".into()];
         let create = shared::song::CreateSong {
+            owner: None,
             not_a_song: false,
             blobs: vec![],
             data: data_with_artist,
@@ -599,6 +645,7 @@ mod tests {
         let mut data_no_artist = crate::test_helpers::minimal_song_data();
         data_no_artist.titles = vec!["SongWithoutArtist".into()];
         let create2 = shared::song::CreateSong {
+            owner: None,
             not_a_song: false,
             blobs: vec![],
             data: data_no_artist,
@@ -703,6 +750,7 @@ mod tests {
         let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
         let data = crate::test_helpers::minimal_song_data();
         let create = CreateSong {
+            owner: None,
             not_a_song: false,
             blobs: vec![],
             data,
@@ -843,6 +891,7 @@ mod tests {
                 .create_song_for_user(
                     &owner_p,
                     CreateSong {
+                        owner: None,
                         not_a_song: false,
                         blobs: vec![BlobLink {
                             id: "base_blob".into(),
@@ -1105,6 +1154,7 @@ mod tests {
         let guest_p = UserPermissions::from_ref(&guest_u, &svc.teams);
         let data = crate::test_helpers::minimal_song_data();
         let create = CreateSong {
+            owner: None,
             not_a_song: false,
             blobs: vec![],
             data,
@@ -1119,6 +1169,61 @@ mod tests {
         assert_eq!(
             result.owner, guest_pt,
             "upserted song must be owned by guest's personal team"
+        );
+    }
+
+    /// BLC-SONG-009/010: POST with `owner` targeting another team skips personal default-collection flow.
+    #[tokio::test]
+    async fn blc_song_post_optional_owner_skips_default_collection_side_effect() {
+        use shared::song::CreateSong;
+        let (db, owner, cm, _guest, _nm, team_id) = four_user_song_fixture().await;
+        let svc = SongServiceHandle::build(db.clone());
+        let cm_p = UserPermissions::from_ref(&cm, &svc.teams);
+        let user_svc = crate::test_helpers::user_service(&db);
+        let cm_before = user_svc.get_user(&cm.id).await.expect("cm user");
+        assert!(
+            cm_before.default_collection.is_none(),
+            "fixture: cm has no default collection yet"
+        );
+
+        let song = svc
+            .create_song_for_user(
+                &cm_p,
+                CreateSong {
+                    owner: Some(team_id.clone()),
+                    not_a_song: false,
+                    blobs: vec![],
+                    data: crate::test_helpers::minimal_song_data(),
+                },
+            )
+            .await
+            .expect("create on another user's team as cm");
+
+        assert_eq!(song.owner, team_id);
+        let cm_after = user_svc.get_user(&cm.id).await.expect("cm user");
+        assert!(
+            cm_after.default_collection.is_none(),
+            "must not run BLC-SONG-010 default collection when POST owner is not caller personal team"
+        );
+
+        // Owner should still get default-collection behavior on their own POST (regression anchor).
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
+        let _ = svc
+            .create_song_for_user(
+                &owner_p,
+                CreateSong {
+                    owner: None,
+                    not_a_song: false,
+                    blobs: vec![],
+                    data: crate::test_helpers::minimal_song_data(),
+                },
+            )
+            .await
+            .expect("owner personal song");
+        let owner_after = user_svc.get_user(&owner.id).await.expect("owner");
+        assert!(
+            owner_after.default_collection.is_some(),
+            "owner personal create still applies BLC-SONG-010"
         );
     }
 
@@ -1138,6 +1243,7 @@ mod tests {
             .create_song_for_user(
                 &perms,
                 shared::song::CreateSong {
+                    owner: None,
                     not_a_song: false,
                     blobs: vec![],
                     data: crate::test_helpers::minimal_song_data(),
@@ -1195,6 +1301,7 @@ mod tests {
             .create_song_for_user(
                 &perms,
                 shared::song::CreateSong {
+                    owner: None,
                     not_a_song: false,
                     blobs: vec![],
                     data: {
@@ -1222,6 +1329,7 @@ mod tests {
             .create_song_for_user(
                 &perms2,
                 shared::song::CreateSong {
+                    owner: None,
                     not_a_song: false,
                     blobs: vec![],
                     data: {
@@ -1289,5 +1397,56 @@ mod tests {
             .await
             .expect("get setlist");
         assert!(g.songs.is_empty());
+    }
+
+    /// BLC-SONG-020–021: move between shared teams and idempotent same-owner.
+    #[tokio::test]
+    async fn blc_song_020_move_between_teams_and_idempotent() {
+        let db = test_db().await.expect("db");
+        let mover = create_user(&db, "song-move@test.local")
+            .await
+            .expect("mover");
+        let (team_a, team_b) = two_shared_teams_for_user(&db, &mover).await.expect("teams");
+
+        let svc = SongServiceHandle::build(db.clone());
+        let p = UserPermissions::from_ref(&mover, &svc.teams);
+
+        let song = svc
+            .create_song_for_user(
+                &p,
+                CreateSong {
+                    owner: Some(team_a.clone()),
+                    not_a_song: false,
+                    blobs: vec![],
+                    data: crate::test_helpers::minimal_song_data(),
+                },
+            )
+            .await
+            .expect("create");
+        assert_eq!(song.owner, team_a);
+
+        let on_b = svc
+            .move_song_for_user(
+                &p,
+                &song.id,
+                MoveOwner {
+                    owner: team_b.clone(),
+                },
+            )
+            .await
+            .expect("to B");
+        assert_eq!(on_b.owner, team_b);
+
+        let idem = svc
+            .move_song_for_user(
+                &p,
+                &song.id,
+                MoveOwner {
+                    owner: team_b.clone(),
+                },
+            )
+            .await
+            .expect("idem");
+        assert_eq!(idem.owner, team_b);
     }
 }

--- a/backend/src/resources/song/surreal_repo.rs
+++ b/backend/src/resources/song/surreal_repo.rs
@@ -300,12 +300,11 @@ impl SongRepository for SurrealSongRepo {
             .unwrap_or(0))
     }
 
-    async fn create_song(&self, owner: &str, song: CreateSong) -> Result<Song, AppError> {
+    async fn create_song(&self, owner: RecordId, song: CreateSong) -> Result<Song, AppError> {
         let db = self.inner();
-        let owner_team = db.personal_team_thing_for_user(owner).await?;
         db.db
             .create("song")
-            .content(SongRecord::from_payload(None, Some(owner_team), song))
+            .content(SongRecord::from_payload(None, Some(owner), song))
             .await?
             .map(SongRecord::into_song)
             .ok_or_else(|| AppError::database("failed to create song"))
@@ -377,6 +376,32 @@ impl SongRepository for SurrealSongRepo {
             .query("DELETE FROM type::record($tb, $sid) WHERE owner IN $teams RETURN BEFORE")
             .bind(("tb", tb))
             .bind(("sid", sid))
+            .bind(("teams", write_teams.to_vec()))
+            .await?;
+
+        let rows: Vec<SongRecord> = response.take(0)?;
+        rows.into_iter()
+            .next()
+            .map(SongRecord::into_song)
+            .ok_or_else(|| AppError::NotFound("song not found".into()))
+    }
+
+    async fn move_song_owner(
+        &self,
+        write_teams: &[RecordId],
+        id: &str,
+        new_owner: RecordId,
+    ) -> Result<Song, AppError> {
+        let db = self.inner();
+        let (tb, sid) = resource_id("song", id)?;
+        let mut response = db
+            .db
+            .query(
+                "UPDATE type::record($tb, $sid) SET owner = $new_owner WHERE owner IN $teams RETURN AFTER",
+            )
+            .bind(("tb", tb))
+            .bind(("sid", sid))
+            .bind(("new_owner", new_owner))
             .bind(("teams", write_teams.to_vec()))
             .await?;
 

--- a/backend/src/resources/team/mod.rs
+++ b/backend/src/resources/team/mod.rs
@@ -8,7 +8,10 @@ pub mod service;
 mod surreal_repo;
 
 pub use invitation::rest::invitations_accept_scope;
-pub use model::{DbTeamMember, TeamCreatePayload, TeamFetched, user_thing};
+pub use model::{
+    DbTeamMember, TeamCreatePayload, TeamFetched, parse_owner_record_id, thing_record_key,
+    user_thing,
+};
 pub use repository::TeamRepository;
 pub use resolver::{
     SurrealTeamResolver, TeamResolver, UserPermissions, content_read_team_things,

--- a/backend/src/resources/team/model.rs
+++ b/backend/src/resources/team/model.rs
@@ -253,6 +253,16 @@ pub fn team_resource_or_reject_public(id: &str) -> Result<(String, String), AppE
     Ok(resource)
 }
 
+/// Parse a team id from an API `owner` field (create/move payloads). Trims; rejects empty strings and `team:public`.
+pub fn parse_owner_record_id(owner: &str) -> Result<RecordId, AppError> {
+    let t = owner.trim();
+    if t.is_empty() {
+        return Err(AppError::invalid_request("owner must not be empty"));
+    }
+    let (tb, sid) = team_resource_or_reject_public(t)?;
+    Ok(RecordId::new(tb, sid))
+}
+
 fn team_resource(id: &str) -> Result<(String, String), AppError> {
     if id == "public" {
         return Ok(("team".to_owned(), "public".to_owned()));

--- a/backend/src/resources/team/resolver.rs
+++ b/backend/src/resources/team/resolver.rs
@@ -90,6 +90,19 @@ impl<T: TeamResolver> UserPermissions<T> {
             .await
             .cloned()
     }
+
+    /// Ensures the user may create/update/delete library content for this owning **team** [`RecordId`]
+    /// (same id as the `owner` string in API responses). Same set as [`Self::write_teams`].
+    /// On failure, returns [`AppError::NotFound`] to match other library ACL responses.
+    pub async fn require_write_access_to_owner(&self, owner: &RecordId) -> Result<(), AppError> {
+        let write_teams = self.write_teams().await?;
+        let key = thing_record_key(owner);
+        if write_teams.iter().any(|t| thing_record_key(t) == key) {
+            Ok(())
+        } else {
+            Err(AppError::NotFound("team not found".into()))
+        }
+    }
 }
 
 #[async_trait]

--- a/backend/src/resources/team/service.rs
+++ b/backend/src/resources/team/service.rs
@@ -799,6 +799,7 @@ mod tests {
             .create_collection_for_user(
                 &admin_perms_coll,
                 shared::collection::CreateCollection {
+                    owner: None,
                     title: "SharedColl".into(),
                     cover: "mysongs".into(),
                     songs: vec![],

--- a/backend/src/resources/user/service.rs
+++ b/backend/src/resources/user/service.rs
@@ -184,6 +184,7 @@ impl UserServiceHandle {
             .create_blob_for_user(
                 &perms,
                 CreateBlob {
+                    owner: None,
                     file_type,
                     width: w,
                     height: h,
@@ -247,6 +248,7 @@ impl UserServiceHandle {
             .create_blob_for_user(
                 &perms,
                 CreateBlob {
+                    owner: None,
                     file_type,
                     width: w,
                     height: h,

--- a/backend/src/test_helpers.rs
+++ b/backend/src/test_helpers.rs
@@ -57,6 +57,7 @@ pub async fn create_song_with_title(
     let mut data = minimal_song_data();
     data.titles = vec![title.to_string()];
     let create = CreateSong {
+        owner: None,
         not_a_song: false,
         blobs: vec![],
         data,
@@ -214,8 +215,36 @@ impl TeamFixture {
     }
 }
 
+/// Two distinct shared teams created by the same user (caller is **admin** on both).
+pub async fn two_shared_teams_for_user(
+    db: &Arc<Database>,
+    user: &User,
+) -> AnyResult<(String, String)> {
+    let ts = team_service(db);
+    let a = ts
+        .create_shared_team_for_user(
+            user,
+            CreateTeam {
+                name: "Move fixture A".into(),
+                members: vec![],
+            },
+        )
+        .await?;
+    let b = ts
+        .create_shared_team_for_user(
+            user,
+            CreateTeam {
+                name: "Move fixture B".into(),
+                members: vec![],
+            },
+        )
+        .await?;
+    Ok((a.id, b.id))
+}
+
 pub fn setlist_with_songs(title: &str, song_ids: &[(&str, Option<&str>)]) -> CreateSetlist {
     CreateSetlist {
+        owner: None,
         title: title.into(),
         songs: song_ids
             .iter()

--- a/docs/business-logic-constraints/blob.md
+++ b/docs/business-logic-constraints/blob.md
@@ -17,7 +17,7 @@
 - **BLC-BLOB-006:** WHEN the caller may not read the owning team’s library THEN blob **GET** / list / **…/data** respond **404** (not **403**).
 - **BLC-BLOB-007:** WHEN the caller has **guest**-level membership on the owning team and attempts **PUT** or **DELETE** THEN the API responds **404**.
 - **BLC-BLOB-008:** WHEN the caller is the personal-team **owner**, or **admin** / **content_maintainer** on the owning team, THEN **PUT** and **DELETE** are allowed (subject to validation).
-- **BLC-BLOB-009:** WHEN **POST** creates a blob THEN **`owner`** IS ALWAYS the caller’s **personal** team.
+- **BLC-BLOB-009:** WHEN **POST** omits **`owner`** THEN the new blob’s **`owner`** IS the caller’s **personal** team. WHEN **POST** includes **`owner`**, the same team ACL rules apply as for collections ([collection.md](./collection.md) **BLC-COLL-009**).
 - **BLC-BLOB-010:** WHEN **GET /blobs** or **GET /blobs/{id}** runs THEN only blobs whose **`owner`** team the caller may read are included or returned; catalog-wide readable material MAY appear without team membership where the product exposes it.
 - **BLC-BLOB-011:** WHEN **GET …/data** runs THEN the same visibility rules as metadata **GET** apply; IF bytes are available THEN they are served.
 - **BLC-BLOB-016:** **`GET /blobs/{id}/data`** responses include a weak **`ETag`** over stored bytes, **`Content-Length`**, and **`Cache-Control: private, max-age=3600, immutable`**. **`If-None-Match`** matching the current **`ETag`** yields **304** with an empty body.
@@ -28,3 +28,9 @@
 
 - **BLC-BLOB-014:** WHEN a blob used as a collection **`cover`** IS **DELETE**d THEN **GET** that collection MAY return **404** even if the collection id still exists until it is updated or removed.
 - **BLC-BLOB-015:** WHEN a **user** account IS deleted THEN blobs owned by their **personal** team disappear with that team (see [user.md](./user.md)).
+
+## Move (`POST /blobs/{id}/move`)
+
+- **BLC-BLOB-017:** **`POST /blobs/{id}/move`** with **`{ "owner": "<team id>" }`** requires **library edit** on **both** the blob’s current owning team and the target team; otherwise **404** (or **400** for malformed **`owner`**). Platform **admin** MUST NOT bypass library write for move.
+- **BLC-BLOB-018:** WHEN the target **`owner`** equals the current owning team THEN **200** with unchanged metadata (idempotent).
+- **BLC-BLOB-019:** Move changes **metadata** **`owner`** only; stored bytes stay associated with the blob id (no cross-resource rewriting).

--- a/docs/business-logic-constraints/collection.md
+++ b/docs/business-logic-constraints/collection.md
@@ -16,7 +16,7 @@
 - **BLC-COLL-006:** WHEN the caller may not read the owning team’s library THEN collection reads respond **404**.
 - **BLC-COLL-007:** WHEN the caller is **guest** on the owning team and attempts **POST**/**PUT**/**DELETE** THEN the API responds **404**.
 - **BLC-COLL-008:** WHEN the caller is the personal-team **owner**, or **admin** / **content_maintainer** on the owning team, THEN mutations are allowed (subject to validation).
-- **BLC-COLL-009:** WHEN **POST** creates a collection THEN **`owner`** IS ALWAYS the caller’s **personal** team.
+- **BLC-COLL-009:** WHEN **POST** omits **`owner`** THEN the new collection’s **`owner`** IS the caller’s **personal** team. WHEN **POST** includes **`owner`** THEN it MUST name a team id the caller may **edit** (library content); **guest** on that team THEN **404**; unknown team or no edit access THEN **404** (malformed id THEN **400**).
 - **BLC-COLL-010:** WHEN **GET /collections** runs THEN only collections whose **`owner`** team the caller may read are returned; optional **`q`** filters by **title**.
 - **BLC-COLL-011:** WHEN **GET /collections/{id}**, **…/songs**, or **…/player** runs THEN visibility matches **GET /collections/{id}**.
 - **BLC-COLL-012:** WHEN **GET …/songs** runs AND a stored song id does not resolve THEN the API MAY respond **500** rather than a partial list.
@@ -30,3 +30,9 @@
 - **BLC-COLL-017:** WHEN the **cover** blob IS **DELETE**d THEN **GET /collections/{id}** for that collection MAY return **404** until the collection is fixed or removed.
 - **BLC-COLL-018:** WHEN a **user** account IS deleted THEN collections owned by their **personal** team are removed with that team ([user.md](./user.md)).
 - **BLC-COLL-019:** WHEN a referenced **song** IS deleted THEN collection endpoints MAY error or show stale slots until **PUT** updates **songs** ([song.md](./song.md)).
+
+## Move (`POST /collections/{id}/move`)
+
+- **BLC-COLL-020:** **`POST /collections/{id}/move`** with body **`{ "owner": "<team id>" }`** requires **library edit** access on **both** the collection’s **current** owning team and the **target** team; if either check fails, or the target team id is unknown or illegal, the API responds **404** (or **400** for malformed **`owner`**), consistent with other ACL hiding. Platform **admin** MUST NOT bypass library write for this operation.
+- **BLC-COLL-021:** WHEN the target **`owner`** equals the **current** owning team THEN the handler returns **200** with an **unchanged** representation (idempotent).
+- **BLC-COLL-022:** **`POST …/move`** updates **only** the collection’s **`owner`**; it does **not** rewrite **songs** entries or other cross-team references (shallow move).

--- a/docs/business-logic-constraints/setlist.md
+++ b/docs/business-logic-constraints/setlist.md
@@ -19,7 +19,7 @@
 - **BLC-SETL-006:** WHEN the caller may not read the owning team’s library THEN setlist reads respond **404**.
 - **BLC-SETL-007:** WHEN the caller is **guest** on the owning team and attempts **PUT** or **DELETE** THEN the API responds **404**.
 - **BLC-SETL-008:** WHEN the caller is the personal-team **owner**, or **admin** / **content_maintainer** on the owning team, THEN **PUT**/**DELETE** are allowed (subject to validation).
-- **BLC-SETL-009:** WHEN **POST** creates a setlist THEN **`owner`** IS ALWAYS the caller’s **personal** team.
+- **BLC-SETL-009:** WHEN **POST** omits **`owner`** THEN the new setlist’s **`owner`** IS the caller’s **personal** team. WHEN **POST** includes **`owner`**, the same team ACL rules apply as for collections ([collection.md](./collection.md) **BLC-COLL-009**).
 - **BLC-SETL-010:** WHEN **GET /setlists** runs THEN only setlists whose **`owner`** team the caller may read are returned; optional **`q`** filters by **title**.
 - **BLC-SETL-011:** WHEN **GET /setlists/{id}**, **…/songs**, or **…/player** runs THEN visibility matches **GET /setlists/{id}**.
 - **BLC-SETL-012:** WHEN **DELETE** succeeds THEN the setlist no longer appears under the same read rules.
@@ -28,3 +28,9 @@
 
 - **BLC-SETL-013:** WHEN a **user** account IS deleted THEN setlists owned by their **personal** team are removed with that team ([user.md](./user.md)).
 - **BLC-SETL-014:** WHEN a **song** in **`songs`** IS deleted THEN setlist payloads MAY retain stale ids until **PUT** ([song.md](./song.md)).
+
+## Move (`POST /setlists/{id}/move`)
+
+- **BLC-SETL-015:** **`POST /setlists/{id}/move`** with **`{ "owner": "<team id>" }`** requires **library edit** on **both** the setlist’s current owning team and the target team; otherwise **404** (or **400** for malformed **`owner`**). Platform **admin** MUST NOT bypass library write for move.
+- **BLC-SETL-016:** WHEN the target **`owner`** equals the current owning team THEN **200** with unchanged body (idempotent).
+- **BLC-SETL-017:** Move is **shallow**: **`songs`** links are not rewritten for cross-team consistency.

--- a/docs/business-logic-constraints/song.md
+++ b/docs/business-logic-constraints/song.md
@@ -4,7 +4,7 @@
 
 - **BLC-SONG-001:** Every song belongs to exactly one **owning team** (**`owner`** in responses).
 - **BLC-SONG-002:** Listing, single-song **GET**, player, and like endpoints require **read** access to that team’s library; **PUT** and **DELETE** require **library edit** access. Platform **admin** does **not** gain song edit solely by role.
-- **BLC-SONG-003:** **`PUT`** MUST NOT change **`owner`** except where the API explicitly allows ownership moves.
+- **BLC-SONG-003:** **`PUT`** MUST NOT change **`owner`**. Changing the owning team is only via **`POST /songs/{id}/move`** with **`{ "owner": "<team id>" }`**.
 - **BLC-SONG-004:** **Like** state IS per **current user** and **song**; anyone who may read the song MAY read like status via **GET** `/songs/{id}/like`, set liked via **PUT** `/songs/{id}/like` (204), or remove like via **DELETE** `/songs/{id}/like` (204).
 
 ## List pagination and search
@@ -16,8 +16,8 @@
 - **BLC-SONG-006:** WHEN the caller may not read the owning team’s library THEN song reads respond **404** (not **403**).
 - **BLC-SONG-007:** WHEN the caller is **guest** on the owning team and attempts **PUT** or **DELETE** THEN the API responds **404**.
 - **BLC-SONG-008:** WHEN the caller is the personal-team **owner**, or **admin** / **content_maintainer** on the owning team, THEN **PUT**/**DELETE** are allowed (subject to validation).
-- **BLC-SONG-009:** WHEN **POST** creates a song THEN **`owner`** IS ALWAYS the caller’s **personal** team.
-- **BLC-SONG-010:** WHEN **POST** completes THEN IF **`default_collection`** is set THEN the new song IS appended there; OTHERWISE a **“Default”** collection is created, set as default, and the song IS placed there.
+- **BLC-SONG-009:** WHEN **POST** omits **`owner`** THEN the new song’s **`owner`** IS the caller’s **personal** team. WHEN **POST** includes **`owner`** THEN it MUST name a team id the caller may **edit**; otherwise **404** (or **400** for malformed id), same visibility pattern as collections.
+- **BLC-SONG-010:** WHEN **POST** completes AND the effective target team IS the caller’s **personal** team (omit **`owner`** OR **`owner`** equals that personal team) THEN IF **`user.default_collection`** is set THEN the new song IS appended there; OTHERWISE a **“Default”** collection is created, **`user.default_collection`** is set, and the song IS placed there. WHEN **POST** targets a **non-personal** team via **`owner`**, this automatic default-collection behavior does **not** run.
 - **BLC-SONG-011:** WHEN **GET /songs** runs THEN only songs whose **`owner`** team the caller may read are returned; optional **`q`** matches **title**, **artists**, and lyric text as defined by the list-search behavior (stemmed where applicable).
 - **BLC-SONG-012:** WHEN **GET /songs/{id}** runs THEN visibility matches the list rule AND the response includes **`liked`** for the current user.
 - **BLC-SONG-013:** WHEN **GET …/player** runs THEN visibility matches **GET /songs/{id}**.
@@ -25,6 +25,12 @@
 - **BLC-SONG-017:** WHEN **PUT /songs/{id}** body fails validation (e.g. empty **`data`**, or wrong types for fields such as **`tempo`** / **`time`**) THEN **400**.
 - **BLC-SONG-019:** WHEN **PATCH /songs/{id}** omits **`data`** and other patch fields THEN those properties remain unchanged; the request body lists only fields to update (see OpenAPI **`PatchSong`**).
 - **BLC-SONG-018:** WHEN **PUT /songs/{id}** uses an **`{id}`** that does not yet refer to an existing song THEN the API MAY create the song (**200**) with that **id** and **`owner`** the caller’s **personal** team, subject to **BLC-SONG-007** and **BLC-SONG-008** for **guest** vs **edit** rights on that team.
+
+## Move (`POST /songs/{id}/move`)
+
+- **BLC-SONG-020:** **`POST /songs/{id}/move`** requires **library edit** on **both** the song’s current owning team and the target team; otherwise **404** (or **400** for malformed **`owner`**). Platform **admin** MUST NOT bypass library write for move.
+- **BLC-SONG-021:** WHEN the target **`owner`** equals the current owning team THEN **200** with an unchanged song (idempotent).
+- **BLC-SONG-022:** Move updates **`owner`** only; it does **not** add or remove the song from any **collection** or **setlist** (shallow move).
 
 ## Cascading deletes and collection/setlist references
 

--- a/frontend/src/components/setlist_editor.rs
+++ b/frontend/src/components/setlist_editor.rs
@@ -159,6 +159,7 @@ pub fn setlist_editor(props: &Props) -> Html {
         let onsave_upstream = props.onsave.clone();
         Callback::from(move |_: MouseEvent| {
             let new_setlist = CreateSetlist {
+                owner: None,
                 title: (*title).clone(),
                 songs: (*items)
                     .iter()

--- a/frontend/src/pages/setlist_editor.rs
+++ b/frontend/src/pages/setlist_editor.rs
@@ -33,6 +33,7 @@ impl From<Setlist> for EditorState {
         Self {
             id: Some(value.id),
             data: CreateSetlist {
+                owner: None,
                 title: value.title,
                 songs: value.songs,
             },

--- a/shared/src/blob/blob.rs
+++ b/shared/src/blob/blob.rs
@@ -56,10 +56,14 @@ impl Blob {
         "file_type": "image/png",
         "width": 1200,
         "height": 800,
-        "ocr": ""
+        "ocr": "",
+        "owner": "team_example_id"
     }))
 )]
 pub struct CreateBlob {
+    /// Owning team id (same format as `Blob.owner` in responses). Omit to create under the caller's personal team.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
     pub file_type: FileType,
     pub width: u32,
     pub height: u32,
@@ -82,6 +86,7 @@ pub struct UpdateBlob {
 impl From<UpdateBlob> for CreateBlob {
     fn from(value: UpdateBlob) -> Self {
         Self {
+            owner: None,
             file_type: value.file_type,
             width: value.width,
             height: value.height,
@@ -105,6 +110,7 @@ pub struct PatchBlob {
 impl From<Blob> for CreateBlob {
     fn from(value: Blob) -> Self {
         Self {
+            owner: None,
             file_type: value.file_type,
             width: value.width,
             height: value.height,

--- a/shared/src/collection/collection.rs
+++ b/shared/src/collection/collection.rs
@@ -36,10 +36,14 @@ pub struct Collection {
     schema(example = json!({
         "title": "Sunday worship",
         "cover": "",
-        "songs": [{ "id": "song_example", "nr": null, "key": null }]
+        "songs": [{ "id": "song_example", "nr": null, "key": null }],
+        "owner": "team_example_id"
     }))
 )]
 pub struct CreateCollection {
+    /// Owning team id (`team` record id, same format as `Collection.owner` in responses). Omit to create under the caller's personal team.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
     pub title: String,
     pub cover: String,
     pub songs: Vec<SongLink>,
@@ -58,6 +62,7 @@ pub struct UpdateCollection {
 impl From<UpdateCollection> for CreateCollection {
     fn from(value: UpdateCollection) -> Self {
         Self {
+            owner: None,
             title: value.title,
             cover: value.cover,
             songs: value.songs,
@@ -78,6 +83,7 @@ pub struct PatchCollection {
 impl From<Collection> for CreateCollection {
     fn from(value: Collection) -> Self {
         Self {
+            owner: None,
             title: value.title,
             cover: value.cover,
             songs: value.songs,

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -6,6 +6,8 @@ pub use patch::Patch;
 pub mod collection;
 pub mod error;
 pub mod like;
+pub mod move_owner;
+pub use move_owner::MoveOwner;
 pub mod net;
 pub mod patch;
 pub mod player;

--- a/shared/src/move_owner.rs
+++ b/shared/src/move_owner.rs
@@ -1,0 +1,21 @@
+//! Request body for `POST .../{id}/move` (change owning team).
+
+#[cfg(feature = "backend")]
+#[allow(unused_imports)]
+use serde_json::json;
+#[cfg(feature = "backend")]
+use utoipa::ToSchema;
+
+use serde::{Deserialize, Serialize};
+
+/// Target owning team for a library resource move (`owner` string matches GET responses).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "backend", derive(ToSchema))]
+#[cfg_attr(
+    feature = "backend",
+    schema(example = json!({ "owner": "team_target_id" }))
+)]
+pub struct MoveOwner {
+    pub owner: String,
+}

--- a/shared/src/setlist/setlist.rs
+++ b/shared/src/setlist/setlist.rs
@@ -32,10 +32,14 @@ pub struct Setlist {
     feature = "backend",
     schema(example = json!({
         "title": "Easter Sunday",
-        "songs": [{ "id": "song_example", "nr": "1", "key": null }]
+        "songs": [{ "id": "song_example", "nr": "1", "key": null }],
+        "owner": "team_example_id"
     }))
 )]
 pub struct CreateSetlist {
+    /// Owning team id (same format as `Setlist.owner` in responses). Omit to create under the caller's personal team.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
     pub title: String,
     pub songs: Vec<SongLink>,
 }
@@ -61,6 +65,7 @@ impl From<CreateSetlist> for UpdateSetlist {
 impl From<UpdateSetlist> for CreateSetlist {
     fn from(value: UpdateSetlist) -> Self {
         Self {
+            owner: None,
             title: value.title,
             songs: value.songs,
         }
@@ -79,6 +84,7 @@ pub struct PatchSetlist {
 impl From<Setlist> for CreateSetlist {
     fn from(value: Setlist) -> Self {
         Self {
+            owner: None,
             title: value.title,
             songs: value.songs,
         }

--- a/shared/src/song/song.rs
+++ b/shared/src/song/song.rs
@@ -47,10 +47,14 @@ pub struct Song {
     schema(example = json!({
         "not_a_song": false,
         "blobs": [],
-        "data": { "titles": ["Example Hymn"], "sections": [] }
+        "data": { "titles": ["Example Hymn"], "sections": [] },
+        "owner": "team_example_id"
     }))
 )]
 pub struct CreateSong {
+    /// Owning team id (same format as `Song.owner` in responses). Omit to create under the caller's personal team (and apply default-collection rules).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
     pub not_a_song: bool,
     pub blobs: Vec<BlobLink>,
     #[cfg_attr(feature = "backend", schema(value_type = SongDataSchema))]
@@ -79,6 +83,7 @@ pub struct UpdateSong {
 impl From<UpdateSong> for CreateSong {
     fn from(value: UpdateSong) -> Self {
         Self {
+            owner: None,
             not_a_song: value.not_a_song,
             blobs: value.blobs,
             data: value.data,
@@ -158,6 +163,7 @@ impl TryFrom<&str> for CreateSong {
 
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         Ok(Self {
+            owner: None,
             not_a_song: false,
             blobs: vec![],
             data: chord_pro::load_string(s)?,
@@ -197,6 +203,11 @@ impl CreateSong {
     /// Reject oversized blob reference lists before hitting the service layer.
     pub fn validate(&self) -> Result<(), String> {
         use crate::validation_limits::MAX_BLOBS_PER_SONG;
+        if let Some(ref o) = self.owner {
+            if o.trim().is_empty() {
+                return Err("owner must not be empty or whitespace-only".to_owned());
+            }
+        }
         if self.blobs.len() > MAX_BLOBS_PER_SONG {
             return Err(format!(
                 "too many blob references (max {MAX_BLOBS_PER_SONG})"
@@ -244,6 +255,7 @@ impl From<CreateSong> for Song {
 impl From<Song> for CreateSong {
     fn from(value: Song) -> Self {
         Self {
+            owner: None,
             not_a_song: value.not_a_song,
             blobs: value.blobs,
             data: value.data,
@@ -268,6 +280,7 @@ mod tests {
     fn create_song_validate_rejects_too_many_blobs() {
         use crate::validation_limits::MAX_BLOBS_PER_SONG;
         let mut s = CreateSong {
+            owner: None,
             not_a_song: false,
             blobs: vec![],
             data: chordlib::types::Song::default(),


### PR DESCRIPTION
- Rename parse_owner_record_id / require_write_access_to_owner for team owner RecordIds
- Optional owner on create for songs, collections, setlists, blobs; frontend CreateSetlist owner: None
- POST /api/v1/{collections,setlists,blobs,songs}/{id}/move with MoveOwner; dual write ACL; shallow move BLC
- OpenAPI snapshot, integration tests, two_shared_teams_for_user helper

Made-with: Cursor
