### PR TITLE
fix(db): define oidc_state.provider for Google OAuth

### DIFF
--- a/backend/db-migrations/20260420000015_oidc_state_provider_field.surql
+++ b/backend/db-migrations/20260420000015_oidc_state_provider_field.surql
@@ -1,0 +1,3 @@
+-- App serializes `provider` on OIDC CSRF state records (`OidcStateRecord`); SCHEMAFULL
+-- `oidc_state` must declare it. Additive for DBs that already ran `20260420000006_define_table_oidc_state.surql`.
+DEFINE FIELD OVERWRITE provider ON oidc_state TYPE none | string PERMISSIONS FULL;


### PR DESCRIPTION
## Summary
Production Google OAuth returned 500 because SurrealDB rejected creating `oidc_state` rows: **`provider` was not defined** on the SCHEMAFULL table while the app always serializes it.

## Change
- Add migration `20260420000015_oidc_state_provider_field.surql`: `DEFINE FIELD OVERWRITE provider ON oidc_state TYPE none | string`.

## Verification
- `cargo build`, `cargo test`, Spectral, `cargo clippy -D warnings`, `cargo fmt --check` (backend + shared)
- Venom `backend/tests/*.yml` against a local server on a random `PORT`

## Deploy
Apply migrations on production (or run the `DEFINE FIELD` once manually) before/after deploy; then retry Google login.

Made with [Cursor](https://cursor.com)