### PR TITLE
fix(db): avoid SurrealDB depth limit when pruning song links

### DIFF
--- a/backend/db-migrations/20260504110000_nonrecursive_array_without_functions.surql
+++ b/backend/db-migrations/20260504110000_nonrecursive_array_without_functions.surql
@@ -1,0 +1,12 @@
+-- `fn::song_link_array_without_song` and `fn::blob_array_without_id` were implemented as linear
+-- recursion (one nested call per array element). That hits SurrealDB's computation depth cap when
+-- trimming long `collection.songs` / `setlist.songs` arrays or large `song.blobs` lists — e.g.
+-- deleting a song would fail in `collection_song_remove` / `setlist_song_remove`.
+
+DEFINE FUNCTION OVERWRITE fn::blob_array_without_id($blobs: array, $rid: any) {
+  RETURN array::filter($blobs, |$b: any| $b != $rid);
+} PERMISSIONS FULL;
+
+DEFINE FUNCTION OVERWRITE fn::song_link_array_without_song($links: array, $song_id: any) {
+  RETURN array::filter($links, |$e: any| $e.id != $song_id);
+} PERMISSIONS FULL;


### PR DESCRIPTION
## Summary

Song deletion failed with `collection_song_remove` / excessive computation depth when collections or setlists had many entries.

## Cause

`fn::song_link_array_without_song` (and `fn::blob_array_without_id`) used linear recursion—one nested call per array element—triggering SurrealDB’s computation depth cap.

## Change

New migration `20260504110000_nonrecursive_array_without_functions.surql` redefines both helpers using `array::filter`, preserving behavior without unbounded recursion.

## Follow-up

Run migrations after deploy.

Made with [Cursor](https://cursor.com)