### PR TITLE
test(auth): add oidc_state SCHEMAFULL contract test

### DIFF
--- a/backend/src/auth/oidc/mod.rs
+++ b/backend/src/auth/oidc/mod.rs
@@ -5,3 +5,6 @@ pub use client::{OidcClients, OidcProvider, build_clients};
 
 mod model;
 pub use model::{Model, PendingOidc};
+
+#[cfg(test)]
+mod schema_contract_tests;

--- a/backend/src/auth/oidc/model.rs
+++ b/backend/src/auth/oidc/model.rs
@@ -75,6 +75,9 @@ impl Model for Database {
     }
 }
 
+/// Persisted shape for table `oidc_state` (SCHEMAFULL). Every serialized field here must have a
+/// matching `DEFINE FIELD` for `oidc_state` under `backend/db-migrations`; new columns require an
+/// additive `.surql` migration so existing databases stay migratable.
 #[derive(Debug, Serialize, Deserialize, SurrealValue)]
 struct OidcStateRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/backend/src/auth/oidc/schema_contract_tests.rs
+++ b/backend/src/auth/oidc/schema_contract_tests.rs
@@ -1,0 +1,39 @@
+//! SCHEMAFULL contract tests: serde content written by OIDC state helpers must match Surreal schema.
+
+use chrono::{Duration as ChronoDuration, Utc};
+use oauth2::PkceCodeChallenge;
+use openidconnect::Nonce;
+
+use super::{Model as OidcModel, OidcProvider, PendingOidc};
+use crate::test_helpers::test_db;
+
+#[tokio::test]
+async fn oidc_state_remember_and_take_round_trip() {
+    let db = test_db().await.expect("test db");
+
+    let (_, verifier) = PkceCodeChallenge::new_random_sha256();
+    let now = Utc::now();
+    let pending = PendingOidc {
+        pkce_verifier: verifier,
+        nonce: Nonce::new_random(),
+        redirect_to: Some("/after-login".into()),
+        created_at: now,
+        expires_at: now + ChronoDuration::seconds(600),
+        provider: OidcProvider::Google,
+    };
+    let key = "contract-test-csrf";
+
+    OidcModel::remember_oidc_state(db.as_ref(), key, pending)
+        .await
+        .expect("remember_oidc_state should accept all OidcStateRecord fields under SCHEMAFULL");
+
+    let taken = OidcModel::take_oidc_state(db.as_ref(), key)
+        .await
+        .expect("take_oidc_state");
+    let Some(out) = taken else {
+        panic!("expected stored oidc_state");
+    };
+
+    assert_eq!(out.provider, OidcProvider::Google);
+    assert_eq!(out.redirect_to.as_deref(), Some("/after-login"));
+}


### PR DESCRIPTION
Exercise remember_oidc_state / take_oidc_state after full migrations so
serde fields stay aligned with DEFINE FIELD on SCHEMAFULL oidc_state.
Document the coupling on OidcStateRecord.

Made-with: Cursor
