### PR TITLE
chore(deps): bump chordlib to 0.10.0

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -50,7 +50,7 @@ hex = "0.4.3"
 actix-files = "0.6.10"
 actix-governor = "0.10"
 shared = { path = "../shared", features = ["backend"] }
-chordlib = { version = "0.9.0", features = ["html"] }
+chordlib = { version = "0.10.0", features = ["html"] }
 zip = "8.6.0"
 imagesize = "0.14"
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chordlib = { version = "0.9.0", features = ["html"] }
+chordlib = { version = "0.10.0", features = ["html"] }
 chrono = { version = "0.4.44", default-features = false, features = [
     "clock",
     "serde",


### PR DESCRIPTION
Updates the [`chordlib`](https://crates.io/crates/chordlib) dependency from 0.9.0 to 0.10.0 in `backend` and `shared`.

**Verification:** `cargo build` and `cargo test` in `backend` (341 tests) succeed locally against 0.10.0.

Made with [Cursor](https://cursor.com)