### PR TITLE
docs & tests: BLC alignment, email validation, pagination, coverage script

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -6299,7 +6299,7 @@
         "operationId": "get_teams",
         "parameters": [
           {
-            "description": "Page index, zero-based. Omit with `page_size` for full list (see nested pagination).",
+            "description": "Page index, zero-based; defaults to 0.",
             "in": "query",
             "name": "page",
             "required": false,
@@ -6311,7 +6311,7 @@
             }
           },
           {
-            "description": "Items per page. Must be 1–500. Defaults to 50. Omit with `page` for full list.",
+            "description": "Items per page. Must be 1–500. Defaults to 50 when omitted.",
             "example": 50,
             "in": "query",
             "name": "page_size",
@@ -7786,7 +7786,7 @@
         "operationId": "get_sessions_for_current_user",
         "parameters": [
           {
-            "description": "Zero-based page. With `page_size`, `X-Total-Count` is pre-pagination total (`list-pagination.md`).",
+            "description": "Zero-based page; defaults to 0. `X-Total-Count` is the total before paging (`list-pagination.md`).",
             "in": "query",
             "name": "page",
             "required": false,
@@ -7798,7 +7798,7 @@
             }
           },
           {
-            "description": "Items per page. Must be 1–500. Defaults to 50. Omit with `page` for full list.",
+            "description": "Items per page. Must be 1–500. Defaults to 50 when omitted.",
             "example": 50,
             "in": "query",
             "name": "page_size",
@@ -8232,7 +8232,7 @@
             }
           },
           {
-            "description": "Zero-based page. With `page_size`, `X-Total-Count` is pre-pagination total (`list-pagination.md`).",
+            "description": "Zero-based page; defaults to 0. `X-Total-Count` is the total before paging (`list-pagination.md`).",
             "in": "query",
             "name": "page",
             "required": false,
@@ -8244,7 +8244,7 @@
             }
           },
           {
-            "description": "Items per page. Must be 1–500. Defaults to 50. Omit with `page` for full list.",
+            "description": "Items per page. Must be 1–500. Defaults to 50 when omitted.",
             "example": 50,
             "in": "query",
             "name": "page_size",

--- a/backend/src/http_tests.rs
+++ b/backend/src/http_tests.rs
@@ -58,7 +58,7 @@ pub(crate) fn build_app(
 }
 
 /// Same as [`build_app`] but with configurable `/api/v1` per-IP rate limits (for **BLC-HTTP-004** tests).
-pub(crate) fn build_app_with_api_limits(
+fn build_app_with_api_limits(
     db: Arc<Database>,
     api_rate_limit_rps: u64,
     api_rate_limit_burst: u32,

--- a/backend/src/http_tests.rs
+++ b/backend/src/http_tests.rs
@@ -7,8 +7,9 @@
 //! - Slice 4D: HTTP contract — invalid path IDs + idempotent DELETE (BLC-HTTP-001, BLC-HTTP-002)
 //! - Slice 4E: user admin gates (BLC-USER-005, BLC-USER-006, BLC-USER-007, BLC-USER-009)
 //! - Slice 4F: session admin gates (BLC-SESS-003, BLC-SESS-004, BLC-SESS-005, BLC-SESS-006, BLC-SESS-009)
-//! - Slice 4G: list pagination HTTP validation (BLC-LP-004 through BLC-LP-009)
+//! - Slice 4G: list pagination HTTP validation (BLC-LP-004 through BLC-LP-010)
 //! - Slice 4H: monitoring / HTTP audit logs (BLC-MON-002 through BLC-MON-004)
+//! - API rate limit (**BLC-HTTP-004**), song ACL / upsert (**BLC-SONG-002**, **BLC-SONG-018**), blob create (**BLC-BLOB-005**)
 //!
 //! # Middleware error note
 //!
@@ -44,6 +45,23 @@ use crate::test_helpers::{create_song_with_title, create_user, session_service, 
 /// `frontend::rest::scope()` (needs a static file directory on disk).
 pub(crate) fn build_app(
     db: Arc<Database>,
+) -> App<
+    impl actix_web::dev::ServiceFactory<
+        actix_web::dev::ServiceRequest,
+        Config = (),
+        Response = actix_web::dev::ServiceResponse,
+        Error = actix_web::Error,
+        InitError = (),
+    >,
+> {
+    build_app_with_api_limits(db, 50, 200)
+}
+
+/// Same as [`build_app`] but with configurable `/api/v1` per-IP rate limits (for **BLC-HTTP-004** tests).
+pub(crate) fn build_app_with_api_limits(
+    db: Arc<Database>,
+    api_rate_limit_rps: u64,
+    api_rate_limit_burst: u32,
 ) -> App<
     impl actix_web::dev::ServiceFactory<
         actix_web::dev::ServiceRequest,
@@ -95,8 +113,8 @@ pub(crate) fn build_app(
         .service(resources::rest::scope(
             20 * 1024 * 1024,
             2 * 1024 * 1024,
-            50,
-            200,
+            api_rate_limit_rps,
+            api_rate_limit_burst,
         ))
 }
 
@@ -523,6 +541,36 @@ mod http_contract {
             .to_request();
         let resp = test::call_service(&app, req).await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+}
+
+#[cfg(test)]
+mod api_rate_limit_http {
+    use super::*;
+    use actix_web::http::StatusCode;
+
+    /// BLC-HTTP-004: when the per-IP API limit is exceeded, **429** includes **`Retry-After`** and **`X-RateLimit-*`** headers.
+    #[actix_web::test]
+    async fn blc_http_004_rate_limit_429_includes_headers() {
+        let db = test_db().await.unwrap();
+        let user = create_user(&db, "api-ratelimit@test.local").await.unwrap();
+        let token = create_session_token(&db, user).await.unwrap();
+        let app = test::init_service(build_app_with_api_limits(db, 1, 1)).await;
+        let uri = "/api/v1/songs";
+        let req1 = test::TestRequest::get()
+            .uri(uri)
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .to_request();
+        let resp1 = test::call_service(&app, req1).await;
+        assert_eq!(resp1.status(), StatusCode::OK);
+        let req2 = test::TestRequest::get()
+            .uri(uri)
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .to_request();
+        let resp2 = test::call_service(&app, req2).await;
+        assert_eq!(resp2.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert!(resp2.headers().get("retry-after").is_some());
+        assert!(resp2.headers().get("x-ratelimit-limit").is_some());
     }
 }
 
@@ -1168,6 +1216,38 @@ mod list_pagination {
             "page 1 of 3 matching with page_size=2 should return 1"
         );
     }
+
+    /// BLC-LP-010: list responses include a `Link` header with pagination relations.
+    #[actix_web::test]
+    async fn blc_lp_010_link_header_on_songs_list() {
+        use actix_web::http::header::LINK;
+
+        let db = test_db().await.unwrap();
+        let (user, token) = authed_user_and_token(&db, "lp010@test.local").await;
+        for i in 0..3 {
+            create_song_with_title(&db, &user, &format!("LP010 Song {i}"))
+                .await
+                .unwrap();
+        }
+
+        let app = test::init_service(build_app(db.clone())).await;
+        let req = test::TestRequest::get()
+            .uri("/api/v1/songs?page=0&page_size=1")
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let link = resp
+            .headers()
+            .get(LINK)
+            .expect("Link header")
+            .to_str()
+            .unwrap();
+        assert!(
+            link.contains("rel=\"next\"") || link.contains("rel=next"),
+            "expected rel=next in Link, got {link:?}"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -1554,6 +1634,95 @@ mod song_patch_http {
         assert_eq!(g2["data"]["titles"][1], "Second");
         assert_eq!(g2["data"]["subtitle"], "sub");
         assert_eq!(g2["data"]["tags"]["hymn_type"], "common");
+    }
+}
+
+#[cfg(test)]
+mod song_acl_http {
+    use super::*;
+    use crate::resources::User;
+    use crate::test_helpers::user_service;
+    use actix_web::http::{StatusCode, header::LOCATION};
+    use shared::user::Role;
+
+    /// BLC-SONG-002: platform admin cannot **PUT** another user's song without library edit (**404**).
+    #[actix_web::test]
+    async fn blc_song_002_platform_admin_put_other_users_song_returns_404() {
+        let db = test_db().await.unwrap();
+        let owner = create_user(&db, "song-owner-pa@test.local").await.unwrap();
+        let song = create_song_with_title(&db, &owner, "ProtectedTitle")
+            .await
+            .unwrap();
+
+        let mut admin_raw = User::new("platform-admin-song@test.local");
+        admin_raw.role = Role::Admin;
+        let admin = user_service(&db).create_user(admin_raw).await.unwrap();
+        let admin_token = create_session_token(&db, admin).await.unwrap();
+
+        let app = test::init_service(build_app(db.clone())).await;
+        let payload = r#"{
+            "not_a_song": false,
+            "blobs": [],
+            "data": { "titles": ["Hacked"], "sections": [] }
+        }"#;
+        let req = test::TestRequest::put()
+            .uri(&format!("/api/v1/songs/{}", song.id))
+            .insert_header(("Authorization", format!("Bearer {admin_token}")))
+            .insert_header(("Content-Type", "application/json"))
+            .set_payload(payload)
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// BLC-SONG-018: **PUT** with a previously unused id returns **201** and **`Location`**.
+    #[actix_web::test]
+    async fn blc_song_018_put_upsert_new_id_returns_201_with_location() {
+        let db = test_db().await.unwrap();
+        let user = create_user(&db, "song-upsert-http@test.local")
+            .await
+            .unwrap();
+        let token = create_session_token(&db, user).await.unwrap();
+        let app = test::init_service(build_app(db)).await;
+        let new_id = "http-upsert-new-song-id";
+        let payload = r#"{
+            "not_a_song": false,
+            "blobs": [],
+            "data": { "titles": ["Upsert Via PUT"], "sections": [] }
+        }"#;
+        let req = test::TestRequest::put()
+            .uri(&format!("/api/v1/songs/{new_id}"))
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .insert_header(("Content-Type", "application/json"))
+            .set_payload(payload)
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let loc = resp.headers().get(LOCATION).unwrap().to_str().unwrap();
+        assert!(loc.ends_with(&format!("/api/v1/songs/{new_id}")));
+    }
+}
+
+#[cfg(test)]
+mod blob_create_http {
+    use super::*;
+    use actix_web::http::StatusCode;
+
+    /// BLC-BLOB-005: unsupported **`file_type`** on create returns **400**.
+    #[actix_web::test]
+    async fn blc_blob_005_unsupported_file_type_returns_400() {
+        let db = test_db().await.unwrap();
+        let user = create_user(&db, "blob-bad-ft@test.local").await.unwrap();
+        let token = create_session_token(&db, user).await.unwrap();
+        let app = test::init_service(build_app(db)).await;
+        let req = test::TestRequest::post()
+            .uri("/api/v1/blobs")
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .insert_header(("Content-Type", "application/json"))
+            .set_payload(r#"{"file_type":"application/pdf","width":1,"height":1,"ocr":""}"#)
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 }
 

--- a/backend/src/resources/team/invitation/service.rs
+++ b/backend/src/resources/team/invitation/service.rs
@@ -77,7 +77,7 @@ impl<R: TeamRepository, IR: TeamInvitationRepository> InvitationService<R, IR> {
             .into_iter()
             .map(|r| r.into_invitation())
             .collect::<Result<Vec<_>, _>>()?;
-        let (page, total) = ListQuery::paginate_nested_vec(invitations, &pagination);
+        let (page, total) = ListQuery::paginate_vec(invitations, &pagination);
         Ok((page, total))
     }
 

--- a/backend/src/resources/team/rest.rs
+++ b/backend/src/resources/team/rest.rs
@@ -30,8 +30,8 @@ pub fn scope() -> Scope {
     get,
     path = "/api/v1/teams",
     params(
-        ("page" = Option<u32>, Query, description = "Page index, zero-based. Omit with `page_size` for full list (see nested pagination).", minimum = 0, nullable = true),
-        ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50. Omit with `page` for full list.", minimum = 1, maximum = 500, example = 50, nullable = true),
+        ("page" = Option<u32>, Query, description = "Page index, zero-based; defaults to 0.", minimum = 0, nullable = true),
+        ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50 when omitted.", minimum = 1, maximum = 500, example = 50, nullable = true),
     ),
     responses(
         (status = 200, description = "Teams readable by the current user; platform admins receive all teams (except internal public). `X-Total-Count` is the total before paging.", body = [Team]),
@@ -63,7 +63,7 @@ async fn get_teams(
     let teams = svc.list_teams_for_user(&user).await?;
     let total = teams.len() as u64;
     let lq = query.as_list_query();
-    let (teams_page, _) = ListQuery::paginate_nested_vec(teams, &lq);
+    let (teams_page, _) = ListQuery::paginate_vec(teams, &lq);
     Ok(HttpResponse::Ok()
         .insert_header((
             header::HeaderName::from_static("x-total-count"),

--- a/backend/src/resources/user/service.rs
+++ b/backend/src/resources/user/service.rs
@@ -74,7 +74,10 @@ impl<R: UserRepository, T: TeamRepository> UserService<R, T> {
 
     #[instrument(level = "debug", err, skip(self, request))]
     pub async fn create_user_from_request(&self, request: CreateUser) -> Result<User, AppError> {
-        self.create_user(request.into_user()).await
+        let user = request
+            .try_into_user()
+            .map_err(|e| AppError::invalid_request(e.to_string()))?;
+        self.create_user(user).await
     }
 
     #[instrument(level = "debug", err, skip(self))]
@@ -530,7 +533,7 @@ mod tests {
     mod integration {
         use crate::error::AppError;
         use crate::test_helpers::{personal_team_id, test_db, user_service};
-        use shared::user::User;
+        use shared::user::{CreateUser, Role, User};
 
         /// BLC-USER-003: creating a user also creates a personal team with the user as owner.
         #[tokio::test]
@@ -593,6 +596,46 @@ mod tests {
             // SurrealDB enforces uniqueness via DB constraints; duplicate insert returns an error.
             let r = svc.create_user(User::new("j3u004@test.local")).await;
             assert!(r.is_err(), "duplicate email must be rejected");
+        }
+
+        /// BLC-USER-001 / BLC-USER-008: `CreateUser` normalizes email; mixed case and whitespace collide.
+        #[tokio::test]
+        async fn blc_user_001_create_user_from_request_email_collision_after_normalize() {
+            let db = test_db().await.expect("db");
+            let svc = user_service(&db);
+            svc.create_user_from_request(CreateUser {
+                email: "MixEd@Case.Test.Local".into(),
+                role: Role::Default,
+                default_collection: None,
+            })
+            .await
+            .expect("first");
+            let r = svc
+                .create_user_from_request(CreateUser {
+                    email: "  mixed@case.test.local  ".into(),
+                    role: Role::Default,
+                    default_collection: None,
+                })
+                .await;
+            assert!(
+                matches!(r, Err(AppError::Conflict(_))),
+                "expected conflict after normalization, got {r:?}"
+            );
+        }
+
+        /// BLC-USER-008: malformed email on `CreateUser` is rejected before the database.
+        #[tokio::test]
+        async fn blc_user_008_invalid_email_from_request() {
+            let db = test_db().await.expect("db");
+            let svc = user_service(&db);
+            let r = svc
+                .create_user_from_request(CreateUser {
+                    email: "not-an-email".into(),
+                    role: Role::Default,
+                    default_collection: None,
+                })
+                .await;
+            assert!(matches!(r, Err(AppError::InvalidRequest(_))));
         }
 
         /// BLC-USER-014: deleting a user, then deleting the same ID again returns NotFound.

--- a/backend/src/resources/user/session/rest.rs
+++ b/backend/src/resources/user/session/rest.rs
@@ -35,8 +35,8 @@ struct ExpandQuery {
     get,
     path = "/api/v1/users/me/sessions",
     params(
-        ("page" = Option<u32>, Query, description = "Zero-based page. With `page_size`, `X-Total-Count` is pre-pagination total (`list-pagination.md`).", minimum = 0, nullable = true),
-        ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50. Omit with `page` for full list.", minimum = 1, maximum = 500, example = 50, nullable = true),
+        ("page" = Option<u32>, Query, description = "Zero-based page; defaults to 0. `X-Total-Count` is the total before paging (`list-pagination.md`).", minimum = 0, nullable = true),
+        ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50 when omitted.", minimum = 1, maximum = 500, example = 50, nullable = true),
         ("expand" = Option<String>, Query, description = "Optional comma-separated relations (`user` = embed full user on each session; default is `id`+`email` link only)."),
     ),
     responses(
@@ -69,7 +69,7 @@ pub async fn get_sessions_for_current_user(
     let page_size = page.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
     let sessions = svc.get_sessions_by_user_id(&user.id).await?;
     let lq = page.as_list_query();
-    let (sessions_page, total) = ListQuery::paginate_nested_vec(sessions, &lq);
+    let (sessions_page, total) = ListQuery::paginate_vec(sessions, &lq);
     let sessions_page: Vec<SessionBody> = sessions_page
         .into_iter()
         .map(|s| SessionBody::from_session(s, expand_user))
@@ -205,8 +205,8 @@ pub async fn create_session_for_user(
     path = "/api/v1/users/{user_id}/sessions",
     params(
         ("user_id" = String, Path, description = "User identifier"),
-        ("page" = Option<u32>, Query, description = "Zero-based page. With `page_size`, `X-Total-Count` is pre-pagination total (`list-pagination.md`).", minimum = 0, nullable = true),
-        ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50. Omit with `page` for full list.", minimum = 1, maximum = 500, example = 50, nullable = true),
+        ("page" = Option<u32>, Query, description = "Zero-based page; defaults to 0. `X-Total-Count` is the total before paging (`list-pagination.md`).", minimum = 0, nullable = true),
+        ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50 when omitted.", minimum = 1, maximum = 500, example = 50, nullable = true),
         ("expand" = Option<String>, Query, description = "Optional comma-separated relations (`user` = full user per session)."),
     ),
     responses(
@@ -240,7 +240,7 @@ pub async fn get_sessions_for_user(
     let page_size = page.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
     let sessions = svc.get_sessions_by_user_id(&path.user_id).await?;
     let lq = page.as_list_query();
-    let (sessions_page, total) = ListQuery::paginate_nested_vec(sessions, &lq);
+    let (sessions_page, total) = ListQuery::paginate_vec(sessions, &lq);
     let sessions_page: Vec<SessionBody> = sessions_page
         .into_iter()
         .map(|s| SessionBody::from_session(s, expand_user))

--- a/docs/business-logic-constraints/api-documentation.md
+++ b/docs/business-logic-constraints/api-documentation.md
@@ -5,3 +5,7 @@
 - **BLC-DOCS-001:** WHEN **`GET /api/docs/openapi.json`** runs **without** authentication THEN the API responds **200** and returns the OpenAPI schema for the HTTP API (exact wire format MAY follow the generator’s JSON layout).
 
 This route is **outside** the **`/api/v1`** authenticated surface; see [authentication.md](./authentication.md).
+
+- **BLC-DOCS-002:** The published OpenAPI document defines a **`Problem`** schema and documents **`application/problem+json`** as the content type for **4xx** and **5xx** response bodies where an error payload is returned.
+- **BLC-DOCS-003:** Auth-related routes that use query parameters (for example **`GET /auth/login`**, **`GET /auth/callback`**) declare those parameters as **`in: query`** in OpenAPI.
+- **BLC-DOCS-004:** Component schema **property** names in the OpenAPI JSON use **snake_case** (ASCII letters, digits, underscores), consistent with Rust serde defaults.

--- a/docs/business-logic-constraints/authentication.md
+++ b/docs/business-logic-constraints/authentication.md
@@ -4,12 +4,19 @@ Applies to routes under **`/api/v1`** that require an authenticated user session
 
 ## When / then
 
-- **BLC-AUTH-001:** WHEN a caller uses a route that **requires authentication** without an **`Authorization`** header whose value is interpreted as a **Bearer** session token (see **BLC-USER-006** for alternate accepted forms on **`GET /users/me`**) THEN the API responds **401**.
+- **BLC-AUTH-001:** WHEN a caller uses a route that **requires authentication** without an **`Authorization`** header whose value is interpreted as a **Bearer** session token (**BLC-USER-006**) THEN the API responds **401**.
 - **BLC-AUTH-002:** WHEN **`Authorization: Bearer <token>`** is present but **`<token>`** IS NOT a valid, active session THEN the API responds **401** before evaluating resource rules that would yield **403** or **404**.
 
 ## Relation to sessions
 
 Session lifecycle and **404**/**403** on **`/users/.../sessions`** are in [session.md](./session.md). **BLC-AUTH-002** applies when the token never identifies a session at all; after **BLC-SESS-008**/**BLC-SESS-009**, a once-valid token MAY also yield **401** on subsequent calls.
+
+## OIDC (browser login)
+
+- **BLC-AUTH-OIDC-001:** **`GET /auth/login`** starts the OIDC **authorization code** flow: the server responds with **302** to the configured identity provider (**`authorization_endpoint`**), passing **`state`** and **`nonce`** query parameters.
+- **BLC-AUTH-OIDC-002:** **`state`** is single-use and bound to the browser session; **`GET /auth/callback`** MUST receive a **`state`** that matches the pending login; mismatch or reuse yields **401** / error response per implementation.
+- **BLC-AUTH-OIDC-003:** Redirect URI used in the authorize request MUST be on the server allowlist; **`nonce`** is validated against the ID token where applicable.
+- **BLC-AUTH-OIDC-004:** Successful OIDC login issues the same session cookie semantics as OTP login (**`Set-Cookie`**, flags, path) unless deployment configuration differs.
 
 ## Email OTP
 

--- a/docs/business-logic-constraints/blob.md
+++ b/docs/business-logic-constraints/blob.md
@@ -5,8 +5,8 @@
 - **BLC-BLOB-001:** Every blob belongs to exactly one **owning team** (the **`owner`** in responses).
 - **BLC-BLOB-002:** Listing, fetching metadata, and downloading bytes require the caller to be allowed to **read that team’s library**; mutating or deleting a blob requires **library edit** rights on that team. Platform **admin** does **not** gain blob edit solely by role.
 - **BLC-BLOB-003:** **`PUT`** MUST NOT change **`owner`**.
-- **BLC-BLOB-004:** New blobs are created as metadata records; **GET …/data** MAY serve empty or placeholder bytes until binary content is supplied outside this HTTP API.
-- **BLC-BLOB-005:** **`file_type`** on create/update MUST be among the image types the API accepts (e.g. **`image/png`**, **`image/jpeg`**); unsupported values THEN **400**.
+- **BLC-BLOB-004:** New blobs are created as metadata records (**POST**). Binary bytes are supplied via **`PUT /api/v1/blobs/{id}/data`** with an appropriate **`Content-Type`** (same API surface as metadata **GET …/data**). Until bytes are written, **GET …/data** MAY serve empty or placeholder content.
+- **BLC-BLOB-005:** **`file_type`** on create/update MUST be among the image types the API accepts: **`image/png`**, **`image/jpeg`**, **`image/svg+xml`**, and the deprecated alias **`image/svg`**; unsupported values THEN **400**.
 
 ## List pagination
 
@@ -22,11 +22,12 @@
 - **BLC-BLOB-011:** WHEN **GET …/data** runs THEN the same visibility rules as metadata **GET** apply; IF bytes are available THEN they are served.
 - **BLC-BLOB-016:** **`GET /blobs/{id}/data`** responses include a weak **`ETag`** over stored bytes, **`Content-Length`**, and **`Cache-Control: private, max-age=3600, immutable`**. **`If-None-Match`** matching the current **`ETag`** yields **304** with an empty body.
 - **BLC-BLOB-012:** WHEN **PUT** runs THEN only **`file_type`**, **`width`**, **`height`**, and **`ocr`** may change.
+- **BLC-BLOB-020:** WHEN **PATCH /blobs/{id}** runs THEN only fields present in the body are updated; omitted fields are unchanged; unknown fields are rejected (**`deny_unknown_fields`**), matching the pattern in **BLC-SONG-019**. Optimistic concurrency uses **`If-Match`** with the resource **ETag**, consistent with other library resources.
 - **BLC-BLOB-013:** WHEN **DELETE** succeeds THEN the blob no longer appears in the API and associated stored bytes MAY be removed.
 
 ## Cascading deletes and dependents
 
-- **BLC-BLOB-014:** WHEN a blob used as a collection **`cover`** IS **DELETE**d THEN **GET** that collection MAY return **404** even if the collection id still exists until it is updated or removed.
+- **BLC-BLOB-014:** WHEN a blob used as a collection **`cover`** IS **DELETE**d THEN **GET** that collection MAY return **404** for the collection or expose inconsistent metadata until the collection is updated or removed; clients SHOULD refresh references after deletes.
 - **BLC-BLOB-015:** WHEN a **user** account IS deleted THEN blobs owned by their **personal** team disappear with that team (see [user.md](./user.md)).
 
 ## Move (`POST /blobs/{id}/move`)

--- a/docs/business-logic-constraints/collection.md
+++ b/docs/business-logic-constraints/collection.md
@@ -3,7 +3,7 @@
 ## Static
 
 - **BLC-COLL-001:** Every collection belongs to exactly one **owning team** (**`owner`** in responses).
-- **BLC-COLL-002:** Read paths (metadata, songs list, player) require **read** access to that team’s library; create/update/delete require **library edit** access. Platform **admin** MAY read but MUST NOT mutate collections solely by admin role.
+- **BLC-COLL-002:** Read paths (metadata, songs list, player) require **read** access to that team’s library; create/update/delete require **library edit** access. Platform **admin** MAY read but MUST NOT mutate collections solely by admin role (see [platform-admin-content.md](./platform-admin-content.md)).
 - **BLC-COLL-003:** **`PUT`** replaces **title**, **cover** (blob id), and the ordered **songs** list; **`PUT`** and **`PATCH`** MAY set **`owner`** when the body includes it and the caller may write both the current and target owning teams; omitting **`owner`** leaves it unchanged.
 - **BLC-COLL-004:** **POST**/**PUT** MAY accept **song** ids the caller cannot read or ids that do not exist; the API MAY still return **201**/**200** and persist those references.
 
@@ -19,9 +19,10 @@
 - **BLC-COLL-009:** WHEN **POST** omits **`owner`** THEN the new collection’s **`owner`** IS the caller’s **personal** team. WHEN **POST** includes **`owner`** THEN it MUST name a team id the caller may **edit** (library content); **guest** on that team THEN **404**; unknown team or no edit access THEN **404** (malformed id THEN **400**).
 - **BLC-COLL-010:** WHEN **GET /collections** runs THEN only collections whose **`owner`** team the caller may read are returned; optional **`q`** filters by **title**.
 - **BLC-COLL-011:** WHEN **GET /collections/{id}**, **…/songs**, or **…/player** runs THEN visibility matches **GET /collections/{id}**.
-- **BLC-COLL-012:** WHEN **GET …/songs** runs AND a stored song id does not resolve THEN the API MAY respond **500** rather than a partial list.
+- **BLC-COLL-012:** WHEN **GET …/songs** runs AND a stored song id does not resolve THEN behavior is defined by the implementation (partial list, omission, or error); **500** is reserved for genuine server/infrastructure failures, not as an optional substitute for **200**.
 - **BLC-COLL-013:** WHEN **PUT** includes a **song** id that does not exist THEN the API MAY still return **200** and persist the slot; clients SHOULD validate ids.
 - **BLC-COLL-014:** WHEN **GET …/songs** includes an entry pointing at a song the caller cannot read THEN the collection **owner** MAY still receive **200** with an entry while per-song detail MAY be incomplete.
+- **BLC-COLL-023:** WHEN **PATCH /collections/{id}** runs THEN only fields present in the body are updated; omitted fields are unchanged; unknown fields are rejected (**`deny_unknown_fields`**), matching **BLC-SONG-019**. Optimistic concurrency uses **`If-Match`** with the resource **ETag**.
 - **BLC-COLL-015:** WHEN **DELETE** succeeds THEN the collection no longer appears under the same rules as other reads.
 - **BLC-COLL-016:** WHEN a song IS appended to a collection automatically (e.g. after creating a song with a default collection) THEN the caller MUST be allowed to **edit** that collection’s owning team’s library.
 

--- a/docs/business-logic-constraints/http-contract.md
+++ b/docs/business-logic-constraints/http-contract.md
@@ -16,4 +16,16 @@ Rules that apply across several **`/api/v1`** resources (path validation, idempo
 
 ## API rate limiting (`/api/v1/*`)
 
-- **BLC-HTTP-004:** Versioned **`/api/v1/*`** routes are rate-limited **per client IP** (see `backend` settings **`API_RATE_LIMIT_RPS`** and **`API_RATE_LIMIT_BURST`**, defaults **50** RPS and burst **200**). WHEN the limit IS exceeded THEN the API responds **429 Too Many Requests** with **`Retry-After`** and **`X-RateLimit-*`** headers ([`actix-governor`](https://docs.rs/actix-governor/latest/actix_governor/)).
+- **BLC-HTTP-004:** Versioned **`/api/v1/*`** routes are rate-limited **per client IP** (see `backend` settings **`API_RATE_LIMIT_RPS`** and **`API_RATE_LIMIT_BURST`**, defaults **50** RPS and burst **200**). The governor uses the client address from the connection, with a fallback when the peer address is unavailable (see implementation). **`/auth/*`** routes use separate **`auth_rate_limit_*`** settings. WHEN the limit IS exceeded THEN the API responds **429 Too Many Requests** with **`Retry-After`** and **`X-RateLimit-*`** headers ([`actix-governor`](https://docs.rs/actix-governor/latest/actix_governor/)).
+
+## Conditional requests (ETag)
+
+- **BLC-HTTP-005:** Single-resource **GET**, **PATCH**, **PUT**, and **DELETE** on **songs**, **collections**, and **setlists** (JSON bodies) use a weak **`ETag`** over the canonical JSON representation. **`If-None-Match`** matching the current **`ETag`** on **GET** yields **304 Not Modified**. **`If-Match`** on mutating requests MUST match the current **`ETag`** or the API responds **412 Precondition Failed** (see **`http_cache`** in the backend). **Blob** byte responses follow **BLC-BLOB-016**.
+
+## Unknown routes under `/api` and `/auth`
+
+- **BLC-HTTP-006:** Requests to unrecognized paths under **`/api/**`** or **`/auth/**`** that are handled by the API return **`application/problem+json`** (not an HTML SPA fallback).
+
+## Platform admin vs team library writes
+
+- See [platform-admin-content.md](./platform-admin-content.md) (**BLC-ADMIN-001**, **BLC-ADMIN-002**).

--- a/docs/business-logic-constraints/list-pagination.md
+++ b/docs/business-logic-constraints/list-pagination.md
@@ -1,6 +1,6 @@
 # List endpoints: query parameters and pagination
 
-Applies to **GET** list routes that support paging: **`/users`** (admin), **`/blobs`**, **`/collections`**, **`/setlists`**, **`/songs`**.
+Applies to **GET** list routes that support paging, including **`/users`** (admin), **`/blobs`**, **`/collections`**, **`/setlists`**, **`/songs`**, **`/teams`**, **`/users/me/sessions`**, **`/users/{id}/sessions`** (admin), and **`/teams/{team}/invitations`**.
 
 ## Query parameters
 
@@ -18,7 +18,8 @@ Applies to **GET** list routes that support paging: **`/users`** (admin), **`/bl
 ## Pagination behavior
 
 - **BLC-LP-006:** ~~WHEN **`page_size`** IS **`0`** THEN no page-size cap IS applied~~ — **removed**: `page_size=0` is now rejected with `400` (see BLC-LP-004a).
-- **BLC-LP-007:** WHEN **`page`** is absent it defaults to **0**. WHEN **`page_size`** is absent it defaults to **50**. The server hard cap is **500**.
+- **BLC-LP-007:** WHEN **`page`** is absent it defaults to **0**. WHEN **`page_size`** is absent it defaults to **50**. The server hard cap is **500**. This default applies to all paginated list routes above.
+- **BLC-LP-007a (nested sub-lists):** For **GET** routes that list items **nested under another resource** (for example **`GET /collections/{id}/songs`**, **`GET /setlists/{id}/songs`**), when **both** **`page`** and **`page_size`** are **omitted**, the implementation MAY return **all** items in one response for backward compatibility. When **either** **`page`** or **`page_size`** is present, normal pagination (**BLC-LP-007**) applies.
 - **BLC-LP-008:** WHEN **`page`** IS beyond the last page THEN the API responds **200** with an **empty array** (not **404**).
 - **BLC-LP-009:** WHEN **`q`** IS combined with **`page`** / **`page_size`** THEN filtering runs first, then pagination over those results.
 

--- a/docs/business-logic-constraints/monitoring.md
+++ b/docs/business-logic-constraints/monitoring.md
@@ -3,6 +3,8 @@
 ## Static
 
 - **BLC-MON-001:** Every HTTP request handled by the backend results in **one** `http_request_audit` row (including `/auth/*`, `/api/docs/*`, and static asset routes), written **asynchronously** with best-effort persistence (logging failures MUST NOT change the HTTP response).
+- **BLC-MON-005:** **`GET /api/v1/monitoring/metrics`** exposes aggregated metrics for an admin-configured time window; access is **admin-only** (same pattern as **BLC-MON-004** for audit logs). Query parameters and response shape are defined in OpenAPI.
+- **BLC-MON-006:** Successful **OTP** and **OIDC** logins produce monitoring/audit records suitable for security review (see `audit_events` tests); failed login attempts SHOULD be auditable where the implementation records them.
 - **BLC-MON-002:** Authenticated `/api/v1/*` requests that pass session validation populate `user` and `session` record links on the audit row; requests without a validated session (or outside `/api/v1`) store **no** user/session links (`NONE`).
 - **BLC-MON-003:** When a **user** or **session** row is **deleted**, existing `http_request_audit` rows remain; the corresponding `user` and/or `session` link fields are cleared so no dangling record references remain.
 - **BLC-MON-004:** `GET /api/v1/monitoring/http-audit-logs` is **admin-only**: an authenticated non-admin receives **403**; no session receives **401**.

--- a/docs/business-logic-constraints/platform-admin-content.md
+++ b/docs/business-logic-constraints/platform-admin-content.md
@@ -1,0 +1,10 @@
+# Platform admin and team library content
+
+Cross-cutting rule for **library** resources (songs, collections, setlists, blobs) and team visibility.
+
+## Rule
+
+- **BLC-ADMIN-001:** A platform **`admin`** user **MAY** see additional **non-public** teams and their content in **read** paths (listing and **GET**) where the resolver grants expanded read scope (`content_read_team_things`).
+- **BLC-ADMIN-002:** Platform **`admin`** does **not** receive **library edit** (mutate) rights on a team’s library **solely** because **`role = admin`** on the user. **PUT**, **PATCH**, **DELETE**, and moves require the same team **library edit** membership as non-admins (`content_write_team_things`).
+
+Resource-specific wording appears in **BLC-SONG-002**, **BLC-COLL-002**, **BLC-SETL-002**, **BLC-BLOB-002**, and related **move** rules; this document is the single cross-reference for the invariant.

--- a/docs/business-logic-constraints/setlist.md
+++ b/docs/business-logic-constraints/setlist.md
@@ -23,6 +23,7 @@
 - **BLC-SETL-010:** WHEN **GET /setlists** runs THEN only setlists whose **`owner`** team the caller may read are returned; optional **`q`** filters by **title**.
 - **BLC-SETL-011:** WHEN **GET /setlists/{id}**, **…/songs**, or **…/player** runs THEN visibility matches **GET /setlists/{id}**.
 - **BLC-SETL-012:** WHEN **DELETE** succeeds THEN the setlist no longer appears under the same read rules.
+- **BLC-SETL-018:** WHEN **PATCH /setlists/{id}** runs THEN only fields present in the body are updated; omitted fields are unchanged; unknown fields are rejected (**`deny_unknown_fields`**), matching **BLC-SONG-019**. Optimistic concurrency uses **`If-Match`** with the resource **ETag**.
 
 ## Cascading deletes
 

--- a/docs/business-logic-constraints/song.md
+++ b/docs/business-logic-constraints/song.md
@@ -24,7 +24,7 @@
 - **BLC-SONG-014:** WHEN **DELETE /songs/{id}** succeeds THEN the song no longer appears via the API under the same access rules as **PUT**.
 - **BLC-SONG-017:** WHEN **PUT /songs/{id}** body fails validation (e.g. empty **`data`**, or wrong types for fields such as **`tempo`** / **`time`**) THEN **400**.
 - **BLC-SONG-019:** WHEN **PATCH /songs/{id}** omits **`data`** and other patch fields THEN those properties remain unchanged; the request body lists only fields to update (see OpenAPI **`PatchSong`**).
-- **BLC-SONG-018:** WHEN **PUT /songs/{id}** uses an **`{id}`** that does not yet refer to an existing song THEN the API MAY create the song with that **id**; **`owner`** in the body selects the owning team when the caller may write that team, otherwise **`owner`** IS the caller’s **personal** team, subject to **BLC-SONG-007** and **BLC-SONG-008** for **guest** vs **edit** rights.
+- **BLC-SONG-018:** WHEN **PUT /songs/{id}** uses an **`{id}`** that does not yet refer to an existing song THEN the API **creates** the song with that **id** and responds **201 Created** with a **`Location`** header naming the new resource, consistent with [create-update-policy.md](./create-update-policy.md) (**Upsert**). **`owner`** in the body selects the owning team when the caller may write that team, otherwise **`owner`** IS the caller’s **personal** team, subject to **BLC-SONG-007** and **BLC-SONG-008** for **guest** vs **edit** rights. WHEN the **`{id}`** already refers to an existing song THEN the API responds **200 OK** with the updated body.
 
 ## Move (`POST /songs/{id}/move`)
 
@@ -34,5 +34,9 @@
 
 ## Cascading deletes and collection/setlist references
 
-- **BLC-SONG-015:** WHEN a song IS deleted THEN collections and setlists MAY still list its id until updated; **POST**/**PUT** MAY accept unknown ids; **GET …/collections/{id}/songs`** MAY return **500** or incomplete entries if a slot no longer resolves; clients SHOULD refresh after deletes.
+- **BLC-SONG-015:** WHEN a song IS deleted THEN collections and setlists MAY still list its id until updated; **POST**/**PUT** MAY accept unknown ids. Clients SHOULD refresh lists after deletes to avoid stale references.
+
+## Developer notes (non-normative)
+
+- Stale **song** ids inside collection/setlist **songs** arrays after a delete are a client-visible consistency concern; list and detail behavior for unresolved ids is defined by the implementation (see OpenAPI and tests), not by speculative **500** outcomes.
 - **BLC-SONG-016:** WHEN a **user** account IS deleted THEN songs owned by their **personal** team are removed with that team ([user.md](./user.md)).

--- a/docs/business-logic-constraints/team-invitation.md
+++ b/docs/business-logic-constraints/team-invitation.md
@@ -3,7 +3,7 @@
 ## Static
 
 - **BLC-TINV-001:** An invitation IS ALWAYS for one **shared** team (not a **personal** team, not the reserved catalog team).
-- **BLC-TINV-002:** Creating, listing, fetching, and deleting invitations IS ALWAYS limited to team **admin** (platform **admin** has no special bypass unless the product adds it later).
+- **BLC-TINV-002:** Creating, listing, fetching, and deleting invitations requires **team admin** on that team. A **member** who is **not** admin receives **403**. Callers who are **not** members of the team (or use a wrong team id) receive **404** for list/get/delete, consistent with ACL hiding. Platform **admin** has no special bypass for these operations unless the product adds it later.
 - **BLC-TINV-003:** Invitations have **no expiry**, **no max uses**, and **no use counter** in the API contract.
 - **BLC-TINV-004:** **DELETE** permanently removes an invitation; there IS no separate “revoked but visible” state.
 - **BLC-TINV-005:** After **accept**, the invitation remains until an **admin** **DELETE**s it.

--- a/docs/business-logic-constraints/team.md
+++ b/docs/business-logic-constraints/team.md
@@ -21,6 +21,9 @@
 - **BLC-TEAM-014:** WHEN someone tries to reassign a personal **`owner`** THEN the operation IS rejected.
 - **BLC-TEAM-015:** WHEN removing the last admin on a shared team THEN the API responds **409** until fixed or the team IS deleted.
 - **BLC-TEAM-016:** WHEN **DELETE** runs on a **shared** team THEN the actor MUST be **admin** (or equivalent); blobs, songs, collections, and setlists that belonged to that team become owned by the deleting **admin**’s **personal** team (they are not deleted).
+- **BLC-TEAM-019:** WHEN **PATCH /teams/{id}** runs THEN only fields present in the body are updated; omitted fields are unchanged; unknown fields are rejected, matching **BLC-SONG-019**. Optimistic concurrency uses **`If-Match`** with the resource **ETag** where applicable.
+
+Platform **admin** read vs write for team-scoped library content: [platform-admin-content.md](./platform-admin-content.md).
 
 ## Cascading deletes (user vs team)
 

--- a/docs/business-logic-constraints/user.md
+++ b/docs/business-logic-constraints/user.md
@@ -2,7 +2,7 @@
 
 ## Static
 
-- **BLC-USER-001:** **`email`** IS ALWAYS unique after normalization (trim, lowercase).
+- **BLC-USER-001:** **`email`** IS ALWAYS unique after normalization (trim, lowercase). The database schema also enforces normalization and email shape as defense-in-depth; callers SHOULD send normalized email, and the API validates at the boundary (see implementation).
 - **BLC-USER-002:** **`role`** IS ALWAYS platform **`default`** or **`admin`** (separate from team **guest** / **content_maintainer** / **admin** on teams).
 - **BLC-USER-003:** Creating a user IS ALWAYS paired with creating that user’s **personal** team (**owner** 1:1).
 - **BLC-USER-004:** Optional **`default_collection`** on create IS stored as provided: the API does **not** require that the collection id exist at insert time (unknown ids MAY still yield **201**).
@@ -14,12 +14,14 @@
 ## When / then
 
 - **BLC-USER-005:** WHEN any authenticated user calls **GET /users/me** THEN they receive their own **User** record for the current session.
-- **BLC-USER-006:** WHEN **GET /users/me** sends the session token as the raw **`Authorization`** value without a **`Bearer `** prefix THEN the server MAY still accept it (deployment-specific).
+- **BLC-USER-006:** **`Authorization`** MUST use the **`Bearer `** scheme: the value MUST be **`Bearer <session token>`**. A raw token without the **`Bearer `** prefix is **not** accepted; the API responds **401** (same as missing auth).
 - **BLC-USER-007:** WHEN a non-admin calls **GET /users**, **GET /users/{id}**, **POST /users**, or **DELETE /users/{id}** THEN the API responds **403**.
 - **BLC-USER-008:** WHEN **POST /users** uses an email that already exists THEN the API responds **409**; invalid or missing email THEN **400**.
 - **BLC-USER-009:** WHEN **GET /users/{id}** runs THEN the caller MUST be platform **admin** OR otherwise be allowed by the API to read that profile; **guest** membership on someone’s **personal** team does **not** imply permission to read the **owner**’s user record (**403**).
 - **BLC-USER-010:** WHEN the current user calls **GET** or **DELETE** on **`/users/me/sessions`** or **`/users/me/sessions/{id}`** THEN only sessions belonging to **me** are visible or deletable; another user’s session id THEN **404**. See [session.md](./session.md).
 - **BLC-USER-011:** WHEN platform admin uses **`/users/{user_id}/sessions`** (and `{id}`) THEN they MAY list, **POST** (create), fetch, or delete that user’s sessions (session lifetime per server configuration).
+- **BLC-USER-015:** **`PUT /users/me/profile-picture`** uploads a profile image: **`Content-Type`** MUST be an allowed image type; body size and dimensions are capped per server configuration; the server stores bytes as a **blob** on the user’s **personal** team and sets **`avatar_blob_id`**.
+- **BLC-USER-016:** **`DELETE /users/me/profile-picture`** removes the uploaded avatar blob reference (**`avatar_blob_id`**) when present; OAuth-cached avatars (**`oauth_avatar_blob_id`**) are unchanged.
 
 ## Cascading deletes
 

--- a/scripts/check_blc_coverage.sh
+++ b/scripts/check_blc_coverage.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# List BLC identifiers declared in docs/business-logic-constraints/*.md and report
+# which never appear in backend test sources (Venom `# BLC:` lines, Rust `BLC-…` in
+# http_tests / audit_events_tests).
+#
+# Usage:
+#   ./scripts/check_blc_coverage.sh
+#   STRICT=1 ./scripts/check_blc_coverage.sh   # exit 1 if any doc BLC is unreferenced in tests
+#
+# Always prints a summary to stdout. Exit 0 by default; STRICT=1 exits 1 when the
+# "missing" list is non-empty.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DOCS_GLOB="$ROOT/docs/business-logic-constraints/*.md"
+TEST_DIRS=(
+  "$ROOT/backend/tests"
+  "$ROOT/backend/src/http_tests.rs"
+  "$ROOT/backend/src/audit_events_tests.rs"
+)
+
+if ! compgen -G "$DOCS_GLOB" >/dev/null; then
+  echo "error: no BLC docs at $DOCS_GLOB" >&2
+  exit 2
+fi
+
+IDS=$(grep -rhoE 'BLC-[A-Z]+-[0-9]+[a-z]?' $DOCS_GLOB | sort -u)
+IDS_COUNT=$(printf '%s\n' "$IDS" | grep -c . || true)
+
+missing=()
+while IFS= read -r id; do
+  [[ -z "$id" ]] && continue
+  hit=0
+  for path in "${TEST_DIRS[@]}"; do
+    if [[ -f "$path" ]] && grep -q "$id" "$path" 2>/dev/null; then
+      hit=1
+      break
+    fi
+    if [[ -d "$path" ]] && grep -rq "$id" "$path" 2>/dev/null; then
+      hit=1
+      break
+    fi
+  done
+  if [[ "$hit" -eq 0 ]]; then
+    missing+=("$id")
+  fi
+done <<< "$IDS"
+
+echo "BLC ids in docs: $IDS_COUNT"
+echo "Unreferenced in backend/tests + http_tests + audit_events_tests: ${#missing[@]}"
+if ((${#missing[@]})); then
+  printf '%s\n' "${missing[@]}"
+  if [[ "${STRICT:-0}" == 1 ]]; then
+    exit 1
+  fi
+fi
+exit 0

--- a/shared/src/user/mod.rs
+++ b/shared/src/user/mod.rs
@@ -4,6 +4,8 @@ mod session;
 mod user;
 
 pub use request::CreateUser;
+#[cfg(feature = "backend")]
+pub use request::CreateUserError;
 pub use role::Role;
 pub use session::{Session, SessionBody, SessionUserBody};
 pub use user::User;

--- a/shared/src/user/request.rs
+++ b/shared/src/user/request.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "backend")]
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "backend")]
+use thiserror::Error;
 
 use super::Role;
 #[cfg(feature = "backend")]
@@ -8,6 +10,31 @@ use super::User;
 #[cfg(feature = "backend")]
 #[allow(unused_imports)]
 use serde_json::json;
+
+/// Failed to build a [`User`] from [`CreateUser`] (missing or malformed email).
+#[cfg(feature = "backend")]
+#[derive(Debug, Clone, Error)]
+pub enum CreateUserError {
+    #[error("email is required")]
+    MissingEmail,
+    #[error("invalid email address")]
+    InvalidEmail,
+}
+
+#[cfg(feature = "backend")]
+fn email_passes_basic_checks(normalized: &str) -> bool {
+    let parts: Vec<&str> = normalized.split('@').collect();
+    if parts.len() != 2 {
+        return false;
+    }
+    let local = parts[0];
+    let domain = parts[1];
+    !local.is_empty()
+        && !domain.is_empty()
+        && domain.contains('.')
+        && !domain.starts_with('.')
+        && !domain.ends_with('.')
+}
 
 #[cfg_attr(feature = "backend", derive(utoipa::ToSchema))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -25,11 +52,19 @@ pub struct CreateUser {
 }
 
 impl CreateUser {
+    /// Normalize and validate **`email`**, then build a new in-memory [`User`] (no id yet).
     #[cfg(feature = "backend")]
-    pub fn into_user(self) -> User {
-        User {
+    pub fn try_into_user(self) -> Result<User, CreateUserError> {
+        let email = self.email.trim().to_lowercase();
+        if email.is_empty() {
+            return Err(CreateUserError::MissingEmail);
+        }
+        if !email_passes_basic_checks(&email) {
+            return Err(CreateUserError::InvalidEmail);
+        }
+        Ok(User {
             id: String::new(),
-            email: self.email,
+            email,
             role: self.role,
             default_collection: self.default_collection,
             created_at: Utc::now(),
@@ -38,6 +73,6 @@ impl CreateUser {
             oauth_picture_url: None,
             oauth_avatar_blob_id: None,
             avatar_blob_id: None,
-        }
+        })
     }
 }


### PR DESCRIPTION
This PR completes the phased BLC remediation from the business-logic reviews (2026-04-18 / 2026-04-20).

**Phase A — docs:** Align BLC markdown with implementation (song upsert 201, Bearer-only auth, invitations ACL, blob/PATCH/pagination, platform-admin cross-cut, OIDC/monitoring/api-docs stubs, avatar rules, MAY-500 tightening).

**Phase B — code:** `CreateUser::try_into_user` (trim/lowercase/email checks); `paginate_vec` for top-level teams/sessions/invitations; OpenAPI regen.

**Phase C — tests:** HTTP rate-limit 429 + headers, Link header on songs list, platform-admin PUT denial, song PUT upsert 201 + Location, blob invalid file_type.

**Phase D:** `scripts/check_blc_coverage.sh` (optional `STRICT=1`).

**Validation:** `cargo build`, `cargo test`, `cargo clippy -D warnings`, `cargo fmt --check`, Spectral on `openapi.json`, full Venom suite on random port.

Also removes an unnecessary `pub(crate)` on the rate-limit test app builder (finish checklist).

Made with [Cursor](https://cursor.com)