### PR TITLE
feat(api): add GET /users/me/session for current credential

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -8007,6 +8007,85 @@
         ]
       }
     },
+    "/api/v1/users/me/session": {
+      "get": {
+        "operationId": "get_current_session_for_user",
+        "parameters": [
+          {
+            "description": "Optional `user` to embed full user (default: `id`+`email` link).",
+            "in": "query",
+            "name": "expand",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionBody"
+                }
+              }
+            },
+            "description": "Returns the session credential used for this request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Session not found"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Failed to fetch session"
+          }
+        },
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "SessionToken": []
+          }
+        ],
+        "tags": [
+          "Users"
+        ]
+      }
+    },
     "/api/v1/users/me/sessions": {
       "get": {
         "operationId": "get_sessions_for_current_user",

--- a/backend/src/docs.rs
+++ b/backend/src/docs.rs
@@ -127,6 +127,7 @@ fn apply_openapi_runtime_metadata(doc: &mut utoipa::openapi::OpenApi, settings: 
         crate::resources::user::rest::get_user,
         crate::resources::user::rest::create_user,
         crate::resources::user::rest::delete_user,
+        crate::resources::user::session::rest::get_current_session_for_user,
         crate::resources::user::session::rest::get_sessions_for_current_user,
         crate::resources::user::session::rest::get_session_for_current_user,
         crate::resources::user::session::rest::delete_session_for_current_user,

--- a/backend/src/resources/user/rest.rs
+++ b/backend/src/resources/user/rest.rs
@@ -22,6 +22,7 @@ pub fn scope(avatar_upload_max_bytes: usize) -> Scope {
                 .route(web::put().to(put_profile_picture))
                 .route(web::delete().to(delete_profile_picture)),
         )
+        .service(session::rest::get_current_session_for_user)
         .service(session::rest::get_sessions_for_current_user)
         .service(session::rest::get_session_for_current_user)
         .service(session::rest::delete_session_for_current_user)

--- a/backend/src/resources/user/session/rest.rs
+++ b/backend/src/resources/user/session/rest.rs
@@ -1,6 +1,6 @@
 use actix_web::http::header;
 use actix_web::{
-    HttpRequest, HttpResponse, delete, get, post,
+    HttpMessage, HttpRequest, HttpResponse, delete, get, post,
     web::{Data, Path, Query, ReqData},
 };
 use serde::Deserialize;
@@ -12,6 +12,7 @@ use shared::user::{Session, SessionBody};
 use crate::docs::Problem;
 use crate::error::AppError;
 use crate::expand::expand_includes_user;
+use crate::http_audit::AuditSessionId;
 use crate::resources::User;
 use crate::settings::CookieConfig;
 
@@ -29,6 +30,46 @@ struct SessionsPageQuery {
 struct ExpandQuery {
     /// Comma-separated relations to expand (`user` → full user object on `user`).
     expand: Option<String>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/users/me/session",
+    params(
+        ("expand" = Option<String>, Query, description = "Optional `user` to embed full user (default: `id`+`email` link)."),
+    ),
+    responses(
+        (status = 200, description = "Returns the session credential used for this request", body = SessionBody),
+        (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
+        (status = 404, description = "Session not found", body = Problem, content_type = "application/problem+json"),
+        (status = 500, description = "Failed to fetch session", body = Problem, content_type = "application/problem+json")
+    ),
+    tag = "Users",
+    security(
+        ("SessionCookie" = []),
+        ("SessionToken" = [])
+    )
+)]
+#[get("/me/session")]
+pub async fn get_current_session_for_user(
+    req: HttpRequest,
+    svc: Data<SessionServiceHandle>,
+    user: ReqData<User>,
+    expand: Query<ExpandQuery>,
+) -> Result<HttpResponse, AppError> {
+    let session_id = req
+        .extensions()
+        .get::<AuditSessionId>()
+        .map(|a| a.0.clone())
+        .ok_or_else(|| {
+            AppError::Internal("authenticated request missing credential session identifier".into())
+        })?;
+    let session = svc.get_session_for_user(&session_id, &user.id).await?;
+    Ok(HttpResponse::Ok().json(SessionBody::from_session(
+        session,
+        expand_includes_user(&expand.expand),
+    )))
 }
 
 #[utoipa::path(

--- a/backend/tests/3_sessions.yml
+++ b/backend/tests/3_sessions.yml
@@ -99,6 +99,18 @@ testcases:
           - result.statuscode ShouldEqual 200
           - result.bodyjson.id ShouldEqual "admin"
 
+  # Matches `get-me-session-admin` via GET /users/me/session (credential used on the wire).
+  - name: get-me-current-session-admin
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/users/me/session"
+        headers:
+          Authorization: "Bearer {{.token_admin}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson.id ShouldEqual "admin"
+
   # BLC: BLC-SESS-004
   - name: get-me-session-admin-notfound
     steps:

--- a/frontend/src/api/api.rs
+++ b/frontend/src/api/api.rs
@@ -204,6 +204,15 @@ impl Api {
     }
 
     #[allow(dead_code)]
+    pub async fn get_current_session(&self) -> Result<SessionBody, ApiError> {
+        ApiError::check_and_notify_offline(OperationType::Read);
+        self.client
+            .get_my_current_session()
+            .await
+            .map_err(|e| self.handle_error(e))
+    }
+
+    #[allow(dead_code)]
     pub async fn delete_session_for_current_user(&self, id: &str) -> Result<(), ApiError> {
         ApiError::check_and_notify_offline(OperationType::Write);
         self.client

--- a/shared/src/api/mod.rs
+++ b/shared/src/api/mod.rs
@@ -125,6 +125,16 @@ impl<C: HttpClient> ApiClient<C> {
             .await
     }
 
+    pub async fn get_my_current_session(&self) -> Result<SessionBody, NetworkClientError> {
+        self.client
+            .get(&append_query_param(
+                "api/v1/users/me/session".to_string(),
+                "expand",
+                "user",
+            ))
+            .await
+    }
+
     pub async fn delete_my_session(&self, id: &str) -> Result<(), NetworkClientError> {
         self.client
             .delete_no_content(&format!("api/v1/users/me/sessions/{id}"))


### PR DESCRIPTION
This change adds authenticated introspection for the credential in use without passing a session id in the URL.

## What changed

- New endpoint `GET /api/v1/users/me/session` returns the same `SessionBody` shape as other session endpoints, keyed off the bearer token or session cookie validated by middleware (`AuditSessionId`).
- OpenAPI snapshot and Venue integration coverage for the admin test credential.
- `shared`: `ApiClient::get_my_current_session`; `frontend`: `Api::get_current_session` wrapper (consistent `expand=user` behaviour with existing session getters).

## Verification

- `cargo test openapi_snapshot_matches_committed_file` (backend)
- `cargo clippy --all-targets` (backend)

Made with [Cursor](https://cursor.com)