### PR TITLE
feat(api): public GET /api/v1/about and GIT_COMMIT_SHA in CI

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -24,6 +24,9 @@ jobs:
   backend-validate:
     if: github.event_name == 'push' && github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    env:
+      # Baked into `backend` via `option_env!("GIT_COMMIT_SHA")` for `GET /api/v1/about`.
+      GIT_COMMIT_SHA: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v4
 
@@ -97,5 +100,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_COMMIT_SHA=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ COPY ./shared ./shared
 WORKDIR /wrk
 COPY ./backend ./backend
 WORKDIR /wrk/backend
-RUN cargo build --release
+ARG GIT_COMMIT_SHA
+# Omit `GIT_COMMIT_SHA` from the environment when unset so `option_env!("GIT_COMMIT_SHA")` stays absent (CI passes `--build-arg`).
+RUN if [ -n "${GIT_COMMIT_SHA:-}" ]; then export GIT_COMMIT_SHA; else unset GIT_COMMIT_SHA; fi && cargo build --release
 
 WORKDIR /wrk
 COPY ./frontend ./frontend

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1,6 +1,34 @@
 {
   "components": {
     "schemas": {
+      "AboutResponse": {
+        "description": "JSON body for [`get_about`].",
+        "properties": {
+          "git_commit": {
+            "description": "Git revision if `GIT_COMMIT_SHA` was set during `cargo build`.",
+            "nullable": true,
+            "type": "string"
+          },
+          "production": {
+            "description": "`true` when [`observability::is_production`] is satisfied.",
+            "type": "boolean"
+          },
+          "service": {
+            "description": "Identifies this server binary.",
+            "type": "string"
+          },
+          "version": {
+            "description": "Semver from `Cargo.toml` at compile time (`CARGO_PKG_VERSION`).",
+            "type": "string"
+          }
+        },
+        "required": [
+          "service",
+          "version",
+          "production"
+        ],
+        "type": "object"
+      },
       "ActivityCalendarMetrics": {
         "properties": {
           "dau_date": {
@@ -2132,7 +2160,7 @@
     }
   },
   "info": {
-    "description": "Versioned REST API under `/api/v1`. Authentication flows live at `/auth/*` (unversioned); clients should treat that split as stable for this major API generation.\n\n**Breaking 2.0:** See `docs/api-breaking-2-0.md` for migration (`PlayerItem`, `Song.blobs` as link objects, `Session` wire model, `Problem` without `error`, PUT bodies use `Update*` types in the spec).\n\n**Timestamps:** All timestamps are UTC and use RFC 3339 with a `Z` suffix (e.g. `2026-04-18T12:00:00Z`).\n\n**Identifiers:** Resource IDs are opaque printable strings returned by the API; treat them as opaque and do not parse their internal structure.\n\n**References & expand:** Cross-resource links use objects such as `BlobLink` (`{ \"id\": \"…\" }`) instead of bare id strings where noted. Session list/detail responses default to a narrow `user` link (`id` + `email`); pass `expand=user` (comma-separated with other tokens as added) to embed the full `User`.\n\n**JSON naming:** Object keys use `snake_case`. Enum wire values use the casing shown in each schema (broader enum casing standardization is planned).\n\n**Pagination:** List endpoints accept `page` (0-based) and `page_size` (1–500, default 50). Responses include `X-Total-Count` with the total matching rows before pagination and RFC 5988 `Link` headers (relations: first, prev, next, last) where applicable.\n\n**Rate limiting:** Versioned `/api/v1/*` routes use token-bucket limits per client IP (`Retry-After`, `X-RateLimit-*` on **429**; configurable via server settings).\n\n**Errors:** Failed requests return `Content-Type: application/problem+json` ([RFC 7807](https://www.rfc-editor.org/rfc/rfc7807)) with a `Problem` body (`type`, `title`, `status`, `code`, optional `detail` / `instance`). Use `detail` for human-readable text; stable machine-readable `code` values include: `unauthorized`, `forbidden`, `not_found`, `invalid_request`, `invalid_page_size`, `conflict`, `too_many_requests`, `not_acceptable`, `precondition_failed`, `internal`. Legacy schemas `ErrorResponse` and `ProblemDetails` remain listed for one release but are deprecated in favor of `Problem`.\n\n**CSRF:** Cookie sessions use `SameSite=Lax`; state-changing methods are `POST`/`PUT`/`PATCH`/`DELETE` (not `GET`). Cross-site simple requests cannot mutate state via cookies under typical browser rules. Browser `fetch` from the SPA should use `credentials: 'same-origin'` (or include cookies only on same-site requests). API clients using bearer tokens should still avoid exposing tokens to third-party origins.\n\n**Examples:** See schema `example` fields on core DTOs in the components section.",
+    "description": "Versioned REST API under `/api/v1`. Authentication flows live at `/auth/*` (unversioned); clients should treat that split as stable for this major API generation. Public deployment metadata is available at `GET /api/v1/about` (no authentication).\n\n**Breaking 2.0:** See `docs/api-breaking-2-0.md` for migration (`PlayerItem`, `Song.blobs` as link objects, `Session` wire model, `Problem` without `error`, PUT bodies use `Update*` types in the spec).\n\n**Timestamps:** All timestamps are UTC and use RFC 3339 with a `Z` suffix (e.g. `2026-04-18T12:00:00Z`).\n\n**Identifiers:** Resource IDs are opaque printable strings returned by the API; treat them as opaque and do not parse their internal structure.\n\n**References & expand:** Cross-resource links use objects such as `BlobLink` (`{ \"id\": \"…\" }`) instead of bare id strings where noted. Session list/detail responses default to a narrow `user` link (`id` + `email`); pass `expand=user` (comma-separated with other tokens as added) to embed the full `User`.\n\n**JSON naming:** Object keys use `snake_case`. Enum wire values use the casing shown in each schema (broader enum casing standardization is planned).\n\n**Pagination:** List endpoints accept `page` (0-based) and `page_size` (1–500, default 50). Responses include `X-Total-Count` with the total matching rows before pagination and RFC 5988 `Link` headers (relations: first, prev, next, last) where applicable.\n\n**Rate limiting:** Versioned `/api/v1/*` routes use token-bucket limits per client IP (`Retry-After`, `X-RateLimit-*` on **429**; configurable via server settings).\n\n**Errors:** Failed requests return `Content-Type: application/problem+json` ([RFC 7807](https://www.rfc-editor.org/rfc/rfc7807)) with a `Problem` body (`type`, `title`, `status`, `code`, optional `detail` / `instance`). Use `detail` for human-readable text; stable machine-readable `code` values include: `unauthorized`, `forbidden`, `not_found`, `invalid_request`, `invalid_page_size`, `conflict`, `too_many_requests`, `not_acceptable`, `precondition_failed`, `internal`. Legacy schemas `ErrorResponse` and `ProblemDetails` remain listed for one release but are deprecated in favor of `Problem`.\n\n**CSRF:** Cookie sessions use `SameSite=Lax`; state-changing methods are `POST`/`PUT`/`PATCH`/`DELETE` (not `GET`). Cross-site simple requests cannot mutate state via cookies under typical browser rules. Browser `fetch` from the SPA should use `credentials: 'same-origin'` (or include cookies only on same-site requests). API clients using bearer tokens should still avoid exposing tokens to third-party origins.\n\n**Examples:** See schema `example` fields on core DTOs in the components section.",
     "license": {
       "name": "MIT",
       "url": "https://opensource.org/licenses/MIT"
@@ -2142,6 +2170,27 @@
   },
   "openapi": "3.0.3",
   "paths": {
+    "/api/v1/about": {
+      "get": {
+        "operationId": "get_about",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AboutResponse"
+                }
+              }
+            },
+            "description": "Deployed backend metadata"
+          }
+        },
+        "summary": "Public metadata: which build is running (no authentication).",
+        "tags": [
+          "About"
+        ]
+      }
+    },
     "/api/v1/blobs": {
       "get": {
         "operationId": "get_blobs",
@@ -8815,6 +8864,10 @@
     }
   ],
   "tags": [
+    {
+      "description": "Public server build and environment metadata (`GET /api/v1/about`).",
+      "name": "About"
+    },
     {
       "description": "OAuth/OIDC login, OTP email codes, and logout. Session cookies are set on successful auth (see authentication BLC).",
       "externalDocs": {

--- a/backend/src/about.rs
+++ b/backend/src/about.rs
@@ -1,0 +1,41 @@
+//! Public deployment metadata (`GET /api/v1/about`).
+
+use actix_web::{HttpResponse, get};
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use crate::observability;
+
+const SERVICE_NAME: &str = "worshipviewer-backend";
+
+/// JSON body for [`get_about`].
+#[derive(Serialize, ToSchema)]
+pub struct AboutResponse {
+    /// Identifies this server binary.
+    pub service: &'static str,
+    /// Semver from `Cargo.toml` at compile time (`CARGO_PKG_VERSION`).
+    pub version: &'static str,
+    /// Git revision if `GIT_COMMIT_SHA` was set during `cargo build`.
+    pub git_commit: Option<&'static str>,
+    /// `true` when [`observability::is_production`] is satisfied.
+    pub production: bool,
+}
+
+/// Public metadata: which build is running (no authentication).
+#[utoipa::path(
+    get,
+    path = "/api/v1/about",
+    responses(
+        (status = 200, description = "Deployed backend metadata", body = AboutResponse),
+    ),
+    tag = "About",
+)]
+#[get("/about")]
+pub async fn get_about() -> HttpResponse {
+    HttpResponse::Ok().json(AboutResponse {
+        service: SERVICE_NAME,
+        version: env!("CARGO_PKG_VERSION"),
+        git_commit: option_env!("GIT_COMMIT_SHA"),
+        production: observability::is_production(),
+    })
+}

--- a/backend/src/docs.rs
+++ b/backend/src/docs.rs
@@ -3,6 +3,7 @@ use utoipa::openapi::info::ContactBuilder;
 use utoipa::openapi::security::{ApiKey, ApiKeyValue, SecurityScheme};
 use utoipa::{Modify, OpenApi};
 
+use crate::about::AboutResponse;
 use crate::settings::Settings;
 
 use crate::resources::blob::PatchBlob;
@@ -95,7 +96,7 @@ fn apply_openapi_runtime_metadata(doc: &mut utoipa::openapi::OpenApi, settings: 
     info(
         title = "Worship Viewer API",
         version = "2.0.0",
-        description = "Versioned REST API under `/api/v1`. Authentication flows live at `/auth/*` (unversioned); clients should treat that split as stable for this major API generation.\n\n\
+        description = "Versioned REST API under `/api/v1`. Authentication flows live at `/auth/*` (unversioned); clients should treat that split as stable for this major API generation. Public deployment metadata is available at `GET /api/v1/about` (no authentication).\n\n\
             **Breaking 2.0:** See `docs/api-breaking-2-0.md` for migration (`PlayerItem`, `Song.blobs` as link objects, `Session` wire model, `Problem` without `error`, PUT bodies use `Update*` types in the spec).\n\n\
             **Timestamps:** All timestamps are UTC and use RFC 3339 with a `Z` suffix (e.g. `2026-04-18T12:00:00Z`).\n\n\
             **Identifiers:** Resource IDs are opaque printable strings returned by the API; treat them as opaque and do not parse their internal structure.\n\n\
@@ -113,6 +114,7 @@ fn apply_openapi_runtime_metadata(doc: &mut utoipa::openapi::OpenApi, settings: 
         (url = "https://app.worshipviewer.com", description = "Production deployment (public web app).")
     ),
     paths(
+        crate::about::get_about,
         crate::auth::oidc::rest::login,
         crate::auth::oidc::rest::callback,
         crate::auth::otp::rest::otp_request,
@@ -187,6 +189,7 @@ fn apply_openapi_runtime_metadata(doc: &mut utoipa::openapi::OpenApi, settings: 
     ),
     components(
         schemas(
+            AboutResponse,
             User,
             SessionBody,
             SessionUserBody,
@@ -262,6 +265,7 @@ fn apply_openapi_runtime_metadata(doc: &mut utoipa::openapi::OpenApi, settings: 
         )
     ),
     tags(
+        (name = "About", description = "Public server build and environment metadata (`GET /api/v1/about`)."),
         (name = "Auth", description = "OAuth/OIDC login, OTP email codes, and logout. Session cookies are set on successful auth (see authentication BLC)."),
         (name = "Monitoring", description = "Admin-only operational metrics and request audit listings under `/monitoring/`."),
         (name = "Users", description = "Current user (`/users/me`), directory listing, sessions (own and admin), and admin user lifecycle."),

--- a/backend/src/http_tests.rs
+++ b/backend/src/http_tests.rs
@@ -289,6 +289,27 @@ mod openapi_endpoint {
     }
 }
 
+/// Public `GET /api/v1/about` (no session).
+#[cfg(test)]
+mod about_endpoint {
+    use super::*;
+    use actix_web::http::StatusCode;
+
+    #[actix_web::test]
+    async fn get_api_v1_about_without_auth_returns_200() {
+        let db = test_db().await.unwrap();
+        let app = test::init_service(build_app(db.clone())).await;
+        let req = test::TestRequest::get().uri("/api/v1/about").to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["service"], "worshipviewer-backend");
+        assert!(body["version"].as_str().is_some());
+        assert!(body.get("git_commit").is_some());
+        assert!(body["production"].is_boolean());
+    }
+}
+
 /// BLC-DOCS-002: OpenAPI documents `Problem` and uses `application/problem+json` for 4xx/5xx bodies.
 #[cfg(test)]
 mod openapi_problem_schema {

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(async_fn_in_trait)]
 
+pub mod about;
 pub mod accept;
 pub mod auth;
 pub mod database;

--- a/backend/src/resources/rest.rs
+++ b/backend/src/resources/rest.rs
@@ -1,4 +1,5 @@
 use super::{blob, collection, monitoring, setlist, song, team, user};
+use crate::about;
 use crate::auth::middleware::RequireUser;
 use crate::governor_audit::AuditRateLimit429;
 use crate::governor_peer::PeerOrFallbackIpKeyExtractor;
@@ -21,13 +22,17 @@ pub fn scope(
     web::scope("/api/v1")
         .wrap(Governor::new(&api_governor))
         .wrap(AuditRateLimit429)
-        .wrap(RequireUser)
-        .service(blob::rest::scope(blob_upload_max_bytes))
-        .service(collection::rest::scope())
-        .service(setlist::rest::scope())
-        .service(song::rest::scope())
-        .service(team::rest::scope())
-        .service(team::invitations_accept_scope())
-        .service(monitoring::rest::scope())
-        .service(user::rest::scope(avatar_upload_max_bytes))
+        .service(about::get_about)
+        .service(
+            web::scope("")
+                .wrap(RequireUser)
+                .service(blob::rest::scope(blob_upload_max_bytes))
+                .service(collection::rest::scope())
+                .service(setlist::rest::scope())
+                .service(song::rest::scope())
+                .service(team::rest::scope())
+                .service(team::invitations_accept_scope())
+                .service(monitoring::rest::scope())
+                .service(user::rest::scope(avatar_upload_max_bytes)),
+        )
 }


### PR DESCRIPTION
Adds an unauthenticated `GET /api/v1/about` JSON endpoint (service name, semver from Cargo, optional compile-time `GIT_COMMIT_SHA`, production flag) with OpenAPI and an HTTP test.

CI and Docker builds set `GIT_COMMIT_SHA` from `github.sha` so deployed images expose the revision in `git_commit`.

Routing: `/api/v1` keeps API rate limits; `RequireUser` wraps only authenticated resources so `/about` stays public.

Made with [Cursor](https://cursor.com)