### PR TITLE
feat(backend): derive user/session audit metrics via Surreal COMPUTED

### DIFF
--- a/backend/benches/repo_perf.rs
+++ b/backend/benches/repo_perf.rs
@@ -1,7 +1,8 @@
 //! Criterion benchmarks for team resolution and setlist repository (in-memory SurrealDB).
+use std::hint::black_box;
 use std::sync::Arc;
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 use tokio::runtime::Runtime;
 
 use backend::database::Database;

--- a/backend/db-migrations/20260504000000_user_audit_metrics_drop_session_audit_idx.surql
+++ b/backend/db-migrations/20260504000000_user_audit_metrics_drop_session_audit_idx.surql
@@ -1,0 +1,6 @@
+-- User activity metrics derive from http_request_audit; drop persisted counters/timestamps.
+REMOVE FIELD IF EXISTS request_count ON user;
+REMOVE FIELD IF EXISTS last_login_at ON user;
+
+-- Speed session-scoped aggregates on http_request_audit.
+DEFINE INDEX OVERWRITE http_request_audit_session_idx ON http_request_audit FIELDS session CONCURRENTLY;

--- a/backend/db-migrations/20260504100000_define_http_audit_computed_metrics.surql
+++ b/backend/db-migrations/20260504100000_define_http_audit_computed_metrics.surql
@@ -1,0 +1,40 @@
+-- Live request_count and last_used_at from http_request_audit (COMPUTED = re-evaluated on SELECT).
+-- COMPUTED `$this` is the document shape; predicates use stable `id` (record refs).
+
+DEFINE FUNCTION OVERWRITE fn::http_audit_count_for_user($rid: record<user>) -> int {
+  LET $rows = SELECT count FROM (SELECT count() AS count FROM http_request_audit WHERE user = $rid GROUP ALL);
+  IF array::len($rows) = 0 {
+    RETURN 0;
+  };
+  RETURN array::first($rows).count;
+} PERMISSIONS FULL;
+
+DEFINE FUNCTION OVERWRITE fn::http_audit_last_used_at_for_user($rid: record<user>) -> option<datetime> {
+  LET $rows = SELECT created_at FROM http_request_audit WHERE user = $rid ORDER BY created_at DESC LIMIT 1;
+  IF array::len($rows) = 0 {
+    RETURN NONE;
+  };
+  RETURN array::first($rows).created_at;
+} PERMISSIONS FULL;
+
+DEFINE FUNCTION OVERWRITE fn::http_audit_count_for_session($rid: record<session>) -> int {
+  LET $rows = SELECT count FROM (SELECT count() AS count FROM http_request_audit WHERE session = $rid GROUP ALL);
+  IF array::len($rows) = 0 {
+    RETURN 0;
+  };
+  RETURN array::first($rows).count;
+} PERMISSIONS FULL;
+
+DEFINE FUNCTION OVERWRITE fn::http_audit_last_used_at_for_session($rid: record<session>) -> option<datetime> {
+  LET $rows = SELECT created_at FROM http_request_audit WHERE session = $rid ORDER BY created_at DESC LIMIT 1;
+  IF array::len($rows) = 0 {
+    RETURN NONE;
+  };
+  RETURN array::first($rows).created_at;
+} PERMISSIONS FULL;
+
+DEFINE FIELD OVERWRITE request_count ON user TYPE int COMPUTED fn::http_audit_count_for_user(id) PERMISSIONS FULL;
+DEFINE FIELD OVERWRITE last_used_at ON user TYPE option<datetime> COMPUTED fn::http_audit_last_used_at_for_user(id) PERMISSIONS FULL;
+
+DEFINE FIELD OVERWRITE request_count ON session TYPE int COMPUTED fn::http_audit_count_for_session(id) PERMISSIONS FULL;
+DEFINE FIELD OVERWRITE last_used_at ON session TYPE option<datetime> COMPUTED fn::http_audit_last_used_at_for_session(id) PERMISSIONS FULL;

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1553,6 +1553,8 @@
           "created_at": "2024-01-01T12:00:00Z",
           "expires_at": "2025-01-01T12:00:00Z",
           "id": "550e8400-e29b-41d4-a716-446655440000",
+          "last_used_at": null,
+          "request_count": 0,
           "user": {
             "email": "singer@example.com",
             "id": "user-1"
@@ -1569,6 +1571,18 @@
           },
           "id": {
             "type": "string"
+          },
+          "last_used_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "request_count": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
           },
           "user": {
             "$ref": "#/components/schemas/SessionUserBody"
@@ -2260,7 +2274,7 @@
           "default_collection": null,
           "email": "singer@example.com",
           "id": "usr_example",
-          "last_login_at": null,
+          "last_used_at": null,
           "oauth_avatar_blob_id": null,
           "oauth_picture_url": null,
           "request_count": 0,
@@ -2290,7 +2304,8 @@
           "id": {
             "type": "string"
           },
-          "last_login_at": {
+          "last_used_at": {
+            "description": "Latest `http_request_audit.created_at` for this user (none if no audited requests were linked).",
             "format": "date-time",
             "type": [
               "string",
@@ -2312,7 +2327,7 @@
             ]
           },
           "request_count": {
-            "description": "Approximate authenticated API request count for this user (diagnostic; semantics may evolve).",
+            "description": "Count of `http_request_audit` rows linked to this user.",
             "format": "int64",
             "minimum": 0,
             "type": "integer"

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -106,7 +106,7 @@ async fn main() -> AnyResult<()> {
                     role: UserRole::Admin,
                     default_collection: None,
                     created_at: Utc::now(),
-                    last_login_at: None,
+                    last_used_at: None,
                     request_count: 0,
                     oauth_picture_url: None,
                     oauth_avatar_blob_id: None,

--- a/backend/src/resources/user/model.rs
+++ b/backend/src/resources/user/model.rs
@@ -53,9 +53,11 @@ pub struct UserRecord {
     default_collection: Option<RecordId>,
     created_at: Datetime,
     #[serde(default)]
-    last_login_at: Option<Datetime>,
-    #[serde(default)]
+    #[serde(skip_serializing)]
     request_count: u64,
+    #[serde(default)]
+    #[serde(skip_serializing)]
+    last_used_at: Option<Datetime>,
     #[serde(default)]
     oauth_picture_url: Option<String>,
     #[serde(default)]
@@ -72,7 +74,7 @@ impl UserRecord {
             role: self.role.0,
             default_collection: self.default_collection.map(|id| record_id_string(&id)),
             created_at: self.created_at.into(),
-            last_login_at: self.last_login_at.map(Into::into),
+            last_used_at: self.last_used_at.map(Into::into),
             request_count: self.request_count,
             oauth_picture_url: self.oauth_picture_url,
             oauth_avatar_blob_id: self.oauth_avatar_blob.map(|id| record_id_string(&id)),
@@ -93,8 +95,8 @@ impl UserRecord {
                 .default_collection
                 .map(|id| RecordId::new("collection", id)),
             created_at: user.created_at.into(),
-            last_login_at: user.last_login_at.map(Into::into),
-            request_count: user.request_count,
+            request_count: 0,
+            last_used_at: None,
             oauth_picture_url: user.oauth_picture_url,
             oauth_avatar_blob: user
                 .oauth_avatar_blob_id

--- a/backend/src/resources/user/session/model.rs
+++ b/backend/src/resources/user/session/model.rs
@@ -11,6 +11,11 @@ pub struct SessionRecord {
     pub user: UserRecord,
     pub created_at: Datetime,
     pub expires_at: Datetime,
+    /// Computed metric may deserialize as Surreal NONE; use [`Option`] for `take()`.
+    #[serde(default)]
+    pub request_count: Option<u64>,
+    #[serde(default)]
+    pub last_used_at: Option<Datetime>,
 }
 
 impl SessionRecord {
@@ -20,6 +25,8 @@ impl SessionRecord {
             user: self.user.into_user(),
             created_at: self.created_at.into(),
             expires_at: self.expires_at.into(),
+            request_count: self.request_count.unwrap_or(0),
+            last_used_at: self.last_used_at.map(Into::into),
         }
     }
 }

--- a/backend/src/resources/user/session/surreal_repo.rs
+++ b/backend/src/resources/user/session/surreal_repo.rs
@@ -92,7 +92,7 @@ impl SessionRepository for SurrealSessionRepo {
         &self,
         id: &str,
     ) -> Result<Option<Session>, AppError> {
-        Ok(self
+        let raw = self
             .inner()
             .db
             .query(
@@ -103,20 +103,14 @@ impl SessionRepository for SurrealSessionRepo {
             WHERE expires_at != NONE
               AND expires_at <= time::now();
                         
-            UPDATE user
-            SET
-              last_login_at = time::now(),
-              request_count += 1
-            WHERE id = (SELECT user FROM $sid)[0].user;
-                        
             RETURN (SELECT * FROM $sid FETCH user)[0];
                 "#,
             )
             .bind(("id", id.to_owned()))
             .await
             .map_err(|e| crate::log_and_convert!(AppError::database, "session.validate.query", e))?
-            .take::<Option<SessionRecord>>(3)
-            .map_err(|e| crate::log_and_convert!(AppError::database, "session.validate.take", e))?
-            .map(SessionRecord::into_session))
+            .take::<Option<SessionRecord>>(2)
+            .map_err(|e| crate::log_and_convert!(AppError::database, "session.validate.take", e))?;
+        Ok(raw.map(SessionRecord::into_session))
     }
 }

--- a/shared/src/user/request.rs
+++ b/shared/src/user/request.rs
@@ -68,7 +68,7 @@ impl CreateUser {
             role: self.role,
             default_collection: self.default_collection,
             created_at: Utc::now(),
-            last_login_at: None,
+            last_used_at: None,
             request_count: 0,
             oauth_picture_url: None,
             oauth_avatar_blob_id: None,

--- a/shared/src/user/session.rs
+++ b/shared/src/user/session.rs
@@ -20,7 +20,9 @@ use super::User;
         "id": "550e8400-e29b-41d4-a716-446655440000",
         "user": { "id": "user-1", "email": "singer@example.com" },
         "created_at": "2024-01-01T12:00:00Z",
-        "expires_at": "2025-01-01T12:00:00Z"
+        "expires_at": "2025-01-01T12:00:00Z",
+        "request_count": 0,
+        "last_used_at": null
     }))
 )]
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -29,6 +31,10 @@ pub struct SessionBody {
     pub user: SessionUserBody,
     pub created_at: DateTime<Utc>,
     pub expires_at: DateTime<Utc>,
+    #[serde(default)]
+    pub request_count: u64,
+    #[serde(default)]
+    pub last_used_at: Option<DateTime<Utc>>,
 }
 
 #[cfg_attr(feature = "backend", derive(utoipa::ToSchema))]
@@ -55,6 +61,8 @@ impl SessionBody {
             user,
             created_at: session.created_at,
             expires_at: session.expires_at,
+            request_count: session.request_count,
+            last_used_at: session.last_used_at,
         }
     }
 }
@@ -65,6 +73,10 @@ pub struct Session {
     pub user: User,
     pub created_at: DateTime<Utc>,
     pub expires_at: DateTime<Utc>,
+    #[serde(default)]
+    pub request_count: u64,
+    #[serde(default)]
+    pub last_used_at: Option<DateTime<Utc>>,
 }
 
 impl Session {
@@ -82,6 +94,8 @@ impl Session {
             user,
             created_at: now,
             expires_at,
+            request_count: 0,
+            last_used_at: None,
         }
     }
 

--- a/shared/src/user/user.rs
+++ b/shared/src/user/user.rs
@@ -17,7 +17,7 @@ use super::Role;
         "role": "default",
         "default_collection": null,
         "created_at": "2026-01-01T12:00:00Z",
-        "last_login_at": null,
+        "last_used_at": null,
         "request_count": 0,
         "oauth_picture_url": null,
         "oauth_avatar_blob_id": null,
@@ -31,9 +31,10 @@ pub struct User {
     #[serde(default)]
     pub default_collection: Option<String>,
     pub created_at: DateTime<Utc>,
+    /// Latest `http_request_audit.created_at` for this user (none if no audited requests were linked).
     #[serde(default)]
-    pub last_login_at: Option<DateTime<Utc>>,
-    /// Approximate authenticated API request count for this user (diagnostic; semantics may evolve).
+    pub last_used_at: Option<DateTime<Utc>>,
+    /// Count of `http_request_audit` rows linked to this user.
     #[serde(default)]
     pub request_count: u64,
     /// Last `picture` claim URL seen from OIDC (used to detect when to re-fetch the cached avatar).
@@ -56,7 +57,7 @@ impl User {
             role: Role::default(),
             default_collection: None,
             created_at: Utc::now(),
-            last_login_at: None,
+            last_used_at: None,
             request_count: 0,
             oauth_picture_url: None,
             oauth_avatar_blob_id: None,


### PR DESCRIPTION
## Summary
- Add Surreal migrations: remove stored `last_login_at` / persisted user request counters, ensure `http_request_audit` index on `session`, and define **`COMPUTED`** `request_count` / `last_used_at` on `user` and `session` derived from `http_request_audit` (with small `fn::` helpers).
- Backend reads metrics from `SELECT … FETCH user` without Rust batch hydration.
- **API:** `User` JSON field `last_login_at` is renamed to **`last_used_at`** (aligned with audit semantics). Session bodies now expose **`request_count`** and **`last_used_at`** in OpenAPI.

## Notes
- `SessionRecord.request_count` deserializes as `Option<u64>` because Surreal may return `NONE` for that computed field on reads; the domain `Session` still uses `u64`.

## Verification
- `cargo fmt`, `cargo clippy --package backend --all-targets -- -D warnings`, `cargo test --package backend`

Also updates `repo_perf` benchmark to use `std::hint::black_box` with the current Criterion version.

Made with [Cursor](https://cursor.com)