### PR TITLE
feat(api): allow owner changes on song, setlist, and collection updates

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -938,6 +938,10 @@
             "nullable": true,
             "type": "string"
           },
+          "owner": {
+            "nullable": true,
+            "type": "string"
+          },
           "songs": {
             "items": {
               "$ref": "#/components/schemas/SongLink"
@@ -956,6 +960,10 @@
         "additionalProperties": false,
         "description": "Partial update for a setlist. Absent fields are left unchanged.",
         "properties": {
+          "owner": {
+            "nullable": true,
+            "type": "string"
+          },
           "songs": {
             "items": {
               "$ref": "#/components/schemas/SongLink"
@@ -990,6 +998,11 @@
           "not_a_song": {
             "nullable": true,
             "type": "boolean"
+          },
+          "owner": {
+            "description": "Set the song's owning team id; omit to leave unchanged.",
+            "nullable": true,
+            "type": "string"
           }
         },
         "required": [
@@ -1958,6 +1971,11 @@
           "cover": {
             "type": "string"
           },
+          "owner": {
+            "description": "Target team id for the collection's `owner`; omit or `null` to keep the current owner.",
+            "nullable": true,
+            "type": "string"
+          },
           "songs": {
             "items": {
               "$ref": "#/components/schemas/SongLink"
@@ -1979,6 +1997,11 @@
         "additionalProperties": false,
         "description": "Full replacement body for `PUT /api/v1/setlists/{id}`.",
         "properties": {
+          "owner": {
+            "description": "Target team id for the setlist's `owner`; omit or `null` to keep the current owner.",
+            "nullable": true,
+            "type": "string"
+          },
           "songs": {
             "items": {
               "$ref": "#/components/schemas/SongLink"
@@ -2020,6 +2043,11 @@
           },
           "not_a_song": {
             "type": "boolean"
+          },
+          "owner": {
+            "description": "Target team id for the song's `owner`; omit or `null` to keep the current owner.",
+            "nullable": true,
+            "type": "string"
           }
         },
         "required": [

--- a/backend/src/resources/collection/repository.rs
+++ b/backend/src/resources/collection/repository.rs
@@ -46,6 +46,7 @@ pub trait CollectionRepository: Send + Sync {
         write_teams: &[RecordId],
         id: &str,
         collection: CreateCollection,
+        owner: Option<RecordId>,
     ) -> Result<Collection, AppError>;
 
     async fn delete_collection(

--- a/backend/src/resources/collection/rest.rs
+++ b/backend/src/resources/collection/rest.rs
@@ -300,8 +300,13 @@ async fn update_collection(
     let etag = weak_etag_json(&collection)
         .map_err(|e| AppError::internal_from_err("collection.rest", e))?;
     check_if_match(&req, &etag)?;
-    let payload = CreateCollection::from(payload.into_inner());
-    Ok(HttpResponse::Ok().json(svc.update_collection_for_user(&perms, &id, payload).await?))
+    let payload = payload.into_inner();
+    let owner = payload.owner.clone();
+    let payload = CreateCollection::from(payload);
+    Ok(HttpResponse::Ok().json(
+        svc.update_collection_for_user(&perms, &id, payload, owner)
+            .await?,
+    ))
 }
 
 #[utoipa::path(

--- a/backend/src/resources/collection/service.rs
+++ b/backend/src/resources/collection/service.rs
@@ -9,7 +9,7 @@ use tracing::instrument;
 
 use crate::database::Database;
 use crate::error::AppError;
-use crate::resources::common::player_from_song_links;
+use crate::resources::common::{player_from_song_links, resolve_owner_team};
 use crate::resources::song::LikedSongIds;
 use crate::resources::team::{
     TeamResolver, UserPermissions, parse_owner_record_id, thing_record_key,
@@ -125,10 +125,12 @@ impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionServic
         perms: &UserPermissions<T>,
         id: &str,
         collection: CreateCollection,
+        owner: Option<String>,
     ) -> Result<Collection, AppError> {
         let write_teams = perms.write_teams().await?;
+        let owner = resolve_owner_team(write_teams, owner)?;
         self.repo
-            .update_collection(write_teams, id, collection)
+            .update_collection(write_teams, id, collection, owner)
             .await
     }
 
@@ -139,6 +141,7 @@ impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionServic
         id: &str,
         patch: PatchCollection,
     ) -> Result<Collection, AppError> {
+        let owner = patch.owner.clone();
         let current = self.get_collection_for_user(perms, id).await?;
         let merged = CreateCollection {
             owner: None,
@@ -146,7 +149,8 @@ impl<R: CollectionRepository, T: TeamResolver, L: LikedSongIds> CollectionServic
             cover: patch.cover.unwrap_or(current.cover),
             songs: patch.songs.unwrap_or(current.songs),
         };
-        self.update_collection_for_user(perms, id, merged).await
+        self.update_collection_for_user(perms, id, merged, owner)
+            .await
     }
 
     #[instrument(level = "debug", err, skip(self, perms, payload))]
@@ -286,6 +290,7 @@ mod tests {
                         key: None,
                     }],
                 },
+                None,
             )
             .await
             .expect("update");
@@ -301,6 +306,7 @@ mod tests {
                     cover: "mysongs".into(),
                     songs: vec![],
                 },
+                None,
             )
             .await;
         assert!(matches!(put_guest, Err(AppError::NotFound(_))));
@@ -398,7 +404,7 @@ mod tests {
             .create_collection_for_user(&owner_p, make_collection("CMTest"))
             .await
             .expect("create");
-        svc.update_collection_for_user(&cm_p, &col.id, make_collection("CMUpdated"))
+        svc.update_collection_for_user(&cm_p, &col.id, make_collection("CMUpdated"), None)
             .await
             .expect("cm update");
     }
@@ -423,7 +429,7 @@ mod tests {
             .await
             .expect("create");
         let r = svc
-            .update_collection_for_user(&guest_p, &col.id, make_collection("Hack"))
+            .update_collection_for_user(&guest_p, &col.id, make_collection("Hack"), None)
             .await;
         assert!(matches!(r, Err(AppError::NotFound(_))));
     }
@@ -455,10 +461,50 @@ mod tests {
             .expect("create");
         assert_eq!(col.owner, tid);
         let updated = svc
-            .update_collection_for_user(&owner_p, &col.id, make_collection("Renamed"))
+            .update_collection_for_user(&owner_p, &col.id, make_collection("Renamed"), None)
             .await
             .expect("update");
-        assert_eq!(updated.owner, tid, "owner must not change on PUT");
+        assert_eq!(
+            updated.owner, tid,
+            "owner must not change on PUT when omitted"
+        );
+    }
+
+    #[tokio::test]
+    async fn blc_coll_put_moves_owner_when_target_writable() {
+        let db = test_db().await.expect("db");
+        let fx = TeamFixture::build(&db).await.expect("fixture");
+        let svc = CollectionServiceHandle::build(db.clone());
+        let admin_p = UserPermissions::from_ref(&fx.admin_user, &svc.teams);
+        let col = svc
+            .create_collection_for_user(
+                &admin_p,
+                CreateCollection {
+                    owner: None,
+                    title: "MoveCol".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![],
+                },
+            )
+            .await
+            .expect("create");
+        let personal = personal_team_id(&db, &fx.admin_user).await.expect("pt");
+        assert_eq!(col.owner, personal);
+        let updated = svc
+            .update_collection_for_user(
+                &admin_p,
+                &col.id,
+                CreateCollection {
+                    owner: None,
+                    title: "MoveCol".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![],
+                },
+                Some(fx.shared_team_id.clone()),
+            )
+            .await
+            .expect("move");
+        assert_eq!(updated.owner, fx.shared_team_id);
     }
 
     /// BLC-COLL-004: POST with a non-existent song ID succeeds (no existence check).
@@ -625,6 +671,7 @@ mod tests {
                     title: Some("New Title".into()),
                     cover: None,
                     songs: None,
+                    owner: None,
                 },
             )
             .await
@@ -660,6 +707,7 @@ mod tests {
                     title: None,
                     cover: Some("newheart".into()),
                     songs: None,
+                    owner: None,
                 },
             )
             .await
@@ -684,6 +732,7 @@ mod tests {
                     title: Some("x".into()),
                     cover: None,
                     songs: None,
+                    owner: None,
                 },
             )
             .await;
@@ -738,6 +787,7 @@ mod tests {
                             nr: Some("9".into()),
                             key: None,
                         }]),
+                        owner: None,
                     },
                 )
                 .await

--- a/backend/src/resources/collection/surreal_repo.rs
+++ b/backend/src/resources/collection/surreal_repo.rs
@@ -166,6 +166,7 @@ impl CollectionRepository for SurrealCollectionRepo {
         write_teams: &[RecordId],
         id: &str,
         collection: CreateCollection,
+        owner: Option<RecordId>,
     ) -> Result<Collection, AppError> {
         let db = self.inner();
         let (tb, sid) = resource_id("collection", id)?;
@@ -173,19 +174,34 @@ impl CollectionRepository for SurrealCollectionRepo {
         let cover = blob_thing(&collection.cover);
         let title = collection.title;
 
-        let mut response = db
-            .db
-            .query(
-                "UPDATE type::record($tb, $sid) SET title = $title, cover = $cover, songs = $songs \
-                 WHERE owner IN $teams RETURN AFTER",
-            )
-            .bind(("tb", tb))
-            .bind(("sid", sid))
-            .bind(("title", title))
-            .bind(("cover", cover))
-            .bind(("songs", songs))
-            .bind(("teams", write_teams.to_vec()))
-            .await?;
+        let mut response = if let Some(ref owner_rid) = owner {
+            db.db
+                .query(
+                    "UPDATE type::record($tb, $sid) SET title = $title, cover = $cover, songs = $songs, \
+                     owner = $owner WHERE owner IN $teams RETURN AFTER",
+                )
+                .bind(("tb", tb))
+                .bind(("sid", sid))
+                .bind(("title", title))
+                .bind(("cover", cover))
+                .bind(("songs", songs))
+                .bind(("owner", owner_rid.clone()))
+                .bind(("teams", write_teams.to_vec()))
+                .await?
+        } else {
+            db.db
+                .query(
+                    "UPDATE type::record($tb, $sid) SET title = $title, cover = $cover, songs = $songs \
+                     WHERE owner IN $teams RETURN AFTER",
+                )
+                .bind(("tb", tb))
+                .bind(("sid", sid))
+                .bind(("title", title))
+                .bind(("cover", cover))
+                .bind(("songs", songs))
+                .bind(("teams", write_teams.to_vec()))
+                .await?
+        };
 
         let rows: Vec<CollectionRecord> = response.take(0)?;
         rows.into_iter()

--- a/backend/src/resources/common.rs
+++ b/backend/src/resources/common.rs
@@ -72,6 +72,31 @@ pub fn blob_thing(id: &str) -> RecordId {
     }
 }
 
+/// Parse a plain team id (API `owner` string) into a `team:…` [`RecordId`].
+pub fn team_thing(id: &str) -> Result<RecordId, AppError> {
+    let (tb, sid) = resource_id("team", id)?;
+    Ok(RecordId::new(tb, sid))
+}
+
+/// Resolve optional `owner` from PUT/PATCH bodies: must be a team the caller may write.
+pub fn resolve_owner_team(
+    write_teams: &[RecordId],
+    owner: Option<String>,
+) -> Result<Option<RecordId>, AppError> {
+    let Some(s) = owner else {
+        return Ok(None);
+    };
+    if s.is_empty() {
+        return Err(AppError::invalid_request("owner must not be empty"));
+    }
+    let tid = team_thing(&s)?;
+    if write_teams.contains(&tid) {
+        Ok(Some(tid))
+    } else {
+        Err(AppError::NotFound("resource not found".into()))
+    }
+}
+
 /// Build a [`Player`] from fetched song links, populating liked flags and
 /// filling in default track numbers where absent.
 pub fn player_from_song_links(

--- a/backend/src/resources/setlist/repository.rs
+++ b/backend/src/resources/setlist/repository.rs
@@ -42,6 +42,7 @@ pub trait SetlistRepository: Send + Sync {
         write_teams: &[RecordId],
         id: &str,
         setlist: CreateSetlist,
+        owner: Option<RecordId>,
     ) -> Result<Setlist, AppError>;
 
     async fn delete_setlist(&self, write_teams: &[RecordId], id: &str)

--- a/backend/src/resources/setlist/rest.rs
+++ b/backend/src/resources/setlist/rest.rs
@@ -300,8 +300,13 @@ async fn update_setlist(
     let etag =
         weak_etag_json(&setlist).map_err(|e| AppError::internal_from_err("setlist.rest", e))?;
     check_if_match(&req, &etag)?;
-    let payload = CreateSetlist::from(payload.into_inner());
-    Ok(HttpResponse::Ok().json(svc.update_setlist_for_user(&perms, &id, payload).await?))
+    let payload = payload.into_inner();
+    let owner = payload.owner.clone();
+    let payload = CreateSetlist::from(payload);
+    Ok(HttpResponse::Ok().json(
+        svc.update_setlist_for_user(&perms, &id, payload, owner)
+            .await?,
+    ))
 }
 
 #[utoipa::path(

--- a/backend/src/resources/setlist/service.rs
+++ b/backend/src/resources/setlist/service.rs
@@ -8,6 +8,7 @@ use shared::song::Song;
 use tracing::instrument;
 
 use crate::error::AppError;
+use crate::resources::common::resolve_owner_team;
 use crate::resources::song::LikedSongIds;
 use crate::resources::team::{
     TeamResolver, UserPermissions, parse_owner_record_id, thing_record_key,
@@ -123,9 +124,13 @@ impl<R: SetlistRepository, T: TeamResolver, L: LikedSongIds> SetlistService<R, T
         perms: &UserPermissions<T>,
         id: &str,
         setlist: CreateSetlist,
+        owner: Option<String>,
     ) -> Result<Setlist, AppError> {
         let write_teams = perms.write_teams().await?;
-        self.repo.update_setlist(write_teams, id, setlist).await
+        let owner = resolve_owner_team(write_teams, owner)?;
+        self.repo
+            .update_setlist(write_teams, id, setlist, owner)
+            .await
     }
 
     #[instrument(level = "debug", err, skip(self, perms, patch))]
@@ -135,13 +140,14 @@ impl<R: SetlistRepository, T: TeamResolver, L: LikedSongIds> SetlistService<R, T
         id: &str,
         patch: PatchSetlist,
     ) -> Result<Setlist, AppError> {
+        let owner = patch.owner.clone();
         let current = self.get_setlist_for_user(perms, id).await?;
         let merged = CreateSetlist {
             owner: None,
             title: patch.title.unwrap_or(current.title),
             songs: patch.songs.unwrap_or(current.songs),
         };
-        self.update_setlist_for_user(perms, id, merged).await
+        self.update_setlist_for_user(perms, id, merged, owner).await
     }
 
     #[instrument(level = "debug", err, skip(self, perms, payload))]
@@ -200,8 +206,8 @@ mod tests {
     use crate::resources::song::LikedSongIds;
     use crate::resources::team::{TeamResolver, UserPermissions};
     use crate::test_helpers::{
-        configure_personal_team_members, create_song_with_title, create_user, personal_team_id,
-        setlist_service, setlist_with_songs, test_db, two_shared_teams_for_user,
+        TeamFixture, configure_personal_team_members, create_song_with_title, create_user,
+        personal_team_id, setlist_service, setlist_with_songs, test_db, two_shared_teams_for_user,
     };
     use shared::MoveOwner;
 
@@ -262,6 +268,7 @@ mod tests {
             _write_teams: &[RecordId],
             _id: &str,
             _setlist: CreateSetlist,
+            _owner: Option<RecordId>,
         ) -> Result<Setlist, AppError> {
             if self.update_ok {
                 Ok(Setlist {
@@ -419,6 +426,7 @@ mod tests {
                     title: "t".into(),
                     songs: vec![],
                 },
+                None,
             )
             .await;
         assert!(matches!(r, Err(AppError::NotFound(_))));
@@ -452,6 +460,7 @@ mod tests {
                     title: "t".into(),
                     songs: vec![],
                 },
+                None,
             )
             .await;
         assert!(r.is_ok());
@@ -462,6 +471,36 @@ mod tests {
     #[tokio::test]
     async fn blc_setl_002_team_acl_configured() {
         let (_db, _owner, _read, _write, _noperm, _team) = four_user_setlist_fixture().await;
+    }
+
+    #[tokio::test]
+    async fn blc_setl_put_moves_owner_when_target_writable() {
+        let db = test_db().await.expect("db");
+        let fx = TeamFixture::build(&db).await.expect("fixture");
+        let sl = setlist_service(&db);
+        let s1 = create_song_with_title(&db, &fx.admin_user, "S")
+            .await
+            .expect("s");
+        let admin_p = UserPermissions::from_ref(&fx.admin_user, &sl.teams);
+        let created = sl
+            .create_setlist_for_user(
+                &admin_p,
+                setlist_with_songs("MoveSet", &[(s1.id.as_str(), None)]),
+            )
+            .await
+            .expect("create");
+        let personal = personal_team_id(&db, &fx.admin_user).await.expect("pt");
+        assert_eq!(created.owner, personal);
+        let updated = sl
+            .update_setlist_for_user(
+                &admin_p,
+                &created.id,
+                setlist_with_songs("MoveSet", &[(s1.id.as_str(), None)]),
+                Some(fx.shared_team_id.clone()),
+            )
+            .await
+            .expect("move");
+        assert_eq!(updated.owner, fx.shared_team_id);
     }
 
     /// BLC-SETL-009a: create sets owner to the owner's personal team and stores title/songs.
@@ -844,6 +883,7 @@ mod tests {
                     "Owner Updated Title",
                     &[(s1.id.as_str(), Some("1")), (s2.id.as_str(), Some("2"))],
                 ),
+                None,
             )
             .await
             .expect("update owner");
@@ -857,6 +897,7 @@ mod tests {
                     "Write User Updated Title",
                     &[(s1.id.as_str(), Some("10")), (s2.id.as_str(), Some("20"))],
                 ),
+                None,
             )
             .await
             .expect("update write user");
@@ -873,6 +914,7 @@ mod tests {
                 &read_p,
                 &created.id,
                 setlist_with_songs("Read User Put", &[(s1.id.as_str(), None)]),
+                None,
             )
             .await;
         assert!(matches!(put_read, Err(AppError::NotFound(_))));
@@ -882,6 +924,7 @@ mod tests {
                 &noperm_p,
                 &created.id,
                 setlist_with_songs("Should Fail", &[(s1.id.as_str(), None)]),
+                None,
             )
             .await;
         assert!(matches!(put_noperm, Err(AppError::NotFound(_))));
@@ -891,6 +934,7 @@ mod tests {
                 &owner_p,
                 "song:invalid",
                 setlist_with_songs("x", &[(s1.id.as_str(), None)]),
+                None,
             )
             .await;
         assert!(matches!(put_bad, Err(AppError::InvalidRequest(_))));
@@ -900,6 +944,7 @@ mod tests {
                 &owner_p,
                 "never-created-setlist",
                 setlist_with_songs("Unknown", &[(s1.id.as_str(), None)]),
+                None,
             )
             .await;
         assert!(matches!(put_nf, Err(AppError::NotFound(_))));
@@ -931,6 +976,7 @@ mod tests {
                 PatchSetlist {
                     title: Some("New Title".into()),
                     songs: None,
+                    owner: None,
                 },
             )
             .await
@@ -958,6 +1004,7 @@ mod tests {
                 PatchSetlist {
                     title: Some("x".into()),
                     songs: None,
+                    owner: None,
                 },
             )
             .await;
@@ -989,6 +1036,7 @@ mod tests {
                 PatchSetlist {
                     title: Some("Hacked".into()),
                     songs: None,
+                    owner: None,
                 },
             )
             .await;
@@ -1032,6 +1080,7 @@ mod tests {
                             nr: Some("9".into()),
                             key: None,
                         }]),
+                        owner: None,
                     },
                 )
                 .await

--- a/backend/src/resources/setlist/surreal_repo.rs
+++ b/backend/src/resources/setlist/surreal_repo.rs
@@ -158,24 +158,39 @@ impl SetlistRepository for SurrealSetlistRepo {
         write_teams: &[RecordId],
         id: &str,
         setlist: CreateSetlist,
+        owner: Option<RecordId>,
     ) -> Result<Setlist, AppError> {
         let db = self.inner();
         let (tb, sid) = resource_id("setlist", id)?;
         let songs: Vec<SongLinkRecord> = setlist.songs.into_iter().map(Into::into).collect();
         let title = setlist.title;
 
-        let mut response = db
-            .db
-            .query(
-                "UPDATE type::record($tb, $sid) SET title = $title, songs = $songs \
-                 WHERE owner IN $teams RETURN AFTER",
-            )
-            .bind(("tb", tb))
-            .bind(("sid", sid))
-            .bind(("title", title))
-            .bind(("songs", songs))
-            .bind(("teams", write_teams.to_vec()))
-            .await?;
+        let mut response = if let Some(ref owner_rid) = owner {
+            db.db
+                .query(
+                    "UPDATE type::record($tb, $sid) SET title = $title, songs = $songs, owner = $owner \
+                     WHERE owner IN $teams RETURN AFTER",
+                )
+                .bind(("tb", tb))
+                .bind(("sid", sid))
+                .bind(("title", title))
+                .bind(("songs", songs))
+                .bind(("owner", owner_rid.clone()))
+                .bind(("teams", write_teams.to_vec()))
+                .await?
+        } else {
+            db.db
+                .query(
+                    "UPDATE type::record($tb, $sid) SET title = $title, songs = $songs \
+                     WHERE owner IN $teams RETURN AFTER",
+                )
+                .bind(("tb", tb))
+                .bind(("sid", sid))
+                .bind(("title", title))
+                .bind(("songs", songs))
+                .bind(("teams", write_teams.to_vec()))
+                .await?
+        };
 
         let rows: Vec<SetlistRecord> = response.take(0)?;
         rows.into_iter()

--- a/backend/src/resources/song/repository.rs
+++ b/backend/src/resources/song/repository.rs
@@ -47,12 +47,16 @@ pub trait SongRepository: Send + Sync {
     /// - If the song does not exist and the actor's personal team is in
     ///   `write_teams`, creates it with the given `id` under that team.
     /// - Otherwise returns [`AppError::NotFound`].
+    ///
+    /// When `owner` is `Some`, the row's `owner` is set to that team (caller must
+    /// already have write access to both the existing and new owner teams).
     async fn update_song(
         &self,
         write_teams: &[RecordId],
         actor_user_id: &str,
         id: &str,
         song: CreateSong,
+        owner: Option<RecordId>,
     ) -> Result<SongUpsertOutcome, AppError>;
 
     async fn delete_song(&self, write_teams: &[RecordId], id: &str) -> Result<Song, AppError>;

--- a/backend/src/resources/song/rest.rs
+++ b/backend/src/resources/song/rest.rs
@@ -238,6 +238,7 @@ async fn update_song(
     let perms = UserPermissions::from_ref(&user, &svc.teams);
     let payload = payload.into_inner();
     payload.validate().map_err(AppError::invalid_request)?;
+    let owner = payload.owner.clone();
     let payload = CreateSong::from(payload);
     let id = id.into_inner();
     match svc.get_song_for_user(&perms, &id).await {
@@ -249,7 +250,10 @@ async fn update_song(
         Err(AppError::NotFound(_)) => {}
         Err(e) => return Err(e),
     }
-    match svc.update_song_for_user(&perms, &id, payload).await? {
+    match svc
+        .update_song_for_user(&perms, &id, payload, owner)
+        .await?
+    {
         SongUpsertOutcome::Created(song) => Ok(HttpResponse::Created()
             .insert_header((header::LOCATION, format!("/api/v1/songs/{}", song.id)))
             .json(song)),

--- a/backend/src/resources/song/service.rs
+++ b/backend/src/resources/song/service.rs
@@ -14,6 +14,7 @@ use shared::song::{
 use crate::database::Database;
 use crate::error::AppError;
 use crate::resources::collection::CollectionRepository;
+use crate::resources::common::resolve_owner_team;
 
 use crate::resources::team::{
     TeamResolver, UserPermissions, parse_owner_record_id, thing_record_key,
@@ -279,10 +280,12 @@ impl<
         perms: &UserPermissions<T>,
         id: &str,
         song: CreateSong,
+        owner: Option<String>,
     ) -> Result<SongUpsertOutcome, AppError> {
         let write_teams = perms.write_teams().await?;
+        let owner = resolve_owner_team(write_teams, owner)?;
         self.repo
-            .update_song(write_teams, &perms.user().id, id, song)
+            .update_song(write_teams, &perms.user().id, id, song, owner)
             .await
     }
 
@@ -293,6 +296,7 @@ impl<
         id: &str,
         patch: PatchSong,
     ) -> Result<Song, AppError> {
+        let owner = patch.owner.clone();
         let current = self.get_song_for_user(perms, id).await?;
         let merged = CreateSong {
             owner: None,
@@ -303,7 +307,7 @@ impl<
                 .map(|song_data_patch| Self::merge_song_data(current.data.clone(), song_data_patch))
                 .unwrap_or(current.data),
         };
-        self.update_song_for_user(perms, id, merged)
+        self.update_song_for_user(perms, id, merged, owner)
             .await
             .map(SongUpsertOutcome::into_song)
     }
@@ -404,8 +408,8 @@ mod tests {
 
     use crate::resources::team::UserPermissions;
     use crate::test_helpers::{
-        configure_personal_team_members, create_song_with_title, create_user, personal_team_id,
-        setlist_service, setlist_with_songs, test_db, two_shared_teams_for_user,
+        TeamFixture, configure_personal_team_members, create_song_with_title, create_user,
+        personal_team_id, setlist_service, setlist_with_songs, test_db, two_shared_teams_for_user,
     };
     use shared::MoveOwner;
     use shared::api::ListQuery;
@@ -548,7 +552,9 @@ mod tests {
             blobs: vec![],
             data: crate::test_helpers::minimal_song_data(),
         };
-        let r = svc.update_song_for_user(&guest_p, &song.id, create).await;
+        let r = svc
+            .update_song_for_user(&guest_p, &song.id, create, None)
+            .await;
         assert!(matches!(r, Err(crate::error::AppError::NotFound(_))));
     }
 
@@ -589,7 +595,7 @@ mod tests {
             blobs: vec![],
             data,
         };
-        svc.update_song_for_user(&cm_p, &song.id, create)
+        svc.update_song_for_user(&cm_p, &song.id, create, None)
             .await
             .expect("cm update")
             .into_song();
@@ -614,11 +620,67 @@ mod tests {
             data,
         };
         let updated = svc
-            .update_song_for_user(&owner_p, &song.id, create)
+            .update_song_for_user(&owner_p, &song.id, create, None)
             .await
             .expect("update")
             .into_song();
-        assert_eq!(updated.owner, tid, "owner must not change on PUT");
+        assert_eq!(
+            updated.owner, tid,
+            "owner must not change on PUT when omitted"
+        );
+    }
+
+    /// PUT with `owner` moves the song when the actor can write both teams.
+    #[tokio::test]
+    async fn blc_song_put_moves_owner_when_target_writable() {
+        use shared::song::CreateSong;
+        let db = test_db().await.expect("db");
+        let fx = TeamFixture::build(&db).await.expect("fixture");
+        let svc = SongServiceHandle::build(db.clone());
+        let admin_p = UserPermissions::from_ref(&fx.admin_user, &svc.teams);
+        let song = create_song_with_title(&db, &fx.admin_user, "MoveMeSong")
+            .await
+            .expect("song");
+        let personal = personal_team_id(&db, &fx.admin_user)
+            .await
+            .expect("personal");
+        assert_eq!(song.owner, personal);
+        let data = crate::test_helpers::minimal_song_data();
+        let create = CreateSong {
+            owner: None,
+            not_a_song: false,
+            blobs: vec![],
+            data,
+        };
+        let updated = svc
+            .update_song_for_user(&admin_p, &song.id, create, Some(fx.shared_team_id.clone()))
+            .await
+            .expect("move owner")
+            .into_song();
+        assert_eq!(updated.owner, fx.shared_team_id);
+    }
+
+    /// PUT with `owner` the actor cannot write returns NotFound.
+    #[tokio::test]
+    async fn blc_song_put_rejects_unwritable_target_owner() {
+        use shared::song::CreateSong;
+        let (db, owner, _cm, _guest, nm, _tid) = four_user_song_fixture().await;
+        let svc = SongServiceHandle::build(db.clone());
+        let owner_p = UserPermissions::from_ref(&owner, &svc.teams);
+        let nm_pt = personal_team_id(&db, &nm).await.expect("nm personal");
+        let song = create_song_with_title(&db, &owner, "StayMine")
+            .await
+            .expect("song");
+        let create = CreateSong {
+            owner: None,
+            not_a_song: false,
+            blobs: vec![],
+            data: crate::test_helpers::minimal_song_data(),
+        };
+        let r = svc
+            .update_song_for_user(&owner_p, &song.id, create, Some(nm_pt))
+            .await;
+        assert!(matches!(r, Err(crate::error::AppError::NotFound(_))));
     }
 
     /// BLC-SONG-011: list songs filtered by artist name matches.
@@ -756,7 +818,7 @@ mod tests {
             data,
         };
         let result = svc
-            .update_song_for_user(&owner_p, "brand-new-id", create)
+            .update_song_for_user(&owner_p, "brand-new-id", create, None)
             .await;
         assert!(
             result.is_ok(),
@@ -786,6 +848,7 @@ mod tests {
                     not_a_song: Some(true),
                     blobs: None,
                     data: None,
+                    owner: None,
                 },
             )
             .await
@@ -818,6 +881,7 @@ mod tests {
                     not_a_song: Some(true),
                     blobs: None,
                     data: None,
+                    owner: None,
                 },
             )
             .await;
@@ -839,6 +903,7 @@ mod tests {
                     not_a_song: Some(true),
                     blobs: None,
                     data: None,
+                    owner: None,
                 },
             )
             .await;
@@ -863,6 +928,7 @@ mod tests {
                     not_a_song: None,
                     blobs: None,
                     data: None,
+                    owner: None,
                 },
             )
             .await
@@ -931,6 +997,7 @@ mod tests {
                             id: "patched_blob".into(),
                         }]),
                         data: include_data.then_some(patch_data.clone()),
+                        owner: None,
                     },
                 )
                 .await
@@ -1161,7 +1228,7 @@ mod tests {
         };
         // Guest can create songs on their own personal team via upsert.
         let result = svc
-            .update_song_for_user(&guest_p, "brand-new-guest-created-id", create)
+            .update_song_for_user(&guest_p, "brand-new-guest-created-id", create, None)
             .await
             .expect("guest can upsert to own personal team")
             .into_song();

--- a/backend/src/resources/song/surreal_repo.rs
+++ b/backend/src/resources/song/surreal_repo.rs
@@ -320,6 +320,7 @@ impl SongRepository for SurrealSongRepo {
         actor_user_id: &str,
         id: &str,
         song: CreateSong,
+        owner: Option<RecordId>,
     ) -> Result<SongUpsertOutcome, AppError> {
         let db = self.inner();
         let resource = resource_id("song", id)?;
@@ -327,20 +328,37 @@ impl SongRepository for SurrealSongRepo {
         let search_content = search_content_from_song_data(&song.data);
         let blobs: Vec<RecordId> = song.blobs.iter().map(|b| blob_thing(&b.id)).collect();
 
-        let mut response = db
-            .db
-            .query(
-                "UPDATE type::record($tb, $sid) SET not_a_song = $not_a_song, blobs = $blobs, \
-                 data = $data, search_content = $search_content WHERE owner IN $teams RETURN AFTER",
-            )
-            .bind(("tb", tb))
-            .bind(("sid", sid))
-            .bind(("not_a_song", song.not_a_song))
-            .bind(("blobs", blobs))
-            .bind(("data", SongDataField(song.data.clone())))
-            .bind(("search_content", search_content))
-            .bind(("teams", write_teams.to_vec()))
-            .await?;
+        let mut response = if let Some(ref owner_rid) = owner {
+            db.db
+                .query(
+                    "UPDATE type::record($tb, $sid) SET not_a_song = $not_a_song, blobs = $blobs, \
+                     data = $data, search_content = $search_content, owner = $owner \
+                     WHERE owner IN $teams RETURN AFTER",
+                )
+                .bind(("tb", tb.clone()))
+                .bind(("sid", sid.clone()))
+                .bind(("not_a_song", song.not_a_song))
+                .bind(("blobs", blobs.clone()))
+                .bind(("data", SongDataField(song.data.clone())))
+                .bind(("search_content", search_content.clone()))
+                .bind(("owner", owner_rid.clone()))
+                .bind(("teams", write_teams.to_vec()))
+                .await?
+        } else {
+            db.db
+                .query(
+                    "UPDATE type::record($tb, $sid) SET not_a_song = $not_a_song, blobs = $blobs, \
+                     data = $data, search_content = $search_content WHERE owner IN $teams RETURN AFTER",
+                )
+                .bind(("tb", tb.clone()))
+                .bind(("sid", sid.clone()))
+                .bind(("not_a_song", song.not_a_song))
+                .bind(("blobs", blobs.clone()))
+                .bind(("data", SongDataField(song.data.clone())))
+                .bind(("search_content", search_content.clone()))
+                .bind(("teams", write_teams.to_vec()))
+                .await?
+        };
 
         let rows: Vec<SongRecord> = response.take(0)?;
         if let Some(updated) = rows.into_iter().next() {
@@ -352,12 +370,16 @@ impl SongRepository for SurrealSongRepo {
             return Err(AppError::NotFound("song not found".into()));
         }
 
-        let personal = db.personal_team_thing_for_user(actor_user_id).await?;
-        if !write_teams.contains(&personal) {
+        let owner_team = if let Some(o) = owner {
+            o
+        } else {
+            db.personal_team_thing_for_user(actor_user_id).await?
+        };
+        if !write_teams.contains(&owner_team) {
             return Err(AppError::NotFound("song not found".into()));
         }
         let record_id = RecordId::new(resource.0.clone(), resource.1.clone());
-        let record = SongRecord::from_payload(Some(record_id), Some(personal), song);
+        let record = SongRecord::from_payload(Some(record_id), Some(owner_team), song);
         let created = db
             .db
             .create(resource)

--- a/docs/business-logic-constraints/collection.md
+++ b/docs/business-logic-constraints/collection.md
@@ -4,7 +4,7 @@
 
 - **BLC-COLL-001:** Every collection belongs to exactly one **owning team** (**`owner`** in responses).
 - **BLC-COLL-002:** Read paths (metadata, songs list, player) require **read** access to that team’s library; create/update/delete require **library edit** access. Platform **admin** MAY read but MUST NOT mutate collections solely by admin role.
-- **BLC-COLL-003:** **`PUT`** MUST NOT change **`owner`**; it replaces **title**, **cover** (blob id), and the ordered **songs** list.
+- **BLC-COLL-003:** **`PUT`** replaces **title**, **cover** (blob id), and the ordered **songs** list; **`PUT`** and **`PATCH`** MAY set **`owner`** when the body includes it and the caller may write both the current and target owning teams; omitting **`owner`** leaves it unchanged.
 - **BLC-COLL-004:** **POST**/**PUT** MAY accept **song** ids the caller cannot read or ids that do not exist; the API MAY still return **201**/**200** and persist those references.
 
 ## List pagination and search

--- a/docs/business-logic-constraints/setlist.md
+++ b/docs/business-logic-constraints/setlist.md
@@ -4,7 +4,7 @@
 
 - **BLC-SETL-001:** Every setlist belongs to exactly one **owning team** (**`owner`** in responses).
 - **BLC-SETL-002:** Reads (metadata, songs, player) require **read** access to that team’s library; **PUT** and **DELETE** require **library edit** access. Platform **admin** MAY read but MUST NOT mutate setlists solely by admin role.
-- **BLC-SETL-003:** **`PUT`** MUST NOT change **`owner`**; it replaces **title**, ordered **songs**, and related fields exposed by the API.
+- **BLC-SETL-003:** **`PUT`** replaces **title**, ordered **songs**, and related fields; **`PUT`** and **`PATCH`** MAY set **`owner`** when the body includes it and the caller may write both the current and target owning teams (see **BLC-SONG-003** pattern); omitting **`owner`** leaves it unchanged.
 
 ## Create payload validation
 

--- a/docs/business-logic-constraints/song.md
+++ b/docs/business-logic-constraints/song.md
@@ -4,7 +4,7 @@
 
 - **BLC-SONG-001:** Every song belongs to exactly one **owning team** (**`owner`** in responses).
 - **BLC-SONG-002:** Listing, single-song **GET**, player, and like endpoints require **read** access to that team’s library; **PUT** and **DELETE** require **library edit** access. Platform **admin** does **not** gain song edit solely by role.
-- **BLC-SONG-003:** **`PUT`** MUST NOT change **`owner`**. Changing the owning team is only via **`POST /songs/{id}/move`** with **`{ "owner": "<team id>" }`**.
+- **BLC-SONG-003:** **`PUT`** and **`PATCH`** MAY change **`owner`** when the body includes **`owner`** (team id) and the caller has **library edit** access to both the song’s current owning team and the target team; omitting **`owner`** leaves it unchanged. Changing the owning team is also available via **`POST /songs/{id}/move`** with **`{ "owner": "<team id>" }`** (see BLC-SONG-020–021).
 - **BLC-SONG-004:** **Like** state IS per **current user** and **song**; anyone who may read the song MAY read like status via **GET** `/songs/{id}/like`, set liked via **PUT** `/songs/{id}/like` (204), or remove like via **DELETE** `/songs/{id}/like` (204).
 
 ## List pagination and search
@@ -24,7 +24,7 @@
 - **BLC-SONG-014:** WHEN **DELETE /songs/{id}** succeeds THEN the song no longer appears via the API under the same access rules as **PUT**.
 - **BLC-SONG-017:** WHEN **PUT /songs/{id}** body fails validation (e.g. empty **`data`**, or wrong types for fields such as **`tempo`** / **`time`**) THEN **400**.
 - **BLC-SONG-019:** WHEN **PATCH /songs/{id}** omits **`data`** and other patch fields THEN those properties remain unchanged; the request body lists only fields to update (see OpenAPI **`PatchSong`**).
-- **BLC-SONG-018:** WHEN **PUT /songs/{id}** uses an **`{id}`** that does not yet refer to an existing song THEN the API MAY create the song (**200**) with that **id** and **`owner`** the caller’s **personal** team, subject to **BLC-SONG-007** and **BLC-SONG-008** for **guest** vs **edit** rights on that team.
+- **BLC-SONG-018:** WHEN **PUT /songs/{id}** uses an **`{id}`** that does not yet refer to an existing song THEN the API MAY create the song with that **id**; **`owner`** in the body selects the owning team when the caller may write that team, otherwise **`owner`** IS the caller’s **personal** team, subject to **BLC-SONG-007** and **BLC-SONG-008** for **guest** vs **edit** rights.
 
 ## Move (`POST /songs/{id}/move`)
 

--- a/shared/src/collection/collection.rs
+++ b/shared/src/collection/collection.rs
@@ -57,6 +57,9 @@ pub struct UpdateCollection {
     pub title: String,
     pub cover: String,
     pub songs: Vec<SongLink>,
+    /// Target team id for the collection's `owner`; omit or `null` to keep the current owner.
+    #[serde(default)]
+    pub owner: Option<String>,
 }
 
 impl From<UpdateCollection> for CreateCollection {
@@ -78,6 +81,8 @@ pub struct PatchCollection {
     pub title: Option<String>,
     pub cover: Option<String>,
     pub songs: Option<Vec<SongLink>>,
+    #[serde(default)]
+    pub owner: Option<String>,
 }
 
 impl From<Collection> for CreateCollection {

--- a/shared/src/setlist/setlist.rs
+++ b/shared/src/setlist/setlist.rs
@@ -51,6 +51,9 @@ pub struct CreateSetlist {
 pub struct UpdateSetlist {
     pub title: String,
     pub songs: Vec<SongLink>,
+    /// Target team id for the setlist's `owner`; omit or `null` to keep the current owner.
+    #[serde(default)]
+    pub owner: Option<String>,
 }
 
 impl From<CreateSetlist> for UpdateSetlist {
@@ -58,6 +61,7 @@ impl From<CreateSetlist> for UpdateSetlist {
         Self {
             title: value.title,
             songs: value.songs,
+            owner: None,
         }
     }
 }
@@ -79,6 +83,8 @@ impl From<UpdateSetlist> for CreateSetlist {
 pub struct PatchSetlist {
     pub title: Option<String>,
     pub songs: Option<Vec<SongLink>>,
+    #[serde(default)]
+    pub owner: Option<String>,
 }
 
 impl From<Setlist> for CreateSetlist {

--- a/shared/src/song/song.rs
+++ b/shared/src/song/song.rs
@@ -78,6 +78,9 @@ pub struct UpdateSong {
     pub blobs: Vec<BlobLink>,
     #[cfg_attr(feature = "backend", schema(value_type = SongDataSchema))]
     pub data: ChordSong,
+    /// Target team id for the song's `owner`; omit or `null` to keep the current owner.
+    #[serde(default)]
+    pub owner: Option<String>,
 }
 
 impl From<UpdateSong> for CreateSong {
@@ -97,6 +100,7 @@ impl From<CreateSong> for UpdateSong {
             not_a_song: value.not_a_song,
             blobs: value.blobs,
             data: value.data,
+            owner: None,
         }
     }
 }
@@ -120,6 +124,9 @@ pub struct PatchSong {
     pub blobs: Option<Vec<BlobLink>>,
     #[cfg_attr(feature = "backend", schema(value_type = PatchSongData))]
     pub data: Option<PatchSongData>,
+    /// Set the song's owning team id; omit to leave unchanged.
+    #[serde(default)]
+    pub owner: Option<String>,
 }
 
 /// Partial update for song metadata.


### PR DESCRIPTION
Optional owner (team id) on PUT/PATCH bodies transfers ownership when the
caller can write both the current and target teams. Shared types, Surreal
repos, services, OpenAPI, and BLC docs updated.

Made-with: Cursor
