### PR TITLE
feat(audit): client origin and version on http_request_audit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN if [ -n "${GIT_COMMIT_SHA:-}" ]; then export GIT_COMMIT_SHA; else unset GIT_
 WORKDIR /wrk
 COPY ./frontend ./frontend
 WORKDIR /wrk/frontend
-RUN trunk build --release
+# Same `GIT_COMMIT_SHA` / `option_env!` contract as the backend `cargo build` above (see backend `about` / CI build-args).
+RUN if [ -n "${GIT_COMMIT_SHA:-}" ]; then export GIT_COMMIT_SHA; else unset GIT_COMMIT_SHA; fi && trunk build --release
 
 FROM scratch AS tester
 

--- a/backend/db-migrations/20260427000000_http_request_audit_client_fields.surql
+++ b/backend/db-migrations/20260427000000_http_request_audit_client_fields.surql
@@ -1,0 +1,7 @@
+-- Client attribution for `http_request_audit` (see `client_attribution` in `http_audit`).
+DEFINE FIELD OVERWRITE client_origin ON http_request_audit
+  TYPE string
+  VALUE $value ?? $before ?? 'unknown'
+  ASSERT $value IN ['frontend', 'cli', 'swagger', 'unknown']
+  PERMISSIONS FULL;
+DEFINE FIELD OVERWRITE client_version ON http_request_audit TYPE option<string> PERMISSIONS FULL;

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -575,6 +575,15 @@
       "HttpAuditLog": {
         "description": "One persisted HTTP request audit row (admin monitoring API).",
         "properties": {
+          "client_origin": {
+            "type": "string"
+          },
+          "client_version": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "created_at": {
             "format": "date-time",
             "type": "string"
@@ -619,6 +628,7 @@
           "path",
           "status_code",
           "duration_ms",
+          "client_origin",
           "created_at"
         ],
         "type": "object"

--- a/backend/src/client_attribution.rs
+++ b/backend/src/client_attribution.rs
@@ -1,0 +1,109 @@
+//! Derive `client_origin` / `client_version` for [`crate::http_audit`] from request headers.
+
+/// HTTP header sent by first-party clients: `<product>/<version>`.
+pub const X_WORSHIP_CLIENT: &str = "X-Worship-Client";
+
+/// Returns `(client_origin, client_version)` for persistence on `http_request_audit`.
+pub fn classify(
+    x_worship_client: Option<&str>,
+    user_agent: Option<&str>,
+    referer: Option<&str>,
+) -> (String, Option<String>) {
+    if let Some(raw) = x_worship_client
+        && let Some((product, ver)) = raw.split_once('/')
+    {
+        let ver = ver.trim();
+        if !ver.is_empty() {
+            let origin = match product.trim() {
+                "worshipviewer-cli" => "cli",
+                "worshipviewer-frontend" => "frontend",
+                _ => "unknown",
+            }
+            .to_string();
+            return (origin, Some(ver.to_string()));
+        }
+    }
+
+    if referer
+        .is_some_and(|r| r.to_ascii_lowercase().contains("/api/docs"))
+    {
+        return ("swagger".to_string(), None);
+    }
+
+    if user_agent.is_some_and(|ua| ua.contains("reqwest")) {
+        return ("cli".to_string(), None);
+    }
+
+    if user_agent.is_some_and(|ua| ua.contains("Mozilla")) {
+        return ("frontend".to_string(), None);
+    }
+
+    ("unknown".to_string(), None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn primary_cli_header() {
+        let (o, v) = classify(
+            Some("worshipviewer-cli/1.2.3"),
+            Some("reqwest/0.12"),
+            None,
+        );
+        assert_eq!(o, "cli");
+        assert_eq!(v.as_deref(), Some("1.2.3"));
+    }
+
+    #[test]
+    fn primary_frontend_header() {
+        let (o, v) = classify(
+            Some("worshipviewer-frontend/0.1.0"),
+            Some("Mozilla/5.0"),
+            None,
+        );
+        assert_eq!(o, "frontend");
+        assert_eq!(v.as_deref(), Some("0.1.0"));
+    }
+
+    #[test]
+    fn unknown_product_with_version() {
+        let (o, v) = classify(Some("other-tool/9.0"), None, None);
+        assert_eq!(o, "unknown");
+        assert_eq!(v.as_deref(), Some("9.0"));
+    }
+
+    #[test]
+    fn referer_swagger_wins_over_mozilla_ua() {
+        let (o, v) = classify(
+            None,
+            Some("Mozilla/5.0"),
+            Some("http://127.0.0.1:8080/api/docs/"),
+        );
+        assert_eq!(o, "swagger");
+        assert!(v.is_none());
+    }
+
+    #[test]
+    fn mozilla_without_referer_is_frontend() {
+        let (o, v) = classify(
+            None,
+            Some("Mozilla/5.0 (Macintosh)"),
+            Some("https://app.example/"),
+        );
+        assert_eq!(o, "frontend");
+        assert!(v.is_none());
+    }
+
+    #[test]
+    fn reqwest_without_header() {
+        let (o, v) = classify(
+            None,
+            Some("reqwest/0.12"),
+            None,
+        );
+        assert_eq!(o, "cli");
+        assert!(v.is_none());
+    }
+}

--- a/backend/src/http_audit.rs
+++ b/backend/src/http_audit.rs
@@ -5,12 +5,14 @@ use std::rc::Rc;
 use std::time::Instant;
 
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready};
+use actix_web::http::header::{REFERER, USER_AGENT};
 use actix_web::web::Data;
 use actix_web::{Error, HttpMessage};
 use futures_util::future::LocalBoxFuture;
 use tracing::error;
 use uuid::Uuid;
 
+use crate::client_attribution::{self, X_WORSHIP_CLIENT};
 use crate::database::Database;
 use crate::request_id::ApiRequestTarget;
 use crate::resources::User;
@@ -85,6 +87,24 @@ where
             .get::<ApiRequestTarget>()
             .map(|t| t.0.clone())
             .unwrap_or(path_fallback.clone());
+        let headers = req.headers();
+        let x_worship_client = headers
+            .get(X_WORSHIP_CLIENT)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
+        let user_agent = headers
+            .get(USER_AGENT)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
+        let referer = headers
+            .get(REFERER)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
+        let (client_origin, client_version) = client_attribution::classify(
+            x_worship_client.as_deref(),
+            user_agent.as_deref(),
+            referer.as_deref(),
+        );
 
         Box::pin(async move {
             let outcome = service.call(req).await;
@@ -120,6 +140,8 @@ where
                 duration_ms,
                 user_id,
                 session_id,
+                client_origin,
+                client_version,
             };
             if cfg!(test) {
                 insert_row(db_inner.get_ref(), row)
@@ -146,6 +168,8 @@ struct HttpAuditInsert {
     duration_ms: i64,
     user_id: Option<String>,
     session_id: Option<String>,
+    client_origin: String,
+    client_version: Option<String>,
 }
 
 async fn insert_row(db: &Database, row: HttpAuditInsert) -> Result<(), surrealdb::Error> {
@@ -154,6 +178,8 @@ async fn insert_row(db: &Database, row: HttpAuditInsert) -> Result<(), surrealdb
         .query(
             "CREATE http_request_audit SET request_id = $request_id, method = $method, \
              path = $path, status_code = $status_code, duration_ms = $duration_ms, \
+             client_origin = $client_origin, \
+             client_version = IF $client_version = NONE THEN NONE ELSE $client_version END, \
              user = IF $user_id = NONE THEN NONE ELSE type::record('user', $user_id) END, \
              session = IF $session_id = NONE THEN NONE ELSE type::record('session', $session_id) END;",
         )
@@ -162,6 +188,8 @@ async fn insert_row(db: &Database, row: HttpAuditInsert) -> Result<(), surrealdb
         .bind(("path", row.path))
         .bind(("status_code", row.status_code))
         .bind(("duration_ms", row.duration_ms))
+        .bind(("client_origin", row.client_origin))
+        .bind(("client_version", row.client_version))
         .bind(("user_id", row.user_id))
         .bind(("session_id", row.session_id))
         .await?;

--- a/backend/src/http_tests.rs
+++ b/backend/src/http_tests.rs
@@ -1320,6 +1320,55 @@ mod monitoring_http {
         .unwrap_or((None, None))
     }
 
+    #[derive(Deserialize, SurrealValue)]
+    struct AuditClient {
+        client_origin: String,
+        client_version: Option<String>,
+    }
+
+    async fn audit_client_for_request(
+        db: &Arc<Database>,
+        request_id: &str,
+    ) -> (String, Option<String>) {
+        let mut r = db
+            .db
+            .query(
+                "SELECT client_origin, client_version FROM http_request_audit WHERE request_id = $rid LIMIT 1",
+            )
+            .bind(("rid", request_id.to_string()))
+            .await
+            .expect("audit client");
+        let row: Option<AuditClient> = r.take(0).expect("take client");
+        row.map(|x| (x.client_origin, x.client_version))
+            .unwrap_or_else(|| ("unknown".to_string(), None))
+    }
+
+    /// `X-Worship-Client` is stored on the audit row (integration check).
+    #[actix_web::test]
+    async fn http_audit_persists_x_worship_client() {
+        let db = test_db().await.unwrap();
+        let app = test::init_service(build_app(db.clone())).await;
+        let req = test::TestRequest::get()
+            .uri("/api/docs/openapi.json")
+            .insert_header((
+                crate::client_attribution::X_WORSHIP_CLIENT,
+                "worshipviewer-cli/9.8.7",
+            ))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let rid = resp
+            .headers()
+            .get("x-request-id")
+            .and_then(|h| h.to_str().ok())
+            .expect("x-request-id")
+            .to_string();
+        wait_audit_row(&db, &rid).await;
+        let (origin, version) = audit_client_for_request(&db, &rid).await;
+        assert_eq!(origin, "cli");
+        assert_eq!(version.as_deref(), Some("9.8.7"));
+    }
+
     /// BLC-MON-004: unauthenticated GET /monitoring/http-audit-logs returns 401.
     #[actix_web::test]
     async fn blc_mon_004_unauthenticated_returns_401() {
@@ -1502,6 +1551,7 @@ mod monitoring_http {
                 .query(
                     "CREATE http_request_audit SET request_id = $rid, method = 'GET', path = $path, \
                      status_code = $status, duration_ms = 10, user = NONE, session = NONE, \
+                     client_origin = 'unknown', client_version = NONE, \
                      created_at = d'2026-04-01T12:00:00Z'",
                 )
                 .bind(("rid", rid.to_string()))

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod about;
 pub mod accept;
 pub mod auth;
+pub mod client_attribution;
 pub mod database;
 pub mod docs;
 pub mod error;

--- a/backend/src/resources/monitoring/model.rs
+++ b/backend/src/resources/monitoring/model.rs
@@ -104,6 +104,10 @@ pub struct HttpAuditRecord {
     pub user: Option<RecordId>,
     #[serde(default)]
     pub session: Option<RecordId>,
+    #[serde(default)]
+    pub client_origin: Option<String>,
+    #[serde(default)]
+    pub client_version: Option<String>,
     pub created_at: Datetime,
 }
 
@@ -119,6 +123,10 @@ impl HttpAuditRecord {
             duration_ms: self.duration_ms as i32,
             user_id: self.user.as_ref().map(record_id_string),
             session_id: self.session.as_ref().map(record_id_string),
+            client_origin: self
+                .client_origin
+                .unwrap_or_else(|| "unknown".to_string()),
+            client_version: self.client_version,
             created_at: self.created_at.into(),
         }
     }
@@ -137,6 +145,9 @@ pub struct HttpAuditLog {
     pub user_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
+    pub client_origin: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_version: Option<String>,
     pub created_at: DateTime<Utc>,
 }
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -93,6 +93,7 @@ pub fn build_http_client_config(
         timeout,
         session_cookie: sso_session,
         bearer_token: options.bearer_token.clone(),
+        client_ident: Some(concat!("worshipviewer-cli/", env!("CARGO_PKG_VERSION")).to_string()),
     };
     Ok((config, base_url))
 }

--- a/frontend/src/api/api.rs
+++ b/frontend/src/api/api.rs
@@ -20,6 +20,16 @@ use shared::api::{ApiClient, ListQuery, SongListQuery};
 
 use std::rc::Rc;
 
+/// `X-Worship-Client` value: `worshipviewer-frontend/<version>`, matching the backend
+/// `GET /api/v1/about` build metadata: git SHA if `GIT_COMMIT_SHA` was set at compile time,
+/// else `CARGO_PKG_VERSION` from this crate.
+fn worshipviewer_frontend_client_ident() -> String {
+    format!(
+        "worshipviewer-frontend/{}",
+        option_env!("GIT_COMMIT_SHA").unwrap_or(env!("CARGO_PKG_VERSION"))
+    )
+}
+
 #[derive(Clone)]
 pub struct Api {
     client: Rc<ApiClient<DefaultHttpClient>>,
@@ -39,6 +49,7 @@ impl Api {
             timeout: None,
             session_cookie: None,
             bearer_token: None,
+            client_ident: Some(worshipviewer_frontend_client_ident()),
         };
         let client = Rc::new(ApiClient::with_default(config));
 

--- a/shared/src/net/desktop.rs
+++ b/shared/src/net/desktop.rs
@@ -29,6 +29,20 @@ impl DesktopHttpClient {
         let path = path.trim_start_matches('/');
         format!("{base}/{path}")
     }
+
+    fn with_common_headers(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        let mut request = request;
+        if let Some(ref cookie) = self.config.session_cookie {
+            request = request.header(reqwest::header::COOKIE, format!("sso_session={cookie}"));
+        }
+        if let Some(ref token) = self.config.bearer_token {
+            request = request.bearer_auth(token);
+        }
+        if let Some(ref id) = self.config.client_ident {
+            request = request.header("X-Worship-Client", id);
+        }
+        request
+    }
 }
 
 #[async_trait::async_trait]
@@ -39,13 +53,7 @@ impl HttpClient for DesktopHttpClient {
     {
         let url = self.make_url(path);
 
-        let mut request = self.client.get(url);
-        if let Some(cookie) = &self.config.session_cookie {
-            request = request.header(reqwest::header::COOKIE, format!("sso_session={cookie}"));
-        }
-        if let Some(token) = &self.config.bearer_token {
-            request = request.bearer_auth(token);
-        }
+        let request = self.with_common_headers(self.client.get(url));
 
         let response = request.send().await?;
         let response = response.error_for_status()?;
@@ -61,13 +69,7 @@ impl HttpClient for DesktopHttpClient {
     {
         let url = self.make_url(path);
 
-        let mut request = self.client.post(url).json(body);
-        if let Some(cookie) = &self.config.session_cookie {
-            request = request.header(reqwest::header::COOKIE, format!("sso_session={cookie}"));
-        }
-        if let Some(token) = &self.config.bearer_token {
-            request = request.bearer_auth(token);
-        }
+        let request = self.with_common_headers(self.client.post(url).json(body));
 
         let response = request.send().await?;
         let response = response.error_for_status()?;
@@ -83,13 +85,7 @@ impl HttpClient for DesktopHttpClient {
     {
         let url = self.make_url(path);
 
-        let mut request = self.client.put(url).json(body);
-        if let Some(cookie) = &self.config.session_cookie {
-            request = request.header(reqwest::header::COOKIE, format!("sso_session={cookie}"));
-        }
-        if let Some(token) = &self.config.bearer_token {
-            request = request.bearer_auth(token);
-        }
+        let request = self.with_common_headers(self.client.put(url).json(body));
 
         let response = request.send().await?;
         let response = response.error_for_status()?;
@@ -105,13 +101,7 @@ impl HttpClient for DesktopHttpClient {
     {
         let url = self.make_url(path);
 
-        let mut request = self.client.patch(url).json(body);
-        if let Some(cookie) = &self.config.session_cookie {
-            request = request.header(reqwest::header::COOKIE, format!("sso_session={cookie}"));
-        }
-        if let Some(token) = &self.config.bearer_token {
-            request = request.bearer_auth(token);
-        }
+        let request = self.with_common_headers(self.client.patch(url).json(body));
 
         let response = request.send().await?;
         let response = response.error_for_status()?;
@@ -126,13 +116,7 @@ impl HttpClient for DesktopHttpClient {
     {
         let url = self.make_url(path);
 
-        let mut request = self.client.post(url).json(body);
-        if let Some(cookie) = &self.config.session_cookie {
-            request = request.header(reqwest::header::COOKIE, format!("sso_session={cookie}"));
-        }
-        if let Some(token) = &self.config.bearer_token {
-            request = request.bearer_auth(token);
-        }
+        let request = self.with_common_headers(self.client.post(url).json(body));
 
         let response = request.send().await?;
         response.error_for_status()?;
@@ -146,13 +130,7 @@ impl HttpClient for DesktopHttpClient {
     {
         let url = self.make_url(path);
 
-        let mut request = self.client.delete(url);
-        if let Some(cookie) = &self.config.session_cookie {
-            request = request.header(reqwest::header::COOKIE, format!("sso_session={cookie}"));
-        }
-        if let Some(token) = &self.config.bearer_token {
-            request = request.bearer_auth(token);
-        }
+        let request = self.with_common_headers(self.client.delete(url));
 
         let response = request.send().await?;
         let response = response.error_for_status()?;
@@ -164,13 +142,7 @@ impl HttpClient for DesktopHttpClient {
     async fn delete_no_content(&self, path: &str) -> Result<(), NetworkClientError> {
         let url = self.make_url(path);
 
-        let mut request = self.client.delete(url);
-        if let Some(cookie) = &self.config.session_cookie {
-            request = request.header(reqwest::header::COOKIE, format!("sso_session={cookie}"));
-        }
-        if let Some(token) = &self.config.bearer_token {
-            request = request.bearer_auth(token);
-        }
+        let request = self.with_common_headers(self.client.delete(url));
 
         let response = request.send().await?;
         response.error_for_status()?;
@@ -180,13 +152,7 @@ impl HttpClient for DesktopHttpClient {
     async fn put_no_content(&self, path: &str) -> Result<(), NetworkClientError> {
         let url = self.make_url(path);
 
-        let mut request = self.client.put(url);
-        if let Some(cookie) = &self.config.session_cookie {
-            request = request.header(reqwest::header::COOKIE, format!("sso_session={cookie}"));
-        }
-        if let Some(token) = &self.config.bearer_token {
-            request = request.bearer_auth(token);
-        }
+        let request = self.with_common_headers(self.client.put(url));
 
         let response = request.send().await?;
         response.error_for_status()?;
@@ -204,17 +170,12 @@ impl HttpClient for DesktopHttpClient {
     {
         let url = self.make_url(path);
 
-        let mut request = self
-            .client
-            .put(url)
-            .header(reqwest::header::CONTENT_TYPE, content_type)
-            .body(body.to_vec());
-        if let Some(cookie) = &self.config.session_cookie {
-            request = request.header(reqwest::header::COOKIE, format!("sso_session={cookie}"));
-        }
-        if let Some(token) = &self.config.bearer_token {
-            request = request.bearer_auth(token);
-        }
+        let request = self.with_common_headers(
+            self.client
+                .put(url)
+                .header(reqwest::header::CONTENT_TYPE, content_type)
+                .body(body.to_vec()),
+        );
 
         let response = request.send().await?;
         let response = response.error_for_status()?;

--- a/shared/src/net/mod.rs
+++ b/shared/src/net/mod.rs
@@ -14,6 +14,8 @@ pub struct HttpClientConfig {
     pub session_cookie: Option<String>,
     /// Optional bearer token used for `Authorization: Bearer <token>` authentication.
     pub bearer_token: Option<String>,
+    /// Value for the `X-Worship-Client` header (`<product>/<version>`, e.g. `worshipviewer-cli/0.1.0`).
+    pub client_ident: Option<String>,
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/shared/src/net/wasm.rs
+++ b/shared/src/net/wasm.rs
@@ -22,6 +22,17 @@ impl WasmHttpClient {
         let path = path.trim_start_matches('/');
         format!("{base}/{path}")
     }
+
+    fn with_client(
+        &self,
+        request: gloo_net::http::RequestBuilder,
+    ) -> gloo_net::http::RequestBuilder {
+        if let Some(ref id) = self.config.client_ident {
+            request.header("X-Worship-Client", id)
+        } else {
+            request
+        }
+    }
 }
 
 #[async_trait::async_trait(?Send)]
@@ -32,7 +43,8 @@ impl HttpClient for WasmHttpClient {
     {
         let url = self.make_url(path);
 
-        let response = gloo_net::http::Request::get(&url)
+        let response = self
+            .with_client(gloo_net::http::Request::get(&url))
             .credentials(RequestCredentials::Include)
             .send()
             .await?;
@@ -58,8 +70,10 @@ impl HttpClient for WasmHttpClient {
         let url = self.make_url(path);
 
         let payload = serde_json::to_string(body)?;
-        let response = gloo_net::http::Request::post(&url)
-            .header("Content-Type", "application/json")
+        let response = self
+            .with_client(
+                gloo_net::http::Request::post(&url).header("Content-Type", "application/json"),
+            )
             .credentials(RequestCredentials::Include)
             .body(payload)?
             .send()
@@ -87,8 +101,10 @@ impl HttpClient for WasmHttpClient {
         let url = self.make_url(path);
 
         let payload = serde_json::to_string(body)?;
-        let response = gloo_net::http::Request::put(&url)
-            .header("Content-Type", "application/json")
+        let response = self
+            .with_client(
+                gloo_net::http::Request::put(&url).header("Content-Type", "application/json"),
+            )
             .credentials(RequestCredentials::Include)
             .body(payload)?
             .send()
@@ -116,8 +132,10 @@ impl HttpClient for WasmHttpClient {
         let url = self.make_url(path);
 
         let payload = serde_json::to_string(body)?;
-        let response = gloo_net::http::Request::patch(&url)
-            .header("Content-Type", "application/json")
+        let response = self
+            .with_client(
+                gloo_net::http::Request::patch(&url).header("Content-Type", "application/json"),
+            )
             .credentials(RequestCredentials::Include)
             .body(payload)?
             .send()
@@ -144,8 +162,10 @@ impl HttpClient for WasmHttpClient {
         let url = self.make_url(path);
 
         let payload = serde_json::to_string(body)?;
-        let response = gloo_net::http::Request::post(&url)
-            .header("Content-Type", "application/json")
+        let response = self
+            .with_client(
+                gloo_net::http::Request::post(&url).header("Content-Type", "application/json"),
+            )
             .credentials(RequestCredentials::Include)
             .body(payload)?
             .send()
@@ -169,7 +189,8 @@ impl HttpClient for WasmHttpClient {
     {
         let url = self.make_url(path);
 
-        let response = gloo_net::http::Request::delete(&url)
+        let response = self
+            .with_client(gloo_net::http::Request::delete(&url))
             .credentials(RequestCredentials::Include)
             .send()
             .await?;
@@ -190,7 +211,8 @@ impl HttpClient for WasmHttpClient {
     async fn delete_no_content(&self, path: &str) -> Result<(), NetworkClientError> {
         let url = self.make_url(path);
 
-        let response = gloo_net::http::Request::delete(&url)
+        let response = self
+            .with_client(gloo_net::http::Request::delete(&url))
             .credentials(RequestCredentials::Include)
             .send()
             .await?;
@@ -210,7 +232,8 @@ impl HttpClient for WasmHttpClient {
     async fn put_no_content(&self, path: &str) -> Result<(), NetworkClientError> {
         let url = self.make_url(path);
 
-        let response = gloo_net::http::Request::put(&url)
+        let response = self
+            .with_client(gloo_net::http::Request::put(&url))
             .credentials(RequestCredentials::Include)
             .send()
             .await?;
@@ -241,8 +264,10 @@ impl HttpClient for WasmHttpClient {
         let buf = Uint8Array::new_with_length(body.len() as u32);
         buf.copy_from(body);
 
-        let response = gloo_net::http::Request::put(&url)
-            .header("Content-Type", content_type)
+        let response = self
+            .with_client(
+                gloo_net::http::Request::put(&url).header("Content-Type", content_type),
+            )
             .credentials(RequestCredentials::Include)
             .body(JsValue::from(buf))?
             .send()


### PR DESCRIPTION
## Summary
- Add `client_origin` and `client_version` to Surreal `http_request_audit` with a migration; classify from `X-Worship-Client` (and Referer/UA fallbacks) in new `client_attribution` module.
- First-party clients send `X-Worship-Client`: CLI uses crate semver; frontend uses `GIT_COMMIT_SHA` when set at build time, else `CARGO_PKG_VERSION` (same contract as `GET /api/v1/about`).
- Dockerfile: pass `GIT_COMMIT_SHA` into the `trunk build` step like the backend `cargo build`.
- Monitoring `HttpAuditLog` and OpenAPI updated; integration test for the header.

## Test plan
- [x] `cargo test` (backend)
- [x] `cargo check --target wasm32-unknown-unknown` (frontend)
- [x] `cargo clippy` (backend, `-D warnings`)

Made with [Cursor](https://cursor.com)