### PR TITLE
chore(deps): update Rust dependencies to latest versions

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -10,10 +10,9 @@ chrono = { version = "0.4", default-features = false, features = [
     "clock",
     "serde",
 ] }
-openidconnect = "3"
-oauth2 = { version = "4.4", default-features = false, features = ["reqwest"] }
+openidconnect = "4"
 once_cell = "1"
-reqwest = { version = "0.11", default-features = false, features = [
+reqwest = { version = "0.12", default-features = false, features = [
     "json",
     "rustls-tls",
     "gzip",
@@ -21,7 +20,7 @@ reqwest = { version = "0.11", default-features = false, features = [
 ] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-thiserror = "1"
+thiserror = "2"
 time = "0.3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 tracing = "0.1"
@@ -29,11 +28,11 @@ tracing-actix-web = "0.7"
 tracing-log = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 uuid = { version = "1", features = ["v4"] }
-rand = { version = "0.8", features = ["std"] }
+rand = { version = "0.10", features = ["std"] }
 envy = "0.4.2"
 futures-util = "0.3"
-utoipa = { version = "4", features = ["chrono"] }
-utoipa-swagger-ui = { version = "5", features = ["actix-web"] }
+utoipa = { version = "5", features = ["chrono"] }
+utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
 surrealdb = { version = "3.0.5", default-features = false, features = [
     "kv-mem",
     "protocol-http",
@@ -48,13 +47,13 @@ hex = "0.4.3"
 actix-files = "0.6.10"
 actix-governor = "0.10"
 shared = { path = "../shared", features = ["backend"] }
-chordlib = { version = "0.8.1", features = ["html"] }
-zip = "6.0.0"
-imagesize = "0.13"
+chordlib = { version = "0.8.2", features = ["html"] }
+zip = "8.6.0"
+imagesize = "0.14"
 
 [dev-dependencies]
 anyhow = "1"
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }
 tempfile = "3"
 tracing-test = "0.2.6"
 

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -6,8 +6,10 @@
         "properties": {
           "git_commit": {
             "description": "Git revision if `GIT_COMMIT_SHA` was set during `cargo build`.",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "production": {
             "description": "`true` when [`observability::is_production`] is satisfied.",
@@ -36,8 +38,10 @@
           },
           "dau_over_mau": {
             "format": "double",
-            "nullable": true,
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "dau_users": {
             "format": "int64",
@@ -210,8 +214,10 @@
           },
           "owner": {
             "description": "Owning team id (same format as `Blob.owner` in responses). Omit to create under the caller's personal team.",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "width": {
             "format": "int32",
@@ -247,8 +253,10 @@
           },
           "owner": {
             "description": "Owning team id (`team` record id, same format as `Collection.owner` in responses). Omit to create under the caller's personal team.",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "songs": {
             "items": {
@@ -283,8 +291,10 @@
         "properties": {
           "owner": {
             "description": "Owning team id (same format as `Setlist.owner` in responses). Omit to create under the caller's personal team.",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "songs": {
             "items": {
@@ -330,8 +340,10 @@
           },
           "owner": {
             "description": "Owning team id (same format as `Song.owner` in responses). Omit to create under the caller's personal team (and apply default-collection rules).",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [
@@ -372,8 +384,10 @@
         },
         "properties": {
           "default_collection": {
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "email": {
             "type": "string"
@@ -411,13 +425,17 @@
           },
           "requests_per_active_user_product": {
             "format": "double",
-            "nullable": true,
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "requests_per_session": {
             "format": "double",
-            "nullable": true,
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "sessioned_requests_in_window": {
             "format": "int64",
@@ -489,13 +507,17 @@
           },
           "p95_ms": {
             "format": "double",
-            "nullable": true,
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "p99_ms": {
             "format": "double",
-            "nullable": true,
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           }
         },
         "required": [
@@ -574,16 +596,20 @@
             "type": "string"
           },
           "session_id": {
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "status_code": {
             "format": "int32",
             "type": "integer"
           },
           "user_id": {
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [
@@ -644,13 +670,17 @@
           },
           "p95_ms_all": {
             "format": "double",
-            "nullable": true,
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "p99_ms_all": {
             "format": "double",
-            "nullable": true,
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           }
         },
         "required": [
@@ -678,13 +708,17 @@
           },
           "p95_ms": {
             "format": "double",
-            "nullable": true,
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "p99_ms": {
             "format": "double",
-            "nullable": true,
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           }
         },
         "required": [
@@ -747,8 +781,10 @@
       "MonitoringMetricsResponse": {
         "properties": {
           "activation_skipped_reason": {
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "activity_calendar": {
             "$ref": "#/components/schemas/ActivityCalendarMetrics"
@@ -772,12 +808,14 @@
             "$ref": "#/components/schemas/MutationHealthMetrics"
           },
           "new_user_activation": {
-            "allOf": [
+            "oneOf": [
+              {
+                "type": "null"
+              },
               {
                 "$ref": "#/components/schemas/NewUserActivationMetrics"
               }
-            ],
-            "nullable": true
+            ]
           },
           "probing": {
             "$ref": "#/components/schemas/IdLike404Metrics"
@@ -931,29 +969,37 @@
         "description": "Partial update for a blob. Absent fields are left unchanged.",
         "properties": {
           "file_type": {
-            "allOf": [
+            "oneOf": [
+              {
+                "type": "null"
+              },
               {
                 "$ref": "#/components/schemas/FileType"
               }
-            ],
-            "nullable": true
+            ]
           },
           "height": {
             "format": "int32",
             "minimum": 0,
-            "nullable": true,
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "ocr": {
             "description": "OCR or extracted text used for search (may be empty).",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "width": {
             "format": "int32",
             "minimum": 0,
-            "nullable": true,
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -963,23 +1009,31 @@
         "description": "Partial update for a collection. Absent fields are left unchanged.",
         "properties": {
           "cover": {
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "owner": {
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "songs": {
             "items": {
               "$ref": "#/components/schemas/SongLink"
             },
-            "nullable": true,
-            "type": "array"
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "title": {
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -989,19 +1043,25 @@
         "description": "Partial update for a setlist. Absent fields are left unchanged.",
         "properties": {
           "owner": {
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "songs": {
             "items": {
               "$ref": "#/components/schemas/SongLink"
             },
-            "nullable": true,
-            "type": "array"
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "title": {
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -1017,20 +1077,26 @@
             "items": {
               "$ref": "#/components/schemas/BlobLink"
             },
-            "nullable": true,
-            "type": "array"
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/PatchSongData"
           },
           "not_a_song": {
-            "nullable": true,
-            "type": "boolean"
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "owner": {
             "description": "Set the song's owning team id; omit to leave unchanged.",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [
@@ -1046,46 +1112,62 @@
             "items": {
               "type": "string"
             },
-            "nullable": true,
-            "type": "array"
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "copyright": {
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "key": {
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "languages": {
             "description": "BCP 47 language tags (e.g. `en`, `de-CH`).",
             "items": {
               "type": "string"
             },
-            "nullable": true,
-            "type": "array"
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "sections": {
             "items": {
               "type": "object"
             },
-            "nullable": true,
-            "type": "array"
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "subtitle": {
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "tags": {
-            "nullable": true,
-            "type": "object"
+            "type": [
+              "object",
+              "null"
+            ]
           },
           "tempo": {
             "description": "Tempo in BPM (beats per minute).",
             "format": "int32",
             "minimum": 0,
-            "nullable": true,
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "time": {
             "items": {
@@ -1093,15 +1175,19 @@
               "minimum": 0,
               "type": "integer"
             },
-            "nullable": true,
-            "type": "array"
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "titles": {
             "items": {
               "type": "string"
             },
-            "nullable": true,
-            "type": "array"
+            "type": [
+              "array",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -1114,12 +1200,16 @@
             "items": {
               "$ref": "#/components/schemas/TeamMemberInput"
             },
-            "nullable": true,
-            "type": "array"
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "name": {
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -1147,7 +1237,8 @@
             "$ref": "#/components/schemas/ScrollType"
           },
           "scroll_type_cache_other_orientation": {
-            "$ref": "#/components/schemas/ScrollType"
+            "$ref": "#/components/schemas/ScrollType",
+            "description": "Scroll mode cached when toggling orientation (book/half-page behavior)."
           },
           "toc": {
             "items": {
@@ -1192,9 +1283,6 @@
         "type": "object"
       },
       "PlayerItem": {
-        "discriminator": {
-          "propertyName": "type"
-        },
         "oneOf": [
           {
             "allOf": [
@@ -1249,13 +1337,17 @@
           },
           "detail": {
             "description": "Human-readable explanation.",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "instance": {
             "description": "Optional URI reference that identifies the specific occurrence.",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "status": {
             "description": "HTTP status code.",
@@ -1289,12 +1381,16 @@
             "type": "string"
           },
           "detail": {
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "instance": {
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "status": {
             "format": "int32",
@@ -1479,7 +1575,8 @@
       "SessionUserBody": {
         "oneOf": [
           {
-            "$ref": "#/components/schemas/User"
+            "$ref": "#/components/schemas/User",
+            "description": "Try full user first so link-shaped JSON (missing required user fields) falls through to [`TeamUser`]."
           },
           {
             "$ref": "#/components/schemas/TeamUser"
@@ -1534,7 +1631,8 @@
             "type": "array"
           },
           "data": {
-            "$ref": "#/components/schemas/SongDataSchema"
+            "$ref": "#/components/schemas/SongDataSchema",
+            "description": "ChordPro-derived payload (sections, lyrics, metadata); see `SongDataSchema` in the OpenAPI components."
           },
           "id": {
             "type": "string"
@@ -1547,7 +1645,8 @@
             "type": "string"
           },
           "user_specific_addons": {
-            "$ref": "#/components/schemas/SongUserSpecificAddons"
+            "$ref": "#/components/schemas/SongUserSpecificAddons",
+            "description": "Per-request flags such as whether the current user liked this song."
           }
         },
         "required": [
@@ -1586,14 +1685,18 @@
             "type": "array"
           },
           "copyright": {
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "key": {
             "description": "Musical key; chord symbols use ChordPro conventions.",
             "example": "G",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "languages": {
             "description": "BCP 47 language tags (e.g. `en`, `de-CH`).",
@@ -1613,8 +1716,10 @@
             "type": "array"
           },
           "subtitle": {
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "tags": {
             "additionalProperties": true,
@@ -1625,8 +1730,10 @@
             "description": "Tempo in BPM (beats per minute).",
             "format": "int32",
             "minimum": 0,
-            "nullable": true,
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "time": {
             "description": "Time signature as `(numerator, denominator)` (e.g. 4/4).",
@@ -1639,8 +1746,10 @@
               "minimum": 0,
               "type": "integer"
             },
-            "nullable": true,
-            "type": "array"
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "titles": {
             "description": "Primary and alternate titles from ChordPro `{title}` / `{title:N}` directives.",
@@ -1670,13 +1779,17 @@
           },
           "key": {
             "description": "Musical key for this slot (e.g. `G`, `Am`, `F#m`).",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "nr": {
             "description": "Optional display position in the parent list (e.g. `1`, `2a`).",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [
@@ -1695,35 +1808,47 @@
         "properties": {
           "lang": {
             "description": "Filter to songs whose `data.languages` contains this string (exact match on an array element).",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "page": {
             "format": "int32",
             "minimum": 0,
-            "nullable": true,
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "page_size": {
             "format": "int32",
             "minimum": 0,
-            "nullable": true,
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "q": {
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "sort": {
             "description": "Sort: comma-separated fields, `-` prefix for descending (e.g. `-id`, `title`, `-id,title`).\nUse `relevance` when searching (`q` non-empty). Legacy tokens (`id_desc`, …) accepted with a warning.",
             "example": "-id",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "tag": {
             "description": "Case-insensitive substring match against the stringified `data.tags` object (keys and values).",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -1772,12 +1897,15 @@
             "type": "string"
           },
           "owner": {
-            "allOf": [
+            "oneOf": [
               {
-                "$ref": "#/components/schemas/TeamUser"
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/TeamUser",
+                "description": "When set, this team is that user's personal team (1:1, not deletable). Not listed in `members`."
               }
-            ],
-            "nullable": true
+            ]
           }
         },
         "required": [
@@ -1883,8 +2011,10 @@
         "properties": {
           "id": {
             "description": "Optional stable id when this TOC row links to a concrete song.",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "idx": {
             "minimum": 0,
@@ -2001,8 +2131,10 @@
           },
           "owner": {
             "description": "Target team id for the collection's `owner`; omit or `null` to keep the current owner.",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "songs": {
             "items": {
@@ -2027,8 +2159,10 @@
         "properties": {
           "owner": {
             "description": "Target team id for the setlist's `owner`; omit or `null` to keep the current owner.",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "songs": {
             "items": {
@@ -2074,8 +2208,10 @@
           },
           "owner": {
             "description": "Target team id for the song's `owner`; omit or `null` to keep the current owner.",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [
@@ -2093,8 +2229,10 @@
             "items": {
               "$ref": "#/components/schemas/TeamMemberInput"
             },
-            "nullable": true,
-            "type": "array"
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "name": {
             "type": "string"
@@ -2121,16 +2259,20 @@
         "properties": {
           "avatar_blob_id": {
             "description": "User-uploaded profile image; takes precedence over [`Self::oauth_avatar_blob_id`].",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "created_at": {
             "format": "date-time",
             "type": "string"
           },
           "default_collection": {
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "email": {
             "type": "string"
@@ -2140,18 +2282,24 @@
           },
           "last_login_at": {
             "format": "date-time",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "oauth_avatar_blob_id": {
             "description": "Backend-cached OAuth profile image (`GET /api/v1/blobs/{id}/data`).",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "oauth_picture_url": {
             "description": "Last `picture` claim URL seen from OIDC (used to detect when to re-fetch the cached avatar).",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "request_count": {
             "description": "Approximate authenticated API request count for this user (diagnostic; semantics may evolve).",
@@ -2196,7 +2344,7 @@
     "title": "Worship Viewer API",
     "version": "2.0.0"
   },
-  "openapi": "3.0.3",
+  "openapi": "3.1.0",
   "paths": {
     "/api/v1/about": {
       "get": {
@@ -2231,8 +2379,10 @@
             "schema": {
               "format": "int32",
               "minimum": 0,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           {
@@ -2245,8 +2395,10 @@
               "format": "int32",
               "maximum": 500,
               "minimum": 1,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           {
@@ -2255,7 +2407,6 @@
             "name": "q",
             "required": false,
             "schema": {
-              "nullable": true,
               "type": "string"
             }
           }
@@ -2829,8 +2980,12 @@
             "content": {
               "image/*": {
                 "schema": {
-                  "format": "binary",
-                  "type": "string"
+                  "items": {
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "type": "array"
                 }
               }
             },
@@ -2919,8 +3074,12 @@
           "content": {
             "application/octet-stream": {
               "schema": {
-                "format": "binary",
-                "type": "string"
+                "items": {
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": "array"
               }
             }
           },
@@ -3126,8 +3285,10 @@
             "schema": {
               "format": "int32",
               "minimum": 0,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           {
@@ -3140,8 +3301,10 @@
               "format": "int32",
               "maximum": 500,
               "minimum": 1,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           {
@@ -3150,7 +3313,6 @@
             "name": "q",
             "required": false,
             "schema": {
-              "nullable": true,
               "type": "string"
             }
           }
@@ -3924,8 +4086,10 @@
             "schema": {
               "format": "int32",
               "minimum": 0,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           {
@@ -3938,8 +4102,10 @@
               "format": "int32",
               "maximum": 500,
               "minimum": 1,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           }
         ],
@@ -4112,8 +4278,10 @@
             "schema": {
               "format": "int32",
               "minimum": 0,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           {
@@ -4126,8 +4294,10 @@
               "format": "int32",
               "maximum": 500,
               "minimum": 1,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           }
         ],
@@ -4321,8 +4491,10 @@
             "schema": {
               "format": "int32",
               "minimum": 0,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           {
@@ -4335,8 +4507,10 @@
               "format": "int32",
               "maximum": 500,
               "minimum": 1,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           {
@@ -4345,7 +4519,6 @@
             "name": "q",
             "required": false,
             "schema": {
-              "nullable": true,
               "type": "string"
             }
           }
@@ -5119,8 +5292,10 @@
             "schema": {
               "format": "int32",
               "minimum": 0,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           {
@@ -5133,8 +5308,10 @@
               "format": "int32",
               "maximum": 500,
               "minimum": 1,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           }
         ],
@@ -5228,8 +5405,10 @@
             "schema": {
               "format": "int32",
               "minimum": 0,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           {
@@ -5242,8 +5421,10 @@
               "format": "int32",
               "maximum": 500,
               "minimum": 1,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           {
@@ -5252,7 +5433,6 @@
             "name": "q",
             "required": false,
             "schema": {
-              "nullable": true,
               "type": "string"
             }
           },
@@ -5262,7 +5442,6 @@
             "name": "sort",
             "required": false,
             "schema": {
-              "nullable": true,
               "type": "string"
             }
           },
@@ -5272,7 +5451,6 @@
             "name": "lang",
             "required": false,
             "schema": {
-              "nullable": true,
               "type": "string"
             }
           },
@@ -5282,7 +5460,6 @@
             "name": "tag",
             "required": false,
             "schema": {
-              "nullable": true,
               "type": "string"
             }
           }
@@ -6306,8 +6483,10 @@
             "schema": {
               "format": "int32",
               "minimum": 0,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           {
@@ -6320,8 +6499,10 @@
               "format": "int32",
               "maximum": 500,
               "minimum": 1,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           }
         ],
@@ -6883,8 +7064,10 @@
             "schema": {
               "format": "int32",
               "minimum": 0,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           {
@@ -6897,8 +7080,10 @@
               "format": "int32",
               "maximum": 500,
               "minimum": 1,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           }
         ],
@@ -7374,8 +7559,10 @@
             "schema": {
               "format": "int32",
               "minimum": 0,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           {
@@ -7388,8 +7575,10 @@
               "format": "int32",
               "maximum": 500,
               "minimum": 1,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           {
@@ -7398,7 +7587,6 @@
             "name": "q",
             "required": false,
             "schema": {
-              "nullable": true,
               "type": "string"
             }
           }
@@ -7698,8 +7886,12 @@
           "content": {
             "image/jpeg": {
               "schema": {
-                "format": "binary",
-                "type": "string"
+                "items": {
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": "array"
               }
             }
           },
@@ -7793,8 +7985,10 @@
             "schema": {
               "format": "int32",
               "minimum": 0,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           {
@@ -7807,8 +8001,10 @@
               "format": "int32",
               "maximum": 500,
               "minimum": 1,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           {
@@ -7817,7 +8013,6 @@
             "name": "expand",
             "required": false,
             "schema": {
-              "nullable": true,
               "type": "string"
             }
           }
@@ -7979,7 +8174,6 @@
             "name": "expand",
             "required": false,
             "schema": {
-              "nullable": true,
               "type": "string"
             }
           }
@@ -8239,8 +8433,10 @@
             "schema": {
               "format": "int32",
               "minimum": 0,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           {
@@ -8253,8 +8449,10 @@
               "format": "int32",
               "maximum": 500,
               "minimum": 1,
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           {
@@ -8263,7 +8461,6 @@
             "name": "expand",
             "required": false,
             "schema": {
-              "nullable": true,
               "type": "string"
             }
           }
@@ -8363,7 +8560,6 @@
             "name": "expand",
             "required": false,
             "schema": {
-              "nullable": true,
               "type": "string"
             }
           }
@@ -8550,7 +8746,6 @@
             "name": "expand",
             "required": false,
             "schema": {
-              "nullable": true,
               "type": "string"
             }
           }
@@ -8701,7 +8896,6 @@
             "name": "redirect_to",
             "required": false,
             "schema": {
-              "nullable": true,
               "type": "string"
             }
           }

--- a/backend/src/auth/oidc/client.rs
+++ b/backend/src/auth/oidc/client.rs
@@ -4,11 +4,22 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result as AnyResult};
 use openidconnect::core::{CoreClient, CoreProviderMetadata};
-use openidconnect::reqwest::async_http_client;
 use openidconnect::{ClientId, ClientSecret, IssuerUrl, RedirectUrl};
+use openidconnect::{EndpointMaybeSet, EndpointNotSet, EndpointSet};
+use reqwest::Client as ReqwestClient;
 use tracing::info;
 
 use crate::settings::Settings;
+
+/// [`CoreClient`] after discovery: auth endpoint set, token endpoint may be present from metadata.
+pub type DiscoveredOidcClient = CoreClient<
+    EndpointSet,
+    EndpointNotSet,
+    EndpointNotSet,
+    EndpointNotSet,
+    EndpointMaybeSet,
+    EndpointMaybeSet,
+>;
 
 /// Supported OIDC identity provider (Google only in this deployment).
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
@@ -43,13 +54,18 @@ impl FromStr for OidcProvider {
 
 #[derive(Debug)]
 pub struct OidcClientRegistration {
-    client: Arc<CoreClient>,
+    client: Arc<DiscoveredOidcClient>,
+    http: ReqwestClient,
     scopes: Vec<String>,
 }
 
 impl OidcClientRegistration {
-    pub fn client(&self) -> &CoreClient {
+    pub fn client(&self) -> &DiscoveredOidcClient {
         self.client.as_ref()
+    }
+
+    pub fn http(&self) -> &ReqwestClient {
+        &self.http
     }
 
     pub fn scopes(&self) -> &[String] {
@@ -80,7 +96,7 @@ impl OidcClients {
 }
 
 pub async fn build_clients(settings: &Settings) -> AnyResult<OidcClients> {
-    let google_client = build_client(
+    let (google_client, google_http) = build_client(
         OidcProvider::Google,
         &settings.oidc_issuer_url,
         &settings.oidc_client_id,
@@ -100,6 +116,7 @@ pub async fn build_clients(settings: &Settings) -> AnyResult<OidcClients> {
     Ok(OidcClients {
         google: OidcClientRegistration {
             client: Arc::new(google_client),
+            http: google_http,
             scopes: settings.oidc_scopes.clone(),
         },
     })
@@ -111,19 +128,27 @@ async fn build_client(
     client_id: &str,
     client_secret: Option<&str>,
     redirect_url: &str,
-) -> AnyResult<CoreClient> {
+) -> AnyResult<(DiscoveredOidcClient, ReqwestClient)> {
+    let http = ReqwestClient::builder()
+        // Following redirects opens the client up to SSRF vulnerabilities.
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .context("build OIDC HTTP client")?;
     let issuer = IssuerUrl::new(issuer_url.to_string())
         .with_context(|| "invalid GOOGLE_ISSUER_URL value")?;
-    let metadata = CoreProviderMetadata::discover_async(issuer, async_http_client)
+    let metadata = CoreProviderMetadata::discover_async(issuer, &http)
         .await
         .with_context(|| "unable to fetch Google provider metadata")?;
     let redirect = RedirectUrl::new(redirect_url.to_string())
         .with_context(|| "invalid GOOGLE_REDIRECT_URL value")?;
 
-    Ok(CoreClient::from_provider_metadata(
-        metadata,
-        ClientId::new(client_id.to_string()),
-        client_secret.map(|secret| ClientSecret::new(secret.to_owned())),
-    )
-    .set_redirect_uri(redirect))
+    Ok((
+        CoreClient::from_provider_metadata(
+            metadata,
+            ClientId::new(client_id.to_string()),
+            client_secret.map(|secret| ClientSecret::new(secret.to_owned())),
+        )
+        .set_redirect_uri(redirect),
+        http,
+    ))
 }

--- a/backend/src/auth/oidc/model.rs
+++ b/backend/src/auth/oidc/model.rs
@@ -1,8 +1,8 @@
 use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
-use oauth2::PkceCodeVerifier;
 use openidconnect::Nonce;
+use openidconnect::PkceCodeVerifier;
 use serde::{Deserialize, Serialize};
 use surrealdb::types::{Datetime, RecordId, SurrealValue};
 

--- a/backend/src/auth/oidc/rest.rs
+++ b/backend/src/auth/oidc/rest.rs
@@ -8,10 +8,8 @@ use actix_web::{
     web::{self, Data},
 };
 use chrono::{Duration as ChronoDuration, Utc};
-use oauth2::{AuthorizationCode, CsrfToken, PkceCodeChallenge};
 use openidconnect::core::CoreAuthenticationFlow;
-use openidconnect::reqwest::async_http_client;
-use openidconnect::{Nonce, Scope};
+use openidconnect::{AuthorizationCode, CsrfToken, Nonce, PkceCodeChallenge, Scope, TokenResponse};
 use serde::Deserialize;
 use time::Duration as CookieDuration;
 use tracing::instrument;
@@ -151,24 +149,24 @@ async fn callback(
         }
     };
     let oidc_client = registration.client();
+    let http = registration.http();
 
-    let mut token_request = oidc_client.exchange_code(AuthorizationCode::new(query.code.clone()));
+    let mut token_request = oidc_client
+        .exchange_code(AuthorizationCode::new(query.code.clone()))
+        .map_err(|e| crate::log_and_convert!(AppError::oidc, "oidc.exchange_code", e))?;
     token_request = token_request.set_pkce_verifier(pkce_verifier);
 
-    let token_response = token_request
-        .request_async(async_http_client)
-        .await
-        .map_err(|e| {
-            crate::audit!(
-                "audit.auth.login.failure",
-                provider = tracing::field::display(&"google"),
-                reason = tracing::field::display(&"token_exchange_failed")
-                ; "oidc login failed"
-            );
-            crate::log_and_convert!(AppError::oidc, "oidc.token_exchange", e)
-        })?;
+    let token_response = token_request.request_async(http).await.map_err(|e| {
+        crate::audit!(
+            "audit.auth.login.failure",
+            provider = tracing::field::display(&"google"),
+            reason = tracing::field::display(&"token_exchange_failed")
+            ; "oidc login failed"
+        );
+        crate::log_and_convert!(AppError::oidc, "oidc.token_exchange", e)
+    })?;
 
-    let id_token = match token_response.extra_fields().id_token() {
+    let id_token = match token_response.id_token() {
         Some(t) => t,
         None => {
             crate::audit!(

--- a/backend/src/auth/oidc/schema_contract_tests.rs
+++ b/backend/src/auth/oidc/schema_contract_tests.rs
@@ -1,8 +1,8 @@
 //! SCHEMAFULL contract tests: serde content written by OIDC state helpers must match Surreal schema.
 
 use chrono::{Duration as ChronoDuration, Utc};
-use oauth2::PkceCodeChallenge;
 use openidconnect::Nonce;
+use openidconnect::PkceCodeChallenge;
 
 use super::{Model as OidcModel, OidcProvider, PendingOidc};
 use crate::test_helpers::test_db;

--- a/backend/src/auth/otp/rest.rs
+++ b/backend/src/auth/otp/rest.rs
@@ -5,7 +5,7 @@ use actix_web::{
     web::{self, Data},
 };
 
-use rand::Rng;
+use rand::RngExt;
 use shared::auth::otp::{OtpRequest, OtpVerify};
 use time::Duration as CookieDuration;
 
@@ -48,7 +48,7 @@ pub(crate) async fn otp_request(
         .ok_if(|value| !value.is_empty())
         .ok_or_else(|| AppError::invalid_request("email is required"))?;
 
-    let code = format!("{:06}", rand::thread_rng().gen_range(0..1_000_000));
+    let code = format!("{:06}", rand::rng().random_range(0..1_000_000));
     db.remember_otp(&email, &code, &otp_cfg.pepper, otp_cfg.ttl_seconds)
         .await?;
 

--- a/backend/src/resources/song/rest.rs
+++ b/backend/src/resources/song/rest.rs
@@ -19,6 +19,7 @@ use crate::resources::song::{CreateSong, UpdateSong};
 use crate::resources::team::UserPermissions;
 use shared::MoveOwner;
 use shared::api::{PAGE_SIZE_DEFAULT, SongListQuery};
+use shared::like::LikeStatus;
 #[allow(unused_imports)]
 use shared::player::Player;
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,11 +8,11 @@ name = "worshipviewer"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.6.0", features = ["derive", "env"] }
-tokio = { version = "1.51.1", features = ["rt-multi-thread", "macros"] }
+clap = { version = "4.6.1", features = ["derive", "env"] }
+tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-toml = "0.8.23"
-dirs = "5.0.1"
+toml = "1.1.2"
+dirs = "6.0.0"
 shared = { path = "../shared", features = ["cli"] }
 

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -5,15 +5,15 @@ edition = "2021"
 
 [dependencies]
 shared = { path = "../shared", features = ["frontend"] }
-yew = { version = "0.21.0", features = ["csr"] }
-yew-router = "0.18"
-stylist = { version = "0.13.0", features = ["yew_integration", "parser"] }
-wasm-bindgen-futures = "0.4.67"
-wasm-bindgen = "0.2.117"
-gloo-net = "0.6.0"
-gloo-console = "0.3.0"
-yew-hooks = "0.3.4"
-web-sys = { version = "0.3.94", features = [
+yew = { version = "0.23.0", features = ["csr"] }
+yew-router = "0.20"
+stylist = { version = "0.15.1", features = ["yew_integration", "parser"] }
+wasm-bindgen-futures = "0.4.68"
+wasm-bindgen = "0.2.118"
+gloo-net = "0.7.0"
+gloo-console = "0.4.0"
+yew-hooks = "0.6.4"
+web-sys = { version = "0.3.95", features = [
     "Blob",
     "DragEvent",
     "File",
@@ -35,13 +35,13 @@ web-sys = { version = "0.3.94", features = [
     "Element",
     "HtmlElement",
 ] }
-gloo = { version = "0.11.0", features = ["futures"] }
+gloo = { version = "0.12.0", features = ["futures"] }
 serde = { version = "1.0.228", features = ["derive"] }
 url = "2.5.8"
 getrandom_0_3 = { package = "getrandom", version = "0.3.4", features = [
     "wasm_js",
 ] }
-js-sys = "0.3.94"
+js-sys = "0.3.95"
 chrono = { version = "0.4.44", default-features = false, features = [
     "clock",
     "serde",

--- a/frontend/src/components/editor/editor.rs
+++ b/frontend/src/components/editor/editor.rs
@@ -246,7 +246,7 @@ impl Component for Editor {
                     {save}
                 </div>
                 <div class={&self.code_mirror_style_class} style="min-width: 100px;">
-                    <textarea id={self.editor_name.clone()}></textarea>
+                    <textarea id={self.editor_name.clone()} default_value={String::new()} />
                 </div>
             </div>
         }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -4,23 +4,23 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chordlib = { version = "0.8.1", features = ["html"] }
+chordlib = { version = "0.8.2", features = ["html"] }
 chrono = { version = "0.4.44", default-features = false, features = [
     "clock",
     "serde",
 ] }
 serde = { version = "1.0.228", features = ["derive"] }
-uuid = { version = "1.23.0", features = ["v4"], optional = true }
+uuid = { version = "1.23.1", features = ["v4"], optional = true }
 tracing = { version = "0.1", optional = true }
-utoipa = { version = "4", optional = true }
-thiserror = "1.0"
+utoipa = { version = "5", optional = true }
+thiserror = "2.0"
 async-trait = "0.1"
 serde_json = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
-gloo-net = { version = "0.6", features = ["http"], optional = true }
-js-sys = { version = "0.3.94", optional = true }
-wasm-bindgen = { version = "0.2.117", optional = true }
-web-sys = { version = "0.3.94", features = ["RequestCredentials"], optional = true }
+gloo-net = { version = "0.7", features = ["http"], optional = true }
+js-sys = { version = "0.3.95", optional = true }
+wasm-bindgen = { version = "0.2.118", optional = true }
+web-sys = { version = "0.3.95", features = ["RequestCredentials"], optional = true }
 
 [features]
 backend = ["utoipa", "tracing", "uuid"]


### PR DESCRIPTION
## Summary
- Bumped all crates in `shared`, `cli`, `frontend`, and `backend` with `cargo upgrade --incompatible allow`.
- **Backend:** Kept a single `reqwest` line compatible with `oauth2`/`openidconnect` (0.12 + `rustls-tls`). Migrated OIDC to **openidconnect 4** / **oauth2 5** (discovered client type parameters, `exchange_code` returning `Result`, `TokenResponse` in scope, shared `reqwest::Client` for async HTTP). Updated **rand 0.10** OTP code (`RngExt::random_range`). Restored **utoipa 5** `LikeStatus` reference for song like endpoint docs.
- **Frontend:** Yew 0.23 requires self-closing `<textarea />` with `default_value` for CodeMirror host.
- Regenerated `backend/openapi.json` for the doc snapshot test.

## Verification
- `cargo build` (backend, cli), `cargo build --target wasm32-unknown-unknown` (frontend)
- `cargo test` (backend), including `openapi_snapshot_matches_committed_file`

Made with [Cursor](https://cursor.com)