### PR TITLE
chore(deps): bump Rust dependency pins

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -50,7 +50,7 @@ hex = "0.4.3"
 actix-files = "0.6.10"
 actix-governor = "0.10"
 shared = { path = "../shared", features = ["backend"] }
-chordlib = { version = "0.8.2", features = ["html"] }
+chordlib = { version = "0.8.3", features = ["html"] }
 zip = "8.6.0"
 imagesize = "0.14"
 

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -8,12 +8,12 @@ shared = { path = "../shared", features = ["frontend"] }
 yew = { version = "0.23.0", features = ["csr"] }
 yew-router = "0.20"
 stylist = { version = "0.15.1", features = ["yew_integration", "parser"] }
-wasm-bindgen-futures = "0.4.68"
-wasm-bindgen = "0.2.118"
+wasm-bindgen-futures = "0.4.70"
+wasm-bindgen = "0.2.120"
 gloo-net = "0.7.0"
 gloo-console = "0.4.0"
 yew-hooks = "0.6.4"
-web-sys = { version = "0.3.95", features = [
+web-sys = { version = "0.3.97", features = [
     "Blob",
     "DragEvent",
     "File",
@@ -38,10 +38,10 @@ web-sys = { version = "0.3.95", features = [
 gloo = { version = "0.12.0", features = ["futures"] }
 serde = { version = "1.0.228", features = ["derive"] }
 url = "2.5.8"
-getrandom_0_3 = { package = "getrandom", version = "0.3.4", features = [
+getrandom_0_3 = { package = "getrandom", version = "0.4.2", features = [
     "wasm_js",
 ] }
-js-sys = "0.3.95"
+js-sys = "0.3.97"
 chrono = { version = "0.4.44", default-features = false, features = [
     "clock",
     "serde",

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chordlib = { version = "0.8.2", features = ["html"] }
+chordlib = { version = "0.8.3", features = ["html"] }
 chrono = { version = "0.4.44", default-features = false, features = [
     "clock",
     "serde",
@@ -18,9 +18,9 @@ async-trait = "0.1"
 serde_json = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
 gloo-net = { version = "0.7", features = ["http"], optional = true }
-js-sys = { version = "0.3.95", optional = true }
-wasm-bindgen = { version = "0.2.118", optional = true }
-web-sys = { version = "0.3.95", features = ["RequestCredentials"], optional = true }
+js-sys = { version = "0.3.97", optional = true }
+wasm-bindgen = { version = "0.2.120", optional = true }
+web-sys = { version = "0.3.97", features = ["RequestCredentials"], optional = true }
 
 [features]
 backend = ["utoipa", "tracing", "uuid"]


### PR DESCRIPTION
Updates version pins in `backend`, `shared`, and `frontend` `Cargo.toml` files (e.g. chordlib, wasm-bindgen ecosystem, js-sys/web-sys, frontend getrandom for wasm). Branch is based on latest `main` after the q-search API work merged in #118.