### PR TITLE
fix(backend): Rustls ring CryptoProvider for Cloud Run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,5 +89,8 @@ COPY --from=builder /wrk/backend/db-migrations/ /app/db-migrations
 COPY --from=builder /wrk/frontend/dist/ /app/static
 
 EXPOSE 8080
+# Cloud Run (and other platforms) set PORT; the process must accept traffic on 0.0.0.0, not
+# loopback only, or the platform health check will never see an open port.
+ENV HOST=0.0.0.0
 WORKDIR /app
 ENTRYPOINT ["/app/worshipviewer"]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -18,6 +18,9 @@ reqwest = { version = "0.12", default-features = false, features = [
     "gzip",
     "multipart",
 ] }
+# Direct dependency: Rustls 0.23+ requires a single process-wide CryptoProvider. We use
+# `ring` (same as reqwest/surrealdb) and install it in `main` before any TLS (wss, OIDC).
+rustls = { version = "0.23", default-features = false, features = ["std", "tls12", "ring"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -29,6 +29,10 @@ use backend::settings::Settings;
 
 #[actix_web::main]
 async fn main() -> AnyResult<()> {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .map_err(|e| anyhow::anyhow!("failed to install rustls ring crypto provider: {e:?}"))?;
+
     backend::observability::init()?;
 
     let settings = Settings::from_env()?;
@@ -56,19 +60,29 @@ async fn main() -> AnyResult<()> {
         ),
     )?;
 
-    let db = Arc::new(
-        database::Database::connect(
-            &settings.db_address,
-            &settings.db_namespace,
-            &settings.db_database,
-            settings.db_username.as_deref(),
-            settings.db_password.as_deref(),
-        )
-        .await?,
-    );
-    db.migrate(settings.db_migration_path.as_str())
-        .await
-        .context("database migration failed")?;
+    // DB setup and OIDC provider discovery (HTTPS) run in parallel so we reach
+    // `HttpServer::bind` sooner. Cloud Run's startup check fails if the process
+    // has not opened `PORT` in time, even with `HOST=0.0.0.0`.
+    let (db, oidc_inner) = tokio::try_join!(
+        async {
+            let db = Arc::new(
+                database::Database::connect(
+                    &settings.db_address,
+                    &settings.db_namespace,
+                    &settings.db_database,
+                    settings.db_username.as_deref(),
+                    settings.db_password.as_deref(),
+                )
+                .await?,
+            );
+            db.migrate(settings.db_migration_path.as_str())
+                .await
+                .context("database migration failed")?;
+            Result::<_, anyhow::Error>::Ok(db)
+        },
+        oidc::build_clients(&settings)
+    )?;
+    let oidc_clients_arc = Arc::new(oidc_inner);
 
     let user_service = UserServiceHandle::build(db.clone());
     let session_service = SessionServiceHandle::build(db.clone());
@@ -123,7 +137,6 @@ async fn main() -> AnyResult<()> {
         }
     }
 
-    let oidc_clients_arc = Arc::new(oidc::build_clients(&settings).await?);
     let oidc_provider_ids = oidc_clients_arc.registered_provider_ids();
     let oidc_clients = Data::new(oidc_clients_arc);
 


### PR DESCRIPTION
## Summary

- Install Rustls **ring** `CryptoProvider` at process start. Rustls 0.23+ panics without it when any code path uses TLS first (e.g. `wss://` Surreal, OIDC discovery, `reqwest`), which surfaced on Google Cloud Run as “failed to listen on PORT” with `exit(101)`.
- Run **DB connect + migrate** and **OIDC `build_clients`** in **parallel** (`tokio::try_join!`) to shorten startup before `HttpServer::bind`.
- **Dockerfile:** `ENV HOST=0.0.0.0` so the image listens on all interfaces when the platform does not set `HOST`.

## Test plan

- [x] `cargo check` / `cargo clippy` on `backend`
- [ ] Deploy image to Cloud Run and confirm revision becomes ready

Made with [Cursor](https://cursor.com)