### PR TITLE
feat(api): q search for teams, sessions, and users

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -6514,6 +6514,15 @@
                 "null"
               ]
             }
+          },
+          {
+            "description": "Optional case-insensitive substring on team name or id. Whitespace-only is treated as absent.",
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -7592,7 +7601,7 @@
             }
           },
           {
-            "description": "Optional case-insensitive email substring filter. Whitespace-only is treated as absent.",
+            "description": "Optional case-insensitive substring filter on email or user id. Whitespace-only is treated as absent.",
             "in": "query",
             "name": "q",
             "required": false,
@@ -8015,6 +8024,15 @@
                 "integer",
                 "null"
               ]
+            }
+          },
+          {
+            "description": "Optional case-insensitive substring on session id, user id, or user email. Whitespace-only is treated as absent.",
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "type": "string"
             }
           },
           {
@@ -8463,6 +8481,15 @@
                 "integer",
                 "null"
               ]
+            }
+          },
+          {
+            "description": "Optional case-insensitive substring on session id, user id, or user email. Whitespace-only is treated as absent.",
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "type": "string"
             }
           },
           {

--- a/backend/src/client_attribution.rs
+++ b/backend/src/client_attribution.rs
@@ -24,9 +24,7 @@ pub fn classify(
         }
     }
 
-    if referer
-        .is_some_and(|r| r.to_ascii_lowercase().contains("/api/docs"))
-    {
+    if referer.is_some_and(|r| r.to_ascii_lowercase().contains("/api/docs")) {
         return ("swagger".to_string(), None);
     }
 
@@ -47,11 +45,7 @@ mod tests {
 
     #[test]
     fn primary_cli_header() {
-        let (o, v) = classify(
-            Some("worshipviewer-cli/1.2.3"),
-            Some("reqwest/0.12"),
-            None,
-        );
+        let (o, v) = classify(Some("worshipviewer-cli/1.2.3"), Some("reqwest/0.12"), None);
         assert_eq!(o, "cli");
         assert_eq!(v.as_deref(), Some("1.2.3"));
     }
@@ -98,11 +92,7 @@ mod tests {
 
     #[test]
     fn reqwest_without_header() {
-        let (o, v) = classify(
-            None,
-            Some("reqwest/0.12"),
-            None,
-        );
+        let (o, v) = classify(None, Some("reqwest/0.12"), None);
         assert_eq!(o, "cli");
         assert!(v.is_none());
     }

--- a/backend/src/resources/monitoring/model.rs
+++ b/backend/src/resources/monitoring/model.rs
@@ -123,9 +123,7 @@ impl HttpAuditRecord {
             duration_ms: self.duration_ms as i32,
             user_id: self.user.as_ref().map(record_id_string),
             session_id: self.session.as_ref().map(record_id_string),
-            client_origin: self
-                .client_origin
-                .unwrap_or_else(|| "unknown".to_string()),
+            client_origin: self.client_origin.unwrap_or_else(|| "unknown".to_string()),
             client_version: self.client_version,
             created_at: self.created_at.into(),
         }

--- a/backend/src/resources/team/rest.rs
+++ b/backend/src/resources/team/rest.rs
@@ -7,7 +7,7 @@ use actix_web::{
     HttpRequest, HttpResponse, Scope, delete, get, patch, post, put,
     web::{self, Data, Json, Path, Query, ReqData},
 };
-use shared::api::{ListQuery, PAGE_SIZE_DEFAULT, PageQuery};
+use shared::api::{ListQuery, PAGE_SIZE_DEFAULT};
 #[allow(unused_imports)]
 use shared::team::Team;
 use shared::team::{CreateTeam, PatchTeam, UpdateTeam};
@@ -32,6 +32,7 @@ pub fn scope() -> Scope {
     params(
         ("page" = Option<u32>, Query, description = "Page index, zero-based; defaults to 0.", minimum = 0, nullable = true),
         ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50 when omitted.", minimum = 1, maximum = 500, example = 50, nullable = true),
+        ("q" = Option<String>, Query, description = "Optional case-insensitive substring on team name or id. Whitespace-only is treated as absent."),
     ),
     responses(
         (status = 200, description = "Teams readable by the current user; platform admins receive all teams (except internal public). `X-Total-Count` is the total before paging.", body = [Team]),
@@ -51,7 +52,7 @@ async fn get_teams(
     req: HttpRequest,
     svc: Data<TeamServiceHandle>,
     user: ReqData<User>,
-    query: Query<PageQuery>,
+    query: Query<ListQuery>,
 ) -> Result<HttpResponse, AppError> {
     let query = query
         .into_inner()
@@ -60,10 +61,8 @@ async fn get_teams(
     let q_link = query.clone();
     let cur_page = query.page.unwrap_or(0);
     let page_size = query.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
-    let teams = svc.list_teams_for_user(&user).await?;
-    let total = teams.len() as u64;
-    let lq = query.as_list_query();
-    let (teams_page, _) = ListQuery::paginate_vec(teams, &lq);
+    let teams = filter_teams_by_q(svc.list_teams_for_user(&user).await?, &query);
+    let (teams_page, total) = ListQuery::paginate_vec(teams, &query);
     Ok(HttpResponse::Ok()
         .insert_header((
             header::HeaderName::from_static("x-total-count"),
@@ -237,4 +236,21 @@ async fn delete_team(
 ) -> Result<HttpResponse, AppError> {
     svc.delete_team_for_user(&user, &id).await?;
     Ok(HttpResponse::NoContent().finish())
+}
+
+fn filter_teams_by_q(mut teams: Vec<Team>, query: &ListQuery) -> Vec<Team> {
+    let Some(needle) = query.q.as_ref().and_then(|s| {
+        let t = s.trim();
+        if t.is_empty() {
+            None
+        } else {
+            Some(t.to_lowercase())
+        }
+    }) else {
+        return teams;
+    };
+    teams.retain(|t| {
+        t.name.to_lowercase().contains(&needle) || t.id.to_lowercase().contains(&needle)
+    });
+    teams
 }

--- a/backend/src/resources/user/rest.rs
+++ b/backend/src/resources/user/rest.rs
@@ -162,7 +162,7 @@ async fn get_user(
     params(
         ("page" = Option<u32>, Query, description = "Page index, zero-based. Defaults to 0. See `docs/business-logic-constraints/list-pagination.md` (Track A: `X-Total-Count` is pre-pagination total; last page when `items.len() < page_size` or empty).", minimum = 0, nullable = true),
         ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50.", minimum = 1, maximum = 500, example = 50, nullable = true),
-        ("q" = Option<String>, Query, description = "Optional case-insensitive email substring filter. Whitespace-only is treated as absent.")
+        ("q" = Option<String>, Query, description = "Optional case-insensitive substring filter on email or user id. Whitespace-only is treated as absent.")
     ),
     responses(
         (status = 200, description = "Returns list of all users. `X-Total-Count` header contains the total matching user count (before pagination).", body = [User]),

--- a/backend/src/resources/user/session/rest.rs
+++ b/backend/src/resources/user/session/rest.rs
@@ -5,8 +5,8 @@ use actix_web::{
 };
 use serde::Deserialize;
 
-use shared::api::{ListQuery, PAGE_SIZE_DEFAULT, PageQuery};
-use shared::user::SessionBody;
+use shared::api::{ListQuery, PAGE_SIZE_DEFAULT};
+use shared::user::{Session, SessionBody};
 
 #[allow(unused_imports)]
 use crate::docs::Problem;
@@ -20,7 +20,7 @@ use super::service::SessionServiceHandle;
 #[derive(Debug, Deserialize)]
 struct SessionsPageQuery {
     #[serde(flatten)]
-    page: PageQuery,
+    list: ListQuery,
     /// Comma-separated relations to expand. Use `user` to embed the full [`crate::resources::User`] instead of the default `id`+`email` link.
     expand: Option<String>,
 }
@@ -37,6 +37,7 @@ struct ExpandQuery {
     params(
         ("page" = Option<u32>, Query, description = "Zero-based page; defaults to 0. `X-Total-Count` is the total before paging (`list-pagination.md`).", minimum = 0, nullable = true),
         ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50 when omitted.", minimum = 1, maximum = 500, example = 50, nullable = true),
+        ("q" = Option<String>, Query, description = "Optional case-insensitive substring on session id, user id, or user email. Whitespace-only is treated as absent."),
         ("expand" = Option<String>, Query, description = "Optional comma-separated relations (`user` = embed full user on each session; default is `id`+`email` link only)."),
     ),
     responses(
@@ -59,17 +60,16 @@ pub async fn get_sessions_for_current_user(
     user: ReqData<User>,
     query: Query<SessionsPageQuery>,
 ) -> Result<HttpResponse, AppError> {
-    let SessionsPageQuery { page, expand } = query.into_inner();
-    let page = page
+    let SessionsPageQuery { list, expand } = query.into_inner();
+    let list = list
         .validate()
         .map_err(crate::error::map_list_query_error)?;
     let expand_user = expand_includes_user(&expand);
-    let q_link = page.clone();
-    let cur_page = page.page.unwrap_or(0);
-    let page_size = page.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
-    let sessions = svc.get_sessions_by_user_id(&user.id).await?;
-    let lq = page.as_list_query();
-    let (sessions_page, total) = ListQuery::paginate_vec(sessions, &lq);
+    let q_link = list.clone();
+    let cur_page = list.page.unwrap_or(0);
+    let page_size = list.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
+    let sessions = filter_sessions_by_q(svc.get_sessions_by_user_id(&user.id).await?, &list);
+    let (sessions_page, total) = ListQuery::paginate_vec(sessions, &list);
     let sessions_page: Vec<SessionBody> = sessions_page
         .into_iter()
         .map(|s| SessionBody::from_session(s, expand_user))
@@ -207,6 +207,7 @@ pub async fn create_session_for_user(
         ("user_id" = String, Path, description = "User identifier"),
         ("page" = Option<u32>, Query, description = "Zero-based page; defaults to 0. `X-Total-Count` is the total before paging (`list-pagination.md`).", minimum = 0, nullable = true),
         ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50 when omitted.", minimum = 1, maximum = 500, example = 50, nullable = true),
+        ("q" = Option<String>, Query, description = "Optional case-insensitive substring on session id, user id, or user email. Whitespace-only is treated as absent."),
         ("expand" = Option<String>, Query, description = "Optional comma-separated relations (`user` = full user per session)."),
     ),
     responses(
@@ -230,17 +231,16 @@ pub async fn get_sessions_for_user(
     path: Path<UserIdPath>,
     query: Query<SessionsPageQuery>,
 ) -> Result<HttpResponse, AppError> {
-    let SessionsPageQuery { page, expand } = query.into_inner();
-    let page = page
+    let SessionsPageQuery { list, expand } = query.into_inner();
+    let list = list
         .validate()
         .map_err(crate::error::map_list_query_error)?;
     let expand_user = expand_includes_user(&expand);
-    let q_link = page.clone();
-    let cur_page = page.page.unwrap_or(0);
-    let page_size = page.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
-    let sessions = svc.get_sessions_by_user_id(&path.user_id).await?;
-    let lq = page.as_list_query();
-    let (sessions_page, total) = ListQuery::paginate_vec(sessions, &lq);
+    let q_link = list.clone();
+    let cur_page = list.page.unwrap_or(0);
+    let page_size = list.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
+    let sessions = filter_sessions_by_q(svc.get_sessions_by_user_id(&path.user_id).await?, &list);
+    let (sessions_page, total) = ListQuery::paginate_vec(sessions, &list);
     let sessions_page: Vec<SessionBody> = sessions_page
         .into_iter()
         .map(|s| SessionBody::from_session(s, expand_user))
@@ -351,4 +351,23 @@ pub struct UserIdPath {
 struct UserSessionPath {
     user_id: String,
     id: String,
+}
+
+fn filter_sessions_by_q(mut sessions: Vec<Session>, query: &ListQuery) -> Vec<Session> {
+    let Some(needle) = query.q.as_ref().and_then(|s| {
+        let t = s.trim();
+        if t.is_empty() {
+            None
+        } else {
+            Some(t.to_lowercase())
+        }
+    }) else {
+        return sessions;
+    };
+    sessions.retain(|s| {
+        s.id.to_lowercase().contains(&needle)
+            || s.user.id.to_lowercase().contains(&needle)
+            || s.user.email.to_lowercase().contains(&needle)
+    });
+    sessions
 }

--- a/backend/src/resources/user/surreal_repo.rs
+++ b/backend/src/resources/user/surreal_repo.rs
@@ -47,6 +47,7 @@ impl UserRepository for SurrealUserRepo {
                 .db
                 .query(
                     "SELECT * FROM user WHERE string::contains(string::lowercase(email), $needle) \
+                     OR string::contains(string::lowercase(type::string(id)), $needle) \
                      LIMIT $limit START $start",
                 )
                 .bind(("needle", needle))
@@ -85,7 +86,8 @@ impl UserRepository for SurrealUserRepo {
             self.inner()
                 .db
                 .query(
-                    "SELECT count() FROM user WHERE string::contains(string::lowercase(email), $needle) GROUP ALL",
+                    "SELECT count() FROM user WHERE string::contains(string::lowercase(email), $needle) \
+                     OR string::contains(string::lowercase(type::string(id)), $needle) GROUP ALL",
                 )
                 .bind(("needle", needle))
                 .await?

--- a/backend/tests/1_teams.yml
+++ b/backend/tests/1_teams.yml
@@ -225,6 +225,67 @@ testcases:
           - result.body ShouldContainSubstring "{{.team-lead-create-shared-b-same-name.shared_team_b_id}}"
           - result.body ShouldContainSubstring "{{.team-solo-sees-personal-only.solo_personal_team_id}}"
 
+  # BLC: BLC-LP-003, BLC-LP-005, BLC-LP-009
+  - name: team-list-q-match-name
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/teams?q=Duplicate"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 2
+
+  # BLC: BLC-LP-003, BLC-LP-009
+  - name: team-list-q-with-pagination
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/teams?q=Duplicate&page=0&page_size=1"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 1
+
+  # BLC: BLC-LP-003
+  - name: team-list-q-by-id
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/teams?q={{.team-lead-create-shared-a.shared_team_a_id}}"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 1
+          - result.bodyjson.bodyjson0.id ShouldEqual "{{.team-lead-create-shared-a.shared_team_a_id}}"
+
+  # BLC: BLC-LP-003, BLC-LP-008
+  - name: team-list-q-no-matches
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/teams?q=TeamNoSuchTokenEver999zz"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 0
+
+  # BLC: BLC-LP-005
+  - name: team-list-q-blank-ignored-full-list
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/teams?q=%20"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 5
+
   # BLC: BLC-TEAM-007
   - name: team-platform-admin-gets-shared-without-membership
     steps:

--- a/backend/tests/2_users.yml
+++ b/backend/tests/2_users.yml
@@ -257,6 +257,68 @@ testcases:
           - result.statuscode ShouldEqual 200
           - result.bodyjson ShouldHaveLength 0
   
+  # BLC: BLC-LP-003, BLC-LP-009
+  - name: get-users-q-email-match
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/users?q=anormaluser"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 1
+          - result.bodyjson.bodyjson0.id ShouldEqual "{{.post-users.userid}}"
+
+  # BLC: BLC-LP-003, BLC-LP-009
+  - name: get-users-q-with-pagination
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/users?q=anormaluser&page=0&page_size=1"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 1
+
+  # BLC: BLC-LP-003, BLC-LP-008
+  - name: get-users-q-no-matches
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/users?q=UserNoSuchTokenEver999zz"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 0
+
+  # BLC: BLC-LP-005
+  - name: get-users-q-blank-still-paginates-like-omit
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/users?q=%20&page_size=1"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 1
+
+  # BLC: BLC-LP-003
+  - name: get-users-q-by-id
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/users?q={{.post-users.userid}}"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 1
+          - result.bodyjson.bodyjson0.id ShouldEqual "{{.post-users.userid}}"
+  
   # BLC: BLC-USER-007, BLC-USER-009
   - name: get-user
     steps:
@@ -317,6 +379,72 @@ testcases:
         vars:
           sessionid:
             from: result.bodyjson.id
+
+  # BLC: BLC-USER-011
+  - name: create-second-session-for-default-user
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/users/{{.post-users.userid}}/sessions"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+          Content-Type: application/json
+        body: ""
+        assertions:
+          - result.statuscode ShouldEqual 201
+        vars:
+          sessionid2:
+            from: result.bodyjson.id
+
+  # BLC: BLC-LP-003, BLC-LP-009
+  - name: get-sessions-for-user-q-match-first
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/users/{{.post-users.userid}}/sessions?q={{.create-session-for-default-user.sessionid}}"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 1
+          - result.bodyjson.bodyjson0.id ShouldEqual "{{.create-session-for-default-user.sessionid}}"
+
+  # BLC: BLC-LP-003, BLC-LP-008
+  - name: get-sessions-for-user-q-no-matches
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/users/{{.post-users.userid}}/sessions?q=SessionNoSuchTokenEver999zz"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 0
+
+  # BLC: BLC-LP-005
+  - name: get-sessions-for-user-q-blank-ignored
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/users/{{.post-users.userid}}/sessions?q=%20"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 2
+
+  # BLC: BLC-LP-003
+  - name: get-me-sessions-q-match-second
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/users/me/sessions?q={{.create-second-session-for-default-user.sessionid2}}"
+        headers:
+          Authorization: "Bearer {{.create-session-for-default-user.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 1
+          - result.bodyjson.bodyjson0.id ShouldEqual "{{.create-second-session-for-default-user.sessionid2}}"
 
   # BLC: BLC-TEAM-001
   - name: get-default-user-personal-team

--- a/docs/business-logic-constraints/list-pagination.md
+++ b/docs/business-logic-constraints/list-pagination.md
@@ -6,7 +6,7 @@ Applies to **GET** list routes that support paging, including **`/users`** (admi
 
 - **BLC-LP-001:** **`page`** — 0-based index of the page.
 - **BLC-LP-002:** **`page_size`** — maximum number of items per page.
-- **BLC-LP-003:** **`q`** — optional search filter: **`/songs`** (full-text: titles, artists, lyrics per analyzer rules), **`/collections`** and **`/setlists`** (**title**), **`/users`** (admin list: **email** substring, case-insensitive), **`/blobs`** (**OCR** substring, case-insensitive). Whitespace-only **`q`** is treated as absent everywhere.
+- **BLC-LP-003:** **`q`** — optional search filter: **`/songs`** (full-text: titles, artists, lyrics per analyzer rules), **`/collections`** and **`/setlists`** (**title**), **`/users`** (admin list: **email** or **user id** substring, case-insensitive), **`/teams`** (**name** or **team id** substring, case-insensitive), **`/users/me/sessions`** and **`/users/{id}/sessions`** (substring on **session id**, **user id**, or **user email**), **`/blobs`** (**OCR** substring, case-insensitive). Whitespace-only **`q`** is treated as absent everywhere.
 
 ## Validation
 

--- a/shared/src/net/wasm.rs
+++ b/shared/src/net/wasm.rs
@@ -265,9 +265,7 @@ impl HttpClient for WasmHttpClient {
         buf.copy_from(body);
 
         let response = self
-            .with_client(
-                gloo_net::http::Request::put(&url).header("Content-Type", content_type),
-            )
+            .with_client(gloo_net::http::Request::put(&url).header("Content-Type", content_type))
             .credentials(RequestCredentials::Include)
             .body(JsValue::from(buf))?
             .send()


### PR DESCRIPTION
Adds optional `q` query parameter to team and session list endpoints (substring filter before pagination), extends admin user list search to match email or user id, updates list-pagination BLC-LP-003, OpenAPI snapshot, and Venom tests for teams/users sessions.

Made with [Cursor](https://cursor.com)