### PR TITLE
feat(team): allow invitations for personal teams

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7232,16 +7232,6 @@
             },
             "description": "Invitation created"
           },
-          "400": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Problem"
-                }
-              }
-            },
-            "description": "Team is not shared"
-          },
           "401": {
             "content": {
               "application/problem+json": {

--- a/backend/src/resources/team/invitation/rest.rs
+++ b/backend/src/resources/team/invitation/rest.rs
@@ -37,7 +37,6 @@ pub fn invitations_accept_scope() -> Scope {
     ),
     responses(
         (status = 201, description = "Invitation created", body = TeamInvitation),
-        (status = 400, description = "Team is not shared", body = Problem, content_type = "application/problem+json"),
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
         (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 403, description = "Not a team admin", body = Problem, content_type = "application/problem+json"),

--- a/backend/src/resources/team/invitation/service.rs
+++ b/backend/src/resources/team/invitation/service.rs
@@ -56,7 +56,9 @@ impl<R: TeamRepository, IR: TeamInvitationRepository> InvitationService<R, IR> {
         user: &User,
         team_id: &str,
     ) -> Result<TeamInvitation, AppError> {
-        let team_thing = self.assert_shared_team_admin(&user.id, team_id).await?;
+        let team_thing = self
+            .assert_team_admin_for_invitations(&user.id, team_id)
+            .await?;
         let inv_id = Uuid::new_v4().to_string();
         self.inv_repo
             .create_invitation(team_thing, user_thing(&user.id), &inv_id)
@@ -71,7 +73,9 @@ impl<R: TeamRepository, IR: TeamInvitationRepository> InvitationService<R, IR> {
         team_id: &str,
         pagination: ListQuery,
     ) -> Result<(Vec<TeamInvitation>, u64), AppError> {
-        let team_thing = self.assert_shared_team_admin(&user.id, team_id).await?;
+        let team_thing = self
+            .assert_team_admin_for_invitations(&user.id, team_id)
+            .await?;
         let rows = self.inv_repo.list_invitations(team_thing).await?;
         let invitations: Vec<TeamInvitation> = rows
             .into_iter()
@@ -88,7 +92,9 @@ impl<R: TeamRepository, IR: TeamInvitationRepository> InvitationService<R, IR> {
         team_id: &str,
         invitation_id: &str,
     ) -> Result<TeamInvitation, AppError> {
-        let team_thing = self.assert_shared_team_admin(&user.id, team_id).await?;
+        let team_thing = self
+            .assert_team_admin_for_invitations(&user.id, team_id)
+            .await?;
         let inv_thing = invitation_thing(invitation_id)?;
         let inv_id_key = record_id_string(&inv_thing);
         let row = self
@@ -111,7 +117,9 @@ impl<R: TeamRepository, IR: TeamInvitationRepository> InvitationService<R, IR> {
         team_id: &str,
         invitation_id: &str,
     ) -> Result<(), AppError> {
-        let team_thing = self.assert_shared_team_admin(&user.id, team_id).await?;
+        let team_thing = self
+            .assert_team_admin_for_invitations(&user.id, team_id)
+            .await?;
         let inv_thing = invitation_thing(invitation_id)?;
         let inv_id_key = record_id_string(&inv_thing);
         let row = self
@@ -154,12 +162,19 @@ impl<R: TeamRepository, IR: TeamInvitationRepository> InvitationService<R, IR> {
         }
 
         let stored = team_fetched_to_stored(&team_row)?;
-        if stored.owner.is_some() {
-            return Err(AppError::NotFound("invitation not found".into()));
-        }
 
         let team_id_str = crate::database::record_id_string(&team_row.id);
         let uid = user.id.clone();
+
+        // Personal team owner is not listed in `members`; accept is idempotent (same as for admin).
+        if let Some(ref o) = stored.owner
+            && thing_user_id(o) == uid
+        {
+            let team = self.team_repo.load_team_display(&team_id_str).await?;
+            audit_invitation_accepted(&team_id_str, invitation_id, &user.id);
+            return Ok(team);
+        }
+
         let mut map: BTreeMap<String, DbTeamMember> = BTreeMap::new();
         for m in &stored.members {
             map.insert(thing_user_id(&m.user), m.clone());
@@ -212,9 +227,10 @@ impl<R: TeamRepository, IR: TeamInvitationRepository> InvitationService<R, IR> {
         Ok(team)
     }
 
-    /// Asserts that a team exists, is a shared team, and the user is an admin of it.
+    /// Asserts that a team exists (not the public catalog team), and the user may manage
+    /// invitations: [`effective_admin`] — shared-team **admin** member, or **owner** of a personal team.
     /// Returns the team `RecordId` for binding into queries.
-    async fn assert_shared_team_admin(
+    async fn assert_team_admin_for_invitations(
         &self,
         user_id: &str,
         team_id: &str,
@@ -228,11 +244,6 @@ impl<R: TeamRepository, IR: TeamInvitationRepository> InvitationService<R, IR> {
             .ok_or_else(|| AppError::NotFound("team not found".into()))?;
 
         let stored = team_fetched_to_stored(&row)?;
-        if stored.owner.is_some() {
-            return Err(AppError::invalid_request(
-                "team invitations are only supported for shared teams",
-            ));
-        }
         if !member_or_owner_readable(user_id, &stored) {
             return Err(AppError::NotFound("team not found".into()));
         }
@@ -527,14 +538,17 @@ mod tests {
         assert!(r.is_ok());
     }
 
-    /// BLC-TINV-001: creating an invitation for a personal team is rejected with invalid request.
+    /// BLC-TINV-001, BLC-TINV-007: personal team owner can create an invitation.
     #[tokio::test]
-    async fn blc_tinv_001_create_personal_team_rejected() {
+    async fn blc_tinv_001_create_personal_team_owner_ok() {
         let user = make_user("u1");
         let team = personal_team("t1", "u1");
-        let svc = make_svc(MockTeamRepo::with(team), MockInvRepo::empty());
+        let svc = make_svc(
+            MockTeamRepo::with(team),
+            MockInvRepo::with_inv(inv_row("any", "t1")),
+        );
         let r = svc.create_invitation_for_user(&user, "t1").await;
-        assert!(matches!(r, Err(AppError::InvalidRequest(_))));
+        assert!(r.is_ok());
     }
 
     /// BLC-TINV-001: creating an invitation for team:public is rejected before DB fetch.
@@ -706,17 +720,38 @@ mod tests {
         assert!(matches!(r, Err(AppError::NotFound(_))));
     }
 
-    /// BLC-TINV-001: accepting an invitation for a personal team returns not found.
+    /// BLC-TINV-010: accepting an invitation for a personal team adds the user as guest.
     #[tokio::test]
-    async fn blc_tinv_001_accept_personal_team_not_found() {
+    async fn blc_tinv_010_accept_personal_team_adds_guest() {
         let user = make_user("u1");
-        let accept_row = inv_accept_row("inv1", personal_team("t1", "owner1"));
-        let svc = make_svc(
-            MockTeamRepo::missing(),
-            MockInvRepo::with_accept(accept_row),
-        );
+        let team = personal_team("t1", "owner1");
+        let accept_row = inv_accept_row("inv1", team.clone());
+        let mock_team = MockTeamRepo::with(personal_team("t1", "owner1"));
+        let update_called = mock_team.update_members_called.clone();
+        let svc = make_svc(mock_team, MockInvRepo::with_accept(accept_row));
         let r = svc.accept_invitation_for_user(&user, "inv1").await;
-        assert!(matches!(r, Err(AppError::NotFound(_))));
+        assert!(r.is_ok());
+        assert!(
+            *update_called.lock().unwrap(),
+            "update_team_members must be called to add guest to personal team"
+        );
+    }
+
+    /// BLC-TINV-010: personal team owner accepting an invitation does not add owner to members.
+    #[tokio::test]
+    async fn blc_tinv_010_accept_personal_team_owner_idempotent() {
+        let user = make_user("owner1");
+        let team = personal_team("t1", "owner1");
+        let accept_row = inv_accept_row("inv1", team.clone());
+        let mock_team = MockTeamRepo::with(team);
+        let update_called = mock_team.update_members_called.clone();
+        let svc = make_svc(mock_team, MockInvRepo::with_accept(accept_row));
+        let r = svc.accept_invitation_for_user(&user, "inv1").await;
+        assert!(r.is_ok());
+        assert!(
+            !*update_called.lock().unwrap(),
+            "owner must not be inserted into members list"
+        );
     }
 
     /// BLC-TINV-011: accepting when already content_maintainer does not downgrade the role.
@@ -809,16 +844,39 @@ mod tests {
             assert!(inv.id.len() >= 32, "invitation id must be UUID-length");
         }
 
-        /// BLC-TINV-001: creating invitation for personal team returns InvalidRequest.
+        /// BLC-TINV-001: personal team owner can create invitation.
         #[tokio::test]
-        async fn blc_tinv_001_personal_team_rejected_integration() {
+        async fn blc_tinv_001_personal_team_owner_create_ok_integration() {
             let db = test_db().await.expect("db");
             let fx = TeamFixture::build(&db).await.expect("fixture");
             let svc = invitation_service(&db);
-            let r = svc
+            let inv = svc
                 .create_invitation_for_user(&fx.owner, &fx.personal_team_id)
-                .await;
-            assert!(matches!(r, Err(AppError::InvalidRequest(_))));
+                .await
+                .expect("create");
+            assert_eq!(inv.team_id, fx.personal_team_id);
+        }
+
+        /// BLC-TINV-010: guest accepts invitation to owner's personal team.
+        #[tokio::test]
+        async fn blc_tinv_010_accept_personal_team_guest_integration() {
+            let db = test_db().await.expect("db");
+            let fx = TeamFixture::build(&db).await.expect("fixture");
+            let svc = invitation_service(&db);
+            let inv = svc
+                .create_invitation_for_user(&fx.owner, &fx.personal_team_id)
+                .await
+                .expect("create");
+            let team = svc
+                .accept_invitation_for_user(&fx.guest, &inv.id)
+                .await
+                .expect("accept");
+            assert_eq!(team.id, fx.personal_team_id);
+            let is_guest = team
+                .members
+                .iter()
+                .any(|m| m.user.id == fx.guest.id && m.role == shared::team::TeamRole::Guest);
+            assert!(is_guest, "accepted user must be a guest member");
         }
 
         /// BLC-TINV-002: content_maintainer cannot create invitation.

--- a/backend/src/resources/team/invitation/surreal_repo.rs
+++ b/backend/src/resources/team/invitation/surreal_repo.rs
@@ -99,10 +99,11 @@ impl TeamInvitationRepository for SurrealTeamInvitationRepo {
     ) -> Result<Option<InvitationAcceptRow>, AppError> {
         let inv_thing = invitation_thing_from_id(inv_id)?;
         // `FETCH team` alone leaves `members[].user` as bare ids; use `team.members.user` to fully expand.
+        // Personal teams also need `team.owner` expanded to `UserRecord`.
         Ok(self
             .inner()
             .db
-            .query("SELECT * FROM $iid FETCH created_by, team, team.members.user")
+            .query("SELECT * FROM $iid FETCH created_by, team, team.members.user, team.owner")
             .bind(("iid", inv_thing))
             .await?
             .take::<Option<InvitationAcceptRow>>(0)?)

--- a/backend/tests/8_team_invitations.yml
+++ b/backend/tests/8_team_invitations.yml
@@ -267,8 +267,8 @@ testcases:
           lead_personal_team_id:
             from: result.bodyjson.bodyjson0.id
 
-  # BLC: BLC-TINV-001, BLC-TINV-007
-  - name: ti-personal-team-invite-bad-request
+  # BLC: BLC-TINV-001, BLC-TINV-007, BLC-TINV-010
+  - name: ti-lead-create-personal-invitation
     steps:
       - type: http
         method: POST
@@ -276,7 +276,22 @@ testcases:
         headers:
           Authorization: "Bearer {{.ti-create-lead-session.sessionid}}"
         assertions:
-          - result.statuscode ShouldEqual 400
+          - result.statuscode ShouldEqual 201
+          - result.bodyjson.team_id ShouldEqual "{{.ti-lead-personal-team-id.lead_personal_team_id}}"
+        vars:
+          invitation_id:
+            from: result.bodyjson.id
+
+  - name: ti-guest-accept-personal-invitation
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/teams/{{.ti-lead-personal-team-id.lead_personal_team_id}}/invitations/{{.ti-lead-create-personal-invitation.invitation_id}}/accept"
+        headers:
+          Authorization: "Bearer {{.ti-create-guest-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson.id ShouldEqual "{{.ti-lead-personal-team-id.lead_personal_team_id}}"
 
   # BLC: BLC-TINV-002
   - name: ti-platform-admin-cannot-invite-without-team-admin

--- a/docs/business-logic-constraints/team-invitation.md
+++ b/docs/business-logic-constraints/team-invitation.md
@@ -2,8 +2,8 @@
 
 ## Static
 
-- **BLC-TINV-001:** An invitation IS ALWAYS for one **shared** team (not a **personal** team, not the reserved catalog team).
-- **BLC-TINV-002:** Creating, listing, fetching, and deleting invitations requires **team admin** on that team. A **member** who is **not** admin receives **403**. Callers who are **not** members of the team (or use a wrong team id) receive **404** for list/get/delete, consistent with ACL hiding. Platform **admin** has no special bypass for these operations unless the product adds it later.
+- **BLC-TINV-001:** An invitation is for one **non-public** team — either a **shared** team or a **personal** team — never the reserved catalog team.
+- **BLC-TINV-002:** Creating, listing, fetching, and deleting invitations requires **team admin** on that team (on a **personal** team, the **owner** is treated as admin for this purpose). A **member** who is **not** admin receives **403**. Callers who are **not** members of the team (or use a wrong team id) receive **404** for list/get/delete, consistent with ACL hiding. Platform **admin** has no special bypass for these operations unless the product adds it later.
 - **BLC-TINV-003:** Invitations have **no expiry**, **no max uses**, and **no use counter** in the API contract.
 - **BLC-TINV-004:** **DELETE** permanently removes an invitation; there IS no separate “revoked but visible” state.
 - **BLC-TINV-005:** After **accept**, the invitation remains until an **admin** **DELETE**s it.
@@ -11,7 +11,7 @@
 
 ## When / then
 
-- **BLC-TINV-007:** WHEN **POST** `/teams/{team_id}/invitations` runs THEN only a team **admin** MAY create; the team MUST be a valid shared team (invalid id THEN **400** or **404** consistent with team routes).
+- **BLC-TINV-007:** WHEN **POST** `/teams/{team_id}/invitations` runs THEN only a team **admin** MAY create (personal team **owner** counts as admin); the team MUST exist and MUST NOT be the catalog team (invalid id THEN **404** consistent with team routes).
 - **BLC-TINV-008:** WHEN **GET** list or **GET** one invitation runs THEN only team **admin** MAY; wrong team or id THEN **404** for others.
 - **BLC-TINV-009:** WHEN **DELETE** an invitation runs THEN only team **admin** MAY; missing id THEN **404** vs **204** MUST stay consistent across the API.
 - **BLC-TINV-010:** WHEN **accept** runs THEN the session MUST be authenticated; the current user IS added as **guest** on the team (**members** in **GET /teams/{id}**). The primary route IS **`POST /api/v1/teams/{team_id}/invitations/{invitation_id}/accept`**; **`POST /api/v1/invitations/{invitation_id}/accept`** remains supported but IS deprecated ( **`Deprecation`** / **`Sunset`** headers on responses).


### PR DESCRIPTION
## Summary

Personal team **owners** can create, list, get, and delete invitations the same way shared-team admins can. Accepting an invitation adds the user as a **guest** in `members`; personal team owners are handled idempotently on accept (they are not inserted into `members`).

## Implementation notes

- Replace shared-only admin check with `assert_team_admin_for_invitations` using `effective_admin` (owner counts as admin).
- Extend Surreal `get_invitation_with_team` with `FETCH team.owner` so `TeamFetched` deserializes for personal teams.
- Update BLC `team-invitation.md`, `8_team_invitations.yml`, and OpenAPI snapshot.

## Testing

- `cargo test resources::team::invitation --lib`
- Regenerated `backend/openapi.json` (snapshot test passes).

Made with [Cursor](https://cursor.com)