### PR TITLE
feat(api)!: HTTP audit metrics on /metrics endpoints

### DIFF
--- a/backend/db-migrations/20260508120000_drop_http_audit_computed_fields_user_session.surql
+++ b/backend/db-migrations/20260508120000_drop_http_audit_computed_fields_user_session.surql
@@ -1,0 +1,5 @@
+-- Live metrics are served via GET .../metrics using fn::http_audit_* (see 20260504100000).
+REMOVE FIELD IF EXISTS request_count ON user;
+REMOVE FIELD IF EXISTS last_used_at ON user;
+REMOVE FIELD IF EXISTS request_count ON session;
+REMOVE FIELD IF EXISTS last_used_at ON session;

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -633,6 +633,31 @@
         ],
         "type": "object"
       },
+      "HttpAuditMetrics": {
+        "description": "HTTP request audit aggregates for a user or session (`GET .../metrics`).",
+        "example": {
+          "last_used_at": "2026-01-01T12:00:00Z",
+          "request_count": 42
+        },
+        "properties": {
+          "last_used_at": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "request_count": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "request_count"
+        ],
+        "type": "object"
+      },
       "IdLike404Metrics": {
         "properties": {
           "id_like_404_count": {
@@ -1553,8 +1578,6 @@
           "created_at": "2024-01-01T12:00:00Z",
           "expires_at": "2025-01-01T12:00:00Z",
           "id": "550e8400-e29b-41d4-a716-446655440000",
-          "last_used_at": null,
-          "request_count": 0,
           "user": {
             "email": "singer@example.com",
             "id": "user-1"
@@ -1571,18 +1594,6 @@
           },
           "id": {
             "type": "string"
-          },
-          "last_used_at": {
-            "format": "date-time",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "request_count": {
-            "format": "int64",
-            "minimum": 0,
-            "type": "integer"
           },
           "user": {
             "$ref": "#/components/schemas/SessionUserBody"
@@ -2274,10 +2285,8 @@
           "default_collection": null,
           "email": "singer@example.com",
           "id": "usr_example",
-          "last_used_at": null,
           "oauth_avatar_blob_id": null,
           "oauth_picture_url": null,
-          "request_count": 0,
           "role": "default"
         },
         "properties": {
@@ -2304,14 +2313,6 @@
           "id": {
             "type": "string"
           },
-          "last_used_at": {
-            "description": "Latest `http_request_audit.created_at` for this user (none if no audited requests were linked).",
-            "format": "date-time",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "oauth_avatar_blob_id": {
             "description": "Backend-cached OAuth profile image (`GET /api/v1/blobs/{id}/data`).",
             "type": [
@@ -2325,12 +2326,6 @@
               "string",
               "null"
             ]
-          },
-          "request_count": {
-            "description": "Count of `http_request_audit` rows linked to this user.",
-            "format": "int64",
-            "minimum": 0,
-            "type": "integer"
           },
           "role": {
             "$ref": "#/components/schemas/Role"
@@ -2361,7 +2356,7 @@
     }
   },
   "info": {
-    "description": "Versioned REST API under `/api/v1`. Authentication flows live at `/auth/*` (unversioned); clients should treat that split as stable for this major API generation. Public deployment metadata is available at `GET /api/v1/about` (no authentication).\n\n**Breaking 2.0:** See `docs/api-breaking-2-0.md` for migration (`PlayerItem`, `Song.blobs` as link objects, `Session` wire model, `Problem` without `error`, PUT bodies use `Update*` types in the spec).\n\n**Timestamps:** All timestamps are UTC and use RFC 3339 with a `Z` suffix (e.g. `2026-04-18T12:00:00Z`).\n\n**Identifiers:** Resource IDs are opaque printable strings returned by the API; treat them as opaque and do not parse their internal structure.\n\n**References & expand:** Cross-resource links use objects such as `BlobLink` (`{ \"id\": \"…\" }`) instead of bare id strings where noted. Session list/detail responses default to a narrow `user` link (`id` + `email`); pass `expand=user` (comma-separated with other tokens as added) to embed the full `User`.\n\n**JSON naming:** Object keys use `snake_case`. Enum wire values use the casing shown in each schema (broader enum casing standardization is planned).\n\n**Pagination:** List endpoints accept `page` (0-based) and `page_size` (1–500, default 50). Responses include `X-Total-Count` with the total matching rows before pagination and RFC 5988 `Link` headers (relations: first, prev, next, last) where applicable.\n\n**Rate limiting:** Versioned `/api/v1/*` routes use token-bucket limits per client IP (`Retry-After`, `X-RateLimit-*` on **429**; configurable via server settings).\n\n**Errors:** Failed requests return `Content-Type: application/problem+json` ([RFC 7807](https://www.rfc-editor.org/rfc/rfc7807)) with a `Problem` body (`type`, `title`, `status`, `code`, optional `detail` / `instance`). Use `detail` for human-readable text; stable machine-readable `code` values include: `unauthorized`, `forbidden`, `not_found`, `invalid_request`, `invalid_page_size`, `conflict`, `too_many_requests`, `not_acceptable`, `precondition_failed`, `internal`. Legacy schemas `ErrorResponse` and `ProblemDetails` remain listed for one release but are deprecated in favor of `Problem`.\n\n**CSRF:** Cookie sessions use `SameSite=Lax`; state-changing methods are `POST`/`PUT`/`PATCH`/`DELETE` (not `GET`). Cross-site simple requests cannot mutate state via cookies under typical browser rules. Browser `fetch` from the SPA should use `credentials: 'same-origin'` (or include cookies only on same-site requests). API clients using bearer tokens should still avoid exposing tokens to third-party origins.\n\n**Examples:** See schema `example` fields on core DTOs in the components section.",
+    "description": "Versioned REST API under `/api/v1`. Authentication flows live at `/auth/*` (unversioned); clients should treat that split as stable for this major API generation. Public deployment metadata is available at `GET /api/v1/about` (no authentication).\n\n**Breaking 2.0:** See `docs/api-breaking-2-0.md` for migration (`PlayerItem`, `Song.blobs` as link objects, `Session` wire model, `Problem` without `error`, PUT bodies use `Update*` types in the spec).\n\n**Timestamps:** All timestamps are UTC and use RFC 3339 with a `Z` suffix (e.g. `2026-04-18T12:00:00Z`).\n\n**Identifiers:** Resource IDs are opaque printable strings returned by the API; treat them as opaque and do not parse their internal structure.\n\n**References & expand:** Cross-resource links use objects such as `BlobLink` (`{ \"id\": \"…\" }`) instead of bare id strings where noted. Session list/detail responses default to a narrow `user` link (`id` + `email`); pass `expand=user` (comma-separated with other tokens as added) to embed the full `User`. HTTP audit request counts and last-used timestamps for a single user or session are available from `GET .../metrics` routes next to each single-resource user/session endpoint, not on the `User` / `SessionBody` objects themselves.\n\n**JSON naming:** Object keys use `snake_case`. Enum wire values use the casing shown in each schema (broader enum casing standardization is planned).\n\n**Pagination:** List endpoints accept `page` (0-based) and `page_size` (1–500, default 50). Responses include `X-Total-Count` with the total matching rows before pagination and RFC 5988 `Link` headers (relations: first, prev, next, last) where applicable.\n\n**Rate limiting:** Versioned `/api/v1/*` routes use token-bucket limits per client IP (`Retry-After`, `X-RateLimit-*` on **429**; configurable via server settings).\n\n**Errors:** Failed requests return `Content-Type: application/problem+json` ([RFC 7807](https://www.rfc-editor.org/rfc/rfc7807)) with a `Problem` body (`type`, `title`, `status`, `code`, optional `detail` / `instance`). Use `detail` for human-readable text; stable machine-readable `code` values include: `unauthorized`, `forbidden`, `not_found`, `invalid_request`, `invalid_page_size`, `conflict`, `too_many_requests`, `not_acceptable`, `precondition_failed`, `internal`. Legacy schemas `ErrorResponse` and `ProblemDetails` remain listed for one release but are deprecated in favor of `Problem`.\n\n**CSRF:** Cookie sessions use `SameSite=Lax`; state-changing methods are `POST`/`PUT`/`PATCH`/`DELETE` (not `GET`). Cross-site simple requests cannot mutate state via cookies under typical browser rules. Browser `fetch` from the SPA should use `credentials: 'same-origin'` (or include cookies only on same-site requests). API clients using bearer tokens should still avoid exposing tokens to third-party origins.\n\n**Examples:** See schema `example` fields on core DTOs in the components section.",
     "license": {
       "name": "MIT",
       "url": "https://opensource.org/licenses/MIT"
@@ -7847,6 +7842,64 @@
         ]
       }
     },
+    "/api/v1/users/me/metrics": {
+      "get": {
+        "operationId": "get_users_me_metrics",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpAuditMetrics"
+                }
+              }
+            },
+            "description": "HTTP audit aggregates for the current user"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Failed to load metrics"
+          }
+        },
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "SessionToken": []
+          }
+        ],
+        "tags": [
+          "Users"
+        ]
+      }
+    },
     "/api/v1/users/me/profile-picture": {
       "delete": {
         "operationId": "delete_profile_picture",
@@ -8061,6 +8114,74 @@
               }
             },
             "description": "Failed to fetch session"
+          }
+        },
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "SessionToken": []
+          }
+        ],
+        "tags": [
+          "Users"
+        ]
+      }
+    },
+    "/api/v1/users/me/session/metrics": {
+      "get": {
+        "operationId": "get_current_session_metrics",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpAuditMetrics"
+                }
+              }
+            },
+            "description": "HTTP audit aggregates for the credential session"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Session not found"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Failed to fetch metrics"
           }
         },
         "security": [
@@ -8355,6 +8476,85 @@
         ]
       }
     },
+    "/api/v1/users/me/sessions/{id}/metrics": {
+      "get": {
+        "operationId": "get_session_for_current_user_metrics",
+        "parameters": [
+          {
+            "description": "Session identifier",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpAuditMetrics"
+                }
+              }
+            },
+            "description": "HTTP audit aggregates for the session"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Session not found for current user"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Failed to fetch metrics"
+          }
+        },
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "SessionToken": []
+          }
+        ],
+        "tags": [
+          "Users"
+        ]
+      }
+    },
     "/api/v1/users/{id}": {
       "delete": {
         "operationId": "delete_user",
@@ -8509,6 +8709,105 @@
               }
             },
             "description": "Failed to fetch user"
+          }
+        },
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "SessionToken": []
+          }
+        ],
+        "tags": [
+          "Users"
+        ]
+      }
+    },
+    "/api/v1/users/{id}/metrics": {
+      "get": {
+        "operationId": "get_user_metrics",
+        "parameters": [
+          {
+            "description": "User identifier",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpAuditMetrics"
+                }
+              }
+            },
+            "description": "HTTP audit aggregates for the user"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Invalid user identifier"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Admin role required"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "User not found"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Failed to fetch metrics"
           }
         },
         "security": [
@@ -8931,6 +9230,104 @@
               }
             },
             "description": "Failed to fetch session"
+          }
+        },
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "SessionToken": []
+          }
+        ],
+        "tags": [
+          "Users"
+        ]
+      }
+    },
+    "/api/v1/users/{user_id}/sessions/{id}/metrics": {
+      "get": {
+        "operationId": "get_session_for_user_metrics",
+        "parameters": [
+          {
+            "description": "User identifier",
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Session identifier",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpAuditMetrics"
+                }
+              }
+            },
+            "description": "HTTP audit aggregates for the session"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Admin role required"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Session not found for specified user"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Failed to fetch metrics"
           }
         },
         "security": [

--- a/backend/src/auth/context.rs
+++ b/backend/src/auth/context.rs
@@ -138,8 +138,6 @@ impl AuthorizationContext {
             role: self.user.role.clone(),
             default_collection: self.user.default_collection.clone(),
             created_at: Utc::now(),
-            last_used_at: None,
-            request_count: 0,
             oauth_picture_url: self.user.oauth_picture_url.clone(),
             oauth_avatar_blob_id: self.user.oauth_avatar_blob_id.clone(),
             avatar_blob_id: self.user.avatar_blob_id.clone(),

--- a/backend/src/docs.rs
+++ b/backend/src/docs.rs
@@ -37,7 +37,7 @@ use shared::team::{
     CreateTeam, PatchTeam, Team, TeamInvitation, TeamMember, TeamMemberInput, TeamRole, TeamUser,
     TeamUserRef, UpdateTeam,
 };
-use shared::user::{SessionBody, SessionUserBody};
+use shared::user::{HttpAuditMetrics, SessionBody, SessionUserBody};
 
 pub mod rest {
     use super::{Settings, openapi_document};
@@ -100,7 +100,7 @@ fn apply_openapi_runtime_metadata(doc: &mut utoipa::openapi::OpenApi, settings: 
             **Breaking 2.0:** See `docs/api-breaking-2-0.md` for migration (`PlayerItem`, `Song.blobs` as link objects, `Session` wire model, `Problem` without `error`, PUT bodies use `Update*` types in the spec).\n\n\
             **Timestamps:** All timestamps are UTC and use RFC 3339 with a `Z` suffix (e.g. `2026-04-18T12:00:00Z`).\n\n\
             **Identifiers:** Resource IDs are opaque printable strings returned by the API; treat them as opaque and do not parse their internal structure.\n\n\
-            **References & expand:** Cross-resource links use objects such as `BlobLink` (`{ \"id\": \"…\" }`) instead of bare id strings where noted. Session list/detail responses default to a narrow `user` link (`id` + `email`); pass `expand=user` (comma-separated with other tokens as added) to embed the full `User`.\n\n\
+            **References & expand:** Cross-resource links use objects such as `BlobLink` (`{ \"id\": \"…\" }`) instead of bare id strings where noted. Session list/detail responses default to a narrow `user` link (`id` + `email`); pass `expand=user` (comma-separated with other tokens as added) to embed the full `User`. HTTP audit request counts and last-used timestamps for a single user or session are available from `GET .../metrics` routes next to each single-resource user/session endpoint, not on the `User` / `SessionBody` objects themselves.\n\n\
             **JSON naming:** Object keys use `snake_case`. Enum wire values use the casing shown in each schema (broader enum casing standardization is planned).\n\n\
             **Pagination:** List endpoints accept `page` (0-based) and `page_size` (1–500, default 50). Responses include `X-Total-Count` with the total matching rows before pagination and RFC 5988 `Link` headers (relations: first, prev, next, last) where applicable.\n\n\
             **Rate limiting:** Versioned `/api/v1/*` routes use token-bucket limits per client IP (`Retry-After`, `X-RateLimit-*` on **429**; configurable via server settings).\n\n\
@@ -120,6 +120,8 @@ fn apply_openapi_runtime_metadata(doc: &mut utoipa::openapi::OpenApi, settings: 
         crate::auth::otp::rest::otp_request,
         crate::auth::otp::rest::otp_verify,
         crate::auth::rest::logout,
+        crate::resources::user::rest::get_users_me_metrics,
+        crate::resources::user::rest::get_user_metrics,
         crate::resources::user::rest::get_users_me,
         crate::resources::user::rest::put_profile_picture,
         crate::resources::user::rest::delete_profile_picture,
@@ -127,11 +129,14 @@ fn apply_openapi_runtime_metadata(doc: &mut utoipa::openapi::OpenApi, settings: 
         crate::resources::user::rest::get_user,
         crate::resources::user::rest::create_user,
         crate::resources::user::rest::delete_user,
+        crate::resources::user::session::rest::get_current_session_metrics,
         crate::resources::user::session::rest::get_current_session_for_user,
         crate::resources::user::session::rest::get_sessions_for_current_user,
+        crate::resources::user::session::rest::get_session_for_current_user_metrics,
         crate::resources::user::session::rest::get_session_for_current_user,
         crate::resources::user::session::rest::delete_session_for_current_user,
         crate::resources::user::session::rest::get_sessions_for_user,
+        crate::resources::user::session::rest::get_session_for_user_metrics,
         crate::resources::user::session::rest::get_session_for_user,
         crate::resources::user::session::rest::create_session_for_user,
         crate::resources::user::session::rest::delete_session_for_user,
@@ -191,6 +196,7 @@ fn apply_openapi_runtime_metadata(doc: &mut utoipa::openapi::OpenApi, settings: 
     components(
         schemas(
             AboutResponse,
+            HttpAuditMetrics,
             User,
             SessionBody,
             SessionUserBody,

--- a/backend/src/http_tests.rs
+++ b/backend/src/http_tests.rs
@@ -654,6 +654,34 @@ mod user_admin_gates {
         assert_eq!(body["email"], user.email);
     }
 
+    /// BLC-USER-005: `User` JSON omits audit metrics; `GET /users/me/metrics` returns them.
+    #[actix_web::test]
+    async fn blc_user_005_me_response_omits_metrics_get_metrics_ok() {
+        let db = test_db().await.unwrap();
+        let user = create_user(&db, "me-metrics-split@test.local")
+            .await
+            .unwrap();
+        let token = create_session_token(&db, user).await.unwrap();
+        let app = test::init_service(build_app(db.clone())).await;
+
+        let req_me = test::TestRequest::get()
+            .uri("/api/v1/users/me")
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .to_request();
+        let body: serde_json::Value = test::call_and_read_body_json(&app, req_me).await;
+        let obj = body.as_object().expect("user object");
+        assert!(!obj.contains_key("request_count"));
+        assert!(!obj.contains_key("last_used_at"));
+
+        let req_m = test::TestRequest::get()
+            .uri("/api/v1/users/me/metrics")
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .to_request();
+        let m: serde_json::Value = test::call_and_read_body_json(&app, req_m).await;
+        assert!(m.get("request_count").is_some());
+        assert!(m.get("last_used_at").is_some());
+    }
+
     /// BLC-USER-005: two different users each see their own record via /users/me.
     #[actix_web::test]
     async fn blc_user_005_different_users_see_own_record() {
@@ -881,7 +909,33 @@ mod session_admin_gates {
         assert_eq!(body.as_array().expect("array").len(), 1);
     }
 
-    /// BLC-SESS-004: DELETE /users/me/sessions/{own_id} succeeds.
+    /// BLC-SESS-003: `SessionBody` omits audit metrics; `GET /users/me/session/metrics` returns them.
+    #[actix_web::test]
+    async fn blc_sess_003_current_session_omits_metrics_get_metrics_ok() {
+        let db = test_db().await.unwrap();
+        let user = create_user(&db, "sess-metrics-split@test.local")
+            .await
+            .unwrap();
+        let token = create_session_token(&db, user).await.unwrap();
+        let app = test::init_service(build_app(db.clone())).await;
+
+        let req_s = test::TestRequest::get()
+            .uri("/api/v1/users/me/session")
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .to_request();
+        let body: serde_json::Value = test::call_and_read_body_json(&app, req_s).await;
+        let obj = body.as_object().expect("session object");
+        assert!(!obj.contains_key("request_count"));
+        assert!(!obj.contains_key("last_used_at"));
+
+        let req_m = test::TestRequest::get()
+            .uri("/api/v1/users/me/session/metrics")
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .to_request();
+        let m: serde_json::Value = test::call_and_read_body_json(&app, req_m).await;
+        assert!(m.get("request_count").is_some());
+        assert!(m.get("last_used_at").is_some());
+    }
     #[actix_web::test]
     async fn blc_sess_004_delete_own_session_succeeds() {
         let db = test_db().await.unwrap();

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -106,8 +106,6 @@ async fn main() -> AnyResult<()> {
                     role: UserRole::Admin,
                     default_collection: None,
                     created_at: Utc::now(),
-                    last_used_at: None,
-                    request_count: 0,
                     oauth_picture_url: None,
                     oauth_avatar_blob_id: None,
                     avatar_blob_id: None,

--- a/backend/src/resources/user/model.rs
+++ b/backend/src/resources/user/model.rs
@@ -53,12 +53,6 @@ pub struct UserRecord {
     default_collection: Option<RecordId>,
     created_at: Datetime,
     #[serde(default)]
-    #[serde(skip_serializing)]
-    request_count: u64,
-    #[serde(default)]
-    #[serde(skip_serializing)]
-    last_used_at: Option<Datetime>,
-    #[serde(default)]
     oauth_picture_url: Option<String>,
     #[serde(default)]
     oauth_avatar_blob: Option<RecordId>,
@@ -74,8 +68,6 @@ impl UserRecord {
             role: self.role.0,
             default_collection: self.default_collection.map(|id| record_id_string(&id)),
             created_at: self.created_at.into(),
-            last_used_at: self.last_used_at.map(Into::into),
-            request_count: self.request_count,
             oauth_picture_url: self.oauth_picture_url,
             oauth_avatar_blob_id: self.oauth_avatar_blob.map(|id| record_id_string(&id)),
             avatar_blob_id: self.avatar_blob.map(|id| record_id_string(&id)),
@@ -95,8 +87,6 @@ impl UserRecord {
                 .default_collection
                 .map(|id| RecordId::new("collection", id)),
             created_at: user.created_at.into(),
-            request_count: 0,
-            last_used_at: None,
             oauth_picture_url: user.oauth_picture_url,
             oauth_avatar_blob: user
                 .oauth_avatar_blob_id

--- a/backend/src/resources/user/repository.rs
+++ b/backend/src/resources/user/repository.rs
@@ -12,7 +12,10 @@ pub trait UserRepository: Send + Sync {
     /// Count users matching the same optional `q` filter as [`get_users`](Self::get_users) (ignores page).
     async fn count_users(&self, query: ListQuery) -> Result<u64, AppError>;
     async fn get_user(&self, id: &str) -> Result<User, AppError>;
-    async fn get_http_audit_metrics_for_user(&self, user_id: &str) -> Result<HttpAuditMetrics, AppError>;
+    async fn get_http_audit_metrics_for_user(
+        &self,
+        user_id: &str,
+    ) -> Result<HttpAuditMetrics, AppError>;
     async fn get_user_by_email(&self, email: &str) -> Result<Option<User>, AppError>;
     /// Insert a user record. Does NOT create a personal team — service layer handles that.
     async fn create_user_record(&self, user: User) -> Result<User, AppError>;

--- a/backend/src/resources/user/repository.rs
+++ b/backend/src/resources/user/repository.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 
 use shared::api::ListQuery;
-use shared::user::User;
+use shared::user::{HttpAuditMetrics, User};
 
 use crate::error::AppError;
 
@@ -12,6 +12,7 @@ pub trait UserRepository: Send + Sync {
     /// Count users matching the same optional `q` filter as [`get_users`](Self::get_users) (ignores page).
     async fn count_users(&self, query: ListQuery) -> Result<u64, AppError>;
     async fn get_user(&self, id: &str) -> Result<User, AppError>;
+    async fn get_http_audit_metrics_for_user(&self, user_id: &str) -> Result<HttpAuditMetrics, AppError>;
     async fn get_user_by_email(&self, email: &str) -> Result<Option<User>, AppError>;
     /// Insert a user record. Does NOT create a personal team — service layer handles that.
     async fn create_user_record(&self, user: User) -> Result<User, AppError>;

--- a/backend/src/resources/user/rest.rs
+++ b/backend/src/resources/user/rest.rs
@@ -13,9 +13,11 @@ use actix_web::{
     web::{self, Bytes, Data, Json, Path, Query, ReqData},
 };
 use shared::api::{ListQuery, PAGE_SIZE_DEFAULT};
+use shared::user::HttpAuditMetrics;
 
 pub fn scope(avatar_upload_max_bytes: usize) -> Scope {
     web::scope("/users")
+        .service(get_users_me_metrics)
         .service(get_users_me)
         .service(
             web::resource("/me/profile-picture")
@@ -23,8 +25,10 @@ pub fn scope(avatar_upload_max_bytes: usize) -> Scope {
                 .route(web::put().to(put_profile_picture))
                 .route(web::delete().to(delete_profile_picture)),
         )
+        .service(session::rest::get_current_session_metrics)
         .service(session::rest::get_current_session_for_user)
         .service(session::rest::get_sessions_for_current_user)
+        .service(session::rest::get_session_for_current_user_metrics)
         .service(session::rest::get_session_for_current_user)
         .service(session::rest::delete_session_for_current_user)
         .service(
@@ -32,13 +36,40 @@ pub fn scope(avatar_upload_max_bytes: usize) -> Scope {
                 .wrap(RequireAdmin)
                 .service(create_user)
                 .service(delete_user)
+                .service(get_user_metrics)
                 .service(get_user)
                 .service(get_users)
                 .service(session::rest::get_sessions_for_user)
+                .service(session::rest::get_session_for_user_metrics)
                 .service(session::rest::get_session_for_user)
                 .service(session::rest::create_session_for_user)
                 .service(session::rest::delete_session_for_user),
         )
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/users/me/metrics",
+    responses(
+        (status = 200, description = "HTTP audit aggregates for the current user", body = HttpAuditMetrics),
+        (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
+        (status = 500, description = "Failed to load metrics", body = Problem, content_type = "application/problem+json")
+    ),
+    tag = "Users",
+    security(
+        ("SessionCookie" = []),
+        ("SessionToken" = [])
+    )
+)]
+#[get("/me/metrics")]
+async fn get_users_me_metrics(
+    ctx: ReqData<AuthorizationContext>,
+    svc: Data<UserServiceHandle>,
+) -> Result<HttpResponse, AppError> {
+    Ok(HttpResponse::Ok().json(
+        svc.get_http_audit_metrics_for_user(&ctx.user.id).await?,
+    ))
 }
 
 #[utoipa::path(
@@ -131,6 +162,39 @@ async fn delete_profile_picture(
         .clear_uploaded_profile_picture(blob_svc.get_ref(), &ctx)
         .await?;
     Ok(HttpResponse::Ok().json(updated))
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/users/{id}/metrics",
+    params(
+        ("id" = String, Path, description = "User identifier")
+    ),
+    responses(
+        (status = 200, description = "HTTP audit aggregates for the user", body = HttpAuditMetrics),
+        (status = 400, description = "Invalid user identifier", body = Problem, content_type = "application/problem+json"),
+        (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
+        (status = 403, description = "Admin role required", body = Problem, content_type = "application/problem+json"),
+        (status = 404, description = "User not found", body = Problem, content_type = "application/problem+json"),
+        (status = 500, description = "Failed to fetch metrics", body = Problem, content_type = "application/problem+json")
+    ),
+    tag = "Users",
+    security(
+        ("SessionCookie" = []),
+        ("SessionToken" = [])
+    )
+)]
+#[get("/{id}/metrics")]
+async fn get_user_metrics(
+    svc: Data<UserServiceHandle>,
+    id: Path<String>,
+) -> Result<HttpResponse, AppError> {
+    let id_str = id.into_inner();
+    svc.get_user(&id_str).await?;
+    Ok(HttpResponse::Ok().json(
+        svc.get_http_audit_metrics_for_user(&id_str).await?,
+    ))
 }
 
 #[utoipa::path(

--- a/backend/src/resources/user/rest.rs
+++ b/backend/src/resources/user/rest.rs
@@ -67,9 +67,7 @@ async fn get_users_me_metrics(
     ctx: ReqData<AuthorizationContext>,
     svc: Data<UserServiceHandle>,
 ) -> Result<HttpResponse, AppError> {
-    Ok(HttpResponse::Ok().json(
-        svc.get_http_audit_metrics_for_user(&ctx.user.id).await?,
-    ))
+    Ok(HttpResponse::Ok().json(svc.get_http_audit_metrics_for_user(&ctx.user.id).await?))
 }
 
 #[utoipa::path(
@@ -192,9 +190,7 @@ async fn get_user_metrics(
 ) -> Result<HttpResponse, AppError> {
     let id_str = id.into_inner();
     svc.get_user(&id_str).await?;
-    Ok(HttpResponse::Ok().json(
-        svc.get_http_audit_metrics_for_user(&id_str).await?,
-    ))
+    Ok(HttpResponse::Ok().json(svc.get_http_audit_metrics_for_user(&id_str).await?))
 }
 
 #[utoipa::path(

--- a/backend/src/resources/user/service.rs
+++ b/backend/src/resources/user/service.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use shared::api::ListQuery;
 use shared::blob::CreateBlob;
-use shared::user::User;
+use shared::user::{HttpAuditMetrics, User};
 use tracing::instrument;
 
 use crate::auth::AuthorizationContext;
@@ -43,6 +43,14 @@ impl<R: UserRepository, T: TeamRepository> UserService<R, T> {
     #[instrument(level = "debug", err, skip(self))]
     pub async fn get_user(&self, id: &str) -> Result<User, AppError> {
         self.repo.get_user(id).await
+    }
+
+    #[instrument(level = "debug", err, skip(self))]
+    pub async fn get_http_audit_metrics_for_user(
+        &self,
+        user_id: &str,
+    ) -> Result<HttpAuditMetrics, AppError> {
+        self.repo.get_http_audit_metrics_for_user(user_id).await
     }
 
     #[instrument(level = "debug", err, skip(self))]
@@ -287,7 +295,7 @@ mod tests {
 
     use shared::api::ListQuery;
     use shared::team::Team;
-    use shared::user::{Role, User};
+    use shared::user::{HttpAuditMetrics, Role, User};
 
     use crate::database::record_id_string;
     use crate::error::AppError;
@@ -346,6 +354,13 @@ mod tests {
         }
 
         async fn get_user(&self, _id: &str) -> Result<User, AppError> {
+            unreachable!("not used in these tests")
+        }
+
+        async fn get_http_audit_metrics_for_user(
+            &self,
+            _user_id: &str,
+        ) -> Result<HttpAuditMetrics, AppError> {
             unreachable!("not used in these tests")
         }
 

--- a/backend/src/resources/user/session/model.rs
+++ b/backend/src/resources/user/session/model.rs
@@ -11,11 +11,6 @@ pub struct SessionRecord {
     pub user: UserRecord,
     pub created_at: Datetime,
     pub expires_at: Datetime,
-    /// Computed metric may deserialize as Surreal NONE; use [`Option`] for `take()`.
-    #[serde(default)]
-    pub request_count: Option<u64>,
-    #[serde(default)]
-    pub last_used_at: Option<Datetime>,
 }
 
 impl SessionRecord {
@@ -25,8 +20,6 @@ impl SessionRecord {
             user: self.user.into_user(),
             created_at: self.created_at.into(),
             expires_at: self.expires_at.into(),
-            request_count: self.request_count.unwrap_or(0),
-            last_used_at: self.last_used_at.map(Into::into),
         }
     }
 }

--- a/backend/src/resources/user/session/repository.rs
+++ b/backend/src/resources/user/session/repository.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 
-use shared::user::Session;
+use shared::user::{HttpAuditMetrics, Session};
 
 use crate::error::AppError;
 
@@ -8,6 +8,7 @@ use crate::error::AppError;
 #[async_trait]
 pub trait SessionRepository: Send + Sync {
     async fn get_session(&self, id: &str) -> Result<Session, AppError>;
+    async fn get_http_audit_metrics_for_session(&self, session_id: &str) -> Result<HttpAuditMetrics, AppError>;
     async fn get_session_for_user(&self, id: &str, user_id: &str) -> Result<Session, AppError>;
     async fn create_session(&self, session: Session) -> Result<Session, AppError>;
     async fn delete_session(&self, id: &str) -> Result<Session, AppError>;

--- a/backend/src/resources/user/session/repository.rs
+++ b/backend/src/resources/user/session/repository.rs
@@ -8,7 +8,10 @@ use crate::error::AppError;
 #[async_trait]
 pub trait SessionRepository: Send + Sync {
     async fn get_session(&self, id: &str) -> Result<Session, AppError>;
-    async fn get_http_audit_metrics_for_session(&self, session_id: &str) -> Result<HttpAuditMetrics, AppError>;
+    async fn get_http_audit_metrics_for_session(
+        &self,
+        session_id: &str,
+    ) -> Result<HttpAuditMetrics, AppError>;
     async fn get_session_for_user(&self, id: &str, user_id: &str) -> Result<Session, AppError>;
     async fn create_session(&self, session: Session) -> Result<Session, AppError>;
     async fn delete_session(&self, id: &str) -> Result<Session, AppError>;

--- a/backend/src/resources/user/session/rest.rs
+++ b/backend/src/resources/user/session/rest.rs
@@ -55,9 +55,7 @@ pub async fn get_current_session_metrics(
 ) -> Result<HttpResponse, AppError> {
     let session_id = ctx.session.id.clone();
     svc.get_session_for_user(&session_id, &ctx.user.id).await?;
-    Ok(HttpResponse::Ok().json(
-        svc.get_http_audit_metrics_for_session(&session_id).await?,
-    ))
+    Ok(HttpResponse::Ok().json(svc.get_http_audit_metrics_for_session(&session_id).await?))
 }
 
 #[utoipa::path(
@@ -187,9 +185,7 @@ pub async fn get_session_for_current_user_metrics(
     path: Path<SessionPath>,
 ) -> Result<HttpResponse, AppError> {
     svc.get_session_for_user(&path.id, &ctx.user.id).await?;
-    Ok(HttpResponse::Ok().json(
-        svc.get_http_audit_metrics_for_session(&path.id).await?,
-    ))
+    Ok(HttpResponse::Ok().json(svc.get_http_audit_metrics_for_session(&path.id).await?))
 }
 
 #[utoipa::path(
@@ -389,9 +385,7 @@ pub async fn get_session_for_user_metrics(
     path: Path<UserSessionPath>,
 ) -> Result<HttpResponse, AppError> {
     svc.get_session_for_user(&path.id, &path.user_id).await?;
-    Ok(HttpResponse::Ok().json(
-        svc.get_http_audit_metrics_for_session(&path.id).await?,
-    ))
+    Ok(HttpResponse::Ok().json(svc.get_http_audit_metrics_for_session(&path.id).await?))
 }
 
 #[utoipa::path(

--- a/backend/src/resources/user/session/rest.rs
+++ b/backend/src/resources/user/session/rest.rs
@@ -6,7 +6,7 @@ use actix_web::{
 use serde::Deserialize;
 
 use shared::api::{ListQuery, PAGE_SIZE_DEFAULT};
-use shared::user::{Session, SessionBody};
+use shared::user::{HttpAuditMetrics, Session, SessionBody};
 
 use crate::auth::AuthorizationContext;
 #[allow(unused_imports)]
@@ -30,6 +30,34 @@ struct SessionsPageQuery {
 struct ExpandQuery {
     /// Comma-separated relations to expand (`user` → full user object on `user`).
     expand: Option<String>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/users/me/session/metrics",
+    responses(
+        (status = 200, description = "HTTP audit aggregates for the credential session", body = HttpAuditMetrics),
+        (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 404, description = "Session not found", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
+        (status = 500, description = "Failed to fetch metrics", body = Problem, content_type = "application/problem+json")
+    ),
+    tag = "Users",
+    security(
+        ("SessionCookie" = []),
+        ("SessionToken" = [])
+    )
+)]
+#[get("/me/session/metrics")]
+pub async fn get_current_session_metrics(
+    svc: Data<SessionServiceHandle>,
+    ctx: ReqData<AuthorizationContext>,
+) -> Result<HttpResponse, AppError> {
+    let session_id = ctx.session.id.clone();
+    svc.get_session_for_user(&session_id, &ctx.user.id).await?;
+    Ok(HttpResponse::Ok().json(
+        svc.get_http_audit_metrics_for_session(&session_id).await?,
+    ))
 }
 
 #[utoipa::path(
@@ -131,6 +159,37 @@ pub async fn get_sessions_for_current_user(
             ),
         ))
         .json(sessions_page))
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/users/me/sessions/{id}/metrics",
+    params(
+        ("id" = String, Path, description = "Session identifier"),
+    ),
+    responses(
+        (status = 200, description = "HTTP audit aggregates for the session", body = HttpAuditMetrics),
+        (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
+        (status = 404, description = "Session not found for current user", body = Problem, content_type = "application/problem+json"),
+        (status = 500, description = "Failed to fetch metrics", body = Problem, content_type = "application/problem+json")
+    ),
+    tag = "Users",
+    security(
+        ("SessionCookie" = []),
+        ("SessionToken" = [])
+    )
+)]
+#[get("/me/sessions/{id}/metrics")]
+pub async fn get_session_for_current_user_metrics(
+    svc: Data<SessionServiceHandle>,
+    ctx: ReqData<AuthorizationContext>,
+    path: Path<SessionPath>,
+) -> Result<HttpResponse, AppError> {
+    svc.get_session_for_user(&path.id, &ctx.user.id).await?;
+    Ok(HttpResponse::Ok().json(
+        svc.get_http_audit_metrics_for_session(&path.id).await?,
+    ))
 }
 
 #[utoipa::path(
@@ -301,6 +360,38 @@ pub async fn get_sessions_for_user(
             ),
         ))
         .json(sessions_page))
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/users/{user_id}/sessions/{id}/metrics",
+    params(
+        ("user_id" = String, Path, description = "User identifier"),
+        ("id" = String, Path, description = "Session identifier"),
+    ),
+    responses(
+        (status = 200, description = "HTTP audit aggregates for the session", body = HttpAuditMetrics),
+        (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 403, description = "Admin role required", body = Problem, content_type = "application/problem+json"),
+        (status = 404, description = "Session not found for specified user", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
+        (status = 500, description = "Failed to fetch metrics", body = Problem, content_type = "application/problem+json")
+    ),
+    tag = "Users",
+    security(
+        ("SessionCookie" = []),
+        ("SessionToken" = [])
+    )
+)]
+#[get("/{user_id}/sessions/{id}/metrics")]
+pub async fn get_session_for_user_metrics(
+    svc: Data<SessionServiceHandle>,
+    path: Path<UserSessionPath>,
+) -> Result<HttpResponse, AppError> {
+    svc.get_session_for_user(&path.id, &path.user_id).await?;
+    Ok(HttpResponse::Ok().json(
+        svc.get_http_audit_metrics_for_session(&path.id).await?,
+    ))
 }
 
 #[utoipa::path(

--- a/backend/src/resources/user/session/service.rs
+++ b/backend/src/resources/user/session/service.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use shared::user::Session;
+use shared::user::{HttpAuditMetrics, Session};
 use tracing::instrument;
 
 use crate::database::Database;
@@ -33,6 +33,16 @@ impl<S: SessionRepository, U: UserRepository> SessionService<S, U> {
     #[instrument(level = "debug", err, skip(self))]
     pub async fn get_session_for_user(&self, id: &str, user_id: &str) -> Result<Session, AppError> {
         self.repo.get_session_for_user(id, user_id).await
+    }
+
+    #[instrument(level = "debug", err, skip(self))]
+    pub async fn get_http_audit_metrics_for_session(
+        &self,
+        session_id: &str,
+    ) -> Result<HttpAuditMetrics, AppError> {
+        self.repo
+            .get_http_audit_metrics_for_session(session_id)
+            .await
     }
 
     #[instrument(level = "debug", err, skip(self, session))]
@@ -100,7 +110,7 @@ mod tests {
     use std::sync::Mutex;
 
     use shared::api::ListQuery;
-    use shared::user::{Session, User};
+    use shared::user::{HttpAuditMetrics, Session, User};
 
     use crate::error::AppError;
     use crate::resources::user::repository::UserRepository;
@@ -161,6 +171,16 @@ mod tests {
                 .find(|s| s.id == id)
                 .cloned()
                 .ok_or_else(|| AppError::NotFound("session not found".into()))
+        }
+
+        async fn get_http_audit_metrics_for_session(
+            &self,
+            _session_id: &str,
+        ) -> Result<HttpAuditMetrics, AppError> {
+            Ok(HttpAuditMetrics {
+                request_count: 0,
+                last_used_at: None,
+            })
         }
 
         async fn get_session_for_user(&self, id: &str, user_id: &str) -> Result<Session, AppError> {
@@ -233,6 +253,13 @@ mod tests {
             self.user
                 .clone()
                 .ok_or_else(|| AppError::NotFound("user not found".into()))
+        }
+
+        async fn get_http_audit_metrics_for_user(
+            &self,
+            _user_id: &str,
+        ) -> Result<HttpAuditMetrics, AppError> {
+            unreachable!("not used in session tests")
         }
 
         async fn get_users(&self, _pagination: ListQuery) -> Result<Vec<User>, AppError> {

--- a/backend/src/resources/user/session/surreal_repo.rs
+++ b/backend/src/resources/user/session/surreal_repo.rs
@@ -55,7 +55,10 @@ impl SessionRepository for SurrealSessionRepo {
             .ok_or(AppError::NotFound("session not found".into()))
     }
 
-    async fn get_http_audit_metrics_for_session(&self, session_id: &str) -> Result<HttpAuditMetrics, AppError> {
+    async fn get_http_audit_metrics_for_session(
+        &self,
+        session_id: &str,
+    ) -> Result<HttpAuditMetrics, AppError> {
         let mut response = self
             .inner()
             .db

--- a/backend/src/resources/user/session/surreal_repo.rs
+++ b/backend/src/resources/user/session/surreal_repo.rs
@@ -1,15 +1,31 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use surrealdb::types::RecordId;
+use serde::Deserialize;
+use surrealdb::types::{RecordId, SurrealValue};
 
-use shared::user::Session;
+use shared::user::{HttpAuditMetrics, Session};
 
 use crate::database::{Database, record_id_string};
 use crate::error::AppError;
 
 use super::model::{SessionCreateRecord, SessionIdRecord, SessionRecord};
 use super::repository::SessionRepository;
+
+#[derive(Debug, Deserialize, SurrealValue)]
+struct HttpAuditMetricsRow {
+    request_count: i64,
+    last_used_at: Option<surrealdb::types::Datetime>,
+}
+
+impl From<HttpAuditMetricsRow> for HttpAuditMetrics {
+    fn from(row: HttpAuditMetricsRow) -> Self {
+        Self {
+            request_count: row.request_count.max(0) as u64,
+            last_used_at: row.last_used_at.map(Into::into),
+        }
+    }
+}
 
 #[derive(Clone)]
 pub struct SurrealSessionRepo {
@@ -37,6 +53,27 @@ impl SessionRepository for SurrealSessionRepo {
             .take::<Option<SessionRecord>>(0)?
             .map(SessionRecord::into_session)
             .ok_or(AppError::NotFound("session not found".into()))
+    }
+
+    async fn get_http_audit_metrics_for_session(&self, session_id: &str) -> Result<HttpAuditMetrics, AppError> {
+        let mut response = self
+            .inner()
+            .db
+            .query(
+                "RETURN { request_count: fn::http_audit_count_for_session($rid), last_used_at: fn::http_audit_last_used_at_for_session($rid) };",
+            )
+            .bind(("rid", RecordId::new("session", session_id.to_owned())))
+            .await
+            .map_err(|e| {
+                crate::log_and_convert!(AppError::database, "session.http_audit_metrics.query", e)
+            })?;
+        let row = response
+            .take::<Option<HttpAuditMetricsRow>>(0)
+            .map_err(|e| {
+                crate::log_and_convert!(AppError::database, "session.http_audit_metrics.take", e)
+            })?
+            .ok_or_else(|| AppError::database("http audit metrics for session returned no row"))?;
+        Ok(row.into())
     }
 
     async fn get_session_for_user(&self, id: &str, user_id: &str) -> Result<Session, AppError> {

--- a/backend/src/resources/user/surreal_repo.rs
+++ b/backend/src/resources/user/surreal_repo.rs
@@ -7,13 +7,28 @@ use serde::Deserialize;
 use surrealdb::types::SurrealValue;
 
 use shared::api::ListQuery;
-use shared::user::User;
+use shared::user::{HttpAuditMetrics, User};
 
 use crate::database::{Database, surreal_take_errors};
 use crate::error::AppError;
 
 use super::model::{UserRecord, user_resource};
 use super::repository::UserRepository;
+
+#[derive(Debug, Deserialize, SurrealValue)]
+struct HttpAuditMetricsRow {
+    request_count: i64,
+    last_used_at: Option<surrealdb::types::Datetime>,
+}
+
+impl From<HttpAuditMetricsRow> for HttpAuditMetrics {
+    fn from(row: HttpAuditMetricsRow) -> Self {
+        Self {
+            request_count: row.request_count.max(0) as u64,
+            last_used_at: row.last_used_at.map(Into::into),
+        }
+    }
+}
 
 #[derive(Clone)]
 pub struct SurrealUserRepo {
@@ -112,6 +127,23 @@ impl UserRepository for SurrealUserRepo {
             .await?
             .map(UserRecord::into_user)
             .ok_or(AppError::NotFound("user not found".into()))
+    }
+
+    async fn get_http_audit_metrics_for_user(&self, user_id: &str) -> Result<HttpAuditMetrics, AppError> {
+        let mut response = self
+            .inner()
+            .db
+            .query(
+                "RETURN { request_count: fn::http_audit_count_for_user($rid), last_used_at: fn::http_audit_last_used_at_for_user($rid) };",
+            )
+            .bind(("rid", RecordId::new("user", user_id.to_owned())))
+            .await
+            .map_err(|e| crate::log_and_convert!(AppError::database, "user.http_audit_metrics.query", e))?;
+        let row = response
+            .take::<Option<HttpAuditMetricsRow>>(0)
+            .map_err(|e| crate::log_and_convert!(AppError::database, "user.http_audit_metrics.take", e))?
+            .ok_or_else(|| AppError::database("http audit metrics for user returned no row"))?;
+        Ok(row.into())
     }
 
     async fn get_user_by_email(&self, email: &str) -> Result<Option<User>, AppError> {

--- a/backend/src/resources/user/surreal_repo.rs
+++ b/backend/src/resources/user/surreal_repo.rs
@@ -129,7 +129,10 @@ impl UserRepository for SurrealUserRepo {
             .ok_or(AppError::NotFound("user not found".into()))
     }
 
-    async fn get_http_audit_metrics_for_user(&self, user_id: &str) -> Result<HttpAuditMetrics, AppError> {
+    async fn get_http_audit_metrics_for_user(
+        &self,
+        user_id: &str,
+    ) -> Result<HttpAuditMetrics, AppError> {
         let mut response = self
             .inner()
             .db
@@ -141,7 +144,9 @@ impl UserRepository for SurrealUserRepo {
             .map_err(|e| crate::log_and_convert!(AppError::database, "user.http_audit_metrics.query", e))?;
         let row = response
             .take::<Option<HttpAuditMetricsRow>>(0)
-            .map_err(|e| crate::log_and_convert!(AppError::database, "user.http_audit_metrics.take", e))?
+            .map_err(|e| {
+                crate::log_and_convert!(AppError::database, "user.http_audit_metrics.take", e)
+            })?
             .ok_or_else(|| AppError::database("http audit metrics for user returned no row"))?;
         Ok(row.into())
     }

--- a/frontend/src/components/setlist_editor.rs
+++ b/frontend/src/components/setlist_editor.rs
@@ -128,10 +128,7 @@ pub fn setlist_editor(props: &Props) -> Html {
         let items = items.clone();
         let api = api.clone();
         let items_req_id = items_req_id.clone();
-        let deps = (
-            props.setlist_id.clone(),
-            props.setlist.songs.clone(),
-        );
+        let deps = (props.setlist_id.clone(), props.setlist.songs.clone());
         use_effect_with(deps, move |(setlist_id, setlist_songs)| {
             let items = items.clone();
             let api = api.clone();

--- a/frontend/src/pages/login.rs
+++ b/frontend/src/pages/login.rs
@@ -41,10 +41,7 @@ pub fn login() -> Html {
             if *otp_requested {
                 let code = otp.trim().to_string();
                 if code.is_empty() {
-                    show_error(
-                        "Code required",
-                        "Enter the one-time code from your email.",
-                    );
+                    show_error("Code required", "Enter the one-time code from your email.");
                     return;
                 }
                 let api = api.clone();

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -12,7 +12,7 @@ chrono = { version = "0.4.44", default-features = false, features = [
 serde = { version = "1.0.228", features = ["derive"] }
 uuid = { version = "1.23.1", features = ["v4"], optional = true }
 tracing = { version = "0.1", optional = true }
-utoipa = { version = "5", optional = true }
+utoipa = { version = "5", optional = true, features = ["chrono"] }
 thiserror = "2.0"
 async-trait = "0.1"
 serde_json = "1.0"

--- a/shared/src/user/metrics.rs
+++ b/shared/src/user/metrics.rs
@@ -1,0 +1,21 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "backend")]
+#[allow(unused_imports)]
+use serde_json::json;
+
+/// HTTP request audit aggregates for a user or session (`GET .../metrics`).
+#[cfg_attr(feature = "backend", derive(utoipa::ToSchema))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "backend",
+    schema(example = json!({
+        "request_count": 42,
+        "last_used_at": "2026-01-01T12:00:00Z"
+    }))
+)]
+pub struct HttpAuditMetrics {
+    pub request_count: u64,
+    pub last_used_at: Option<DateTime<Utc>>,
+}

--- a/shared/src/user/mod.rs
+++ b/shared/src/user/mod.rs
@@ -1,8 +1,10 @@
+mod metrics;
 mod request;
 mod role;
 mod session;
 mod user;
 
+pub use metrics::HttpAuditMetrics;
 pub use request::CreateUser;
 #[cfg(feature = "backend")]
 pub use request::CreateUserError;

--- a/shared/src/user/request.rs
+++ b/shared/src/user/request.rs
@@ -68,8 +68,6 @@ impl CreateUser {
             role: self.role,
             default_collection: self.default_collection,
             created_at: Utc::now(),
-            last_used_at: None,
-            request_count: 0,
             oauth_picture_url: None,
             oauth_avatar_blob_id: None,
             avatar_blob_id: None,

--- a/shared/src/user/session.rs
+++ b/shared/src/user/session.rs
@@ -20,9 +20,7 @@ use super::User;
         "id": "550e8400-e29b-41d4-a716-446655440000",
         "user": { "id": "user-1", "email": "singer@example.com" },
         "created_at": "2024-01-01T12:00:00Z",
-        "expires_at": "2025-01-01T12:00:00Z",
-        "request_count": 0,
-        "last_used_at": null
+        "expires_at": "2025-01-01T12:00:00Z"
     }))
 )]
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -31,10 +29,6 @@ pub struct SessionBody {
     pub user: SessionUserBody,
     pub created_at: DateTime<Utc>,
     pub expires_at: DateTime<Utc>,
-    #[serde(default)]
-    pub request_count: u64,
-    #[serde(default)]
-    pub last_used_at: Option<DateTime<Utc>>,
 }
 
 #[cfg_attr(feature = "backend", derive(utoipa::ToSchema))]
@@ -61,8 +55,6 @@ impl SessionBody {
             user,
             created_at: session.created_at,
             expires_at: session.expires_at,
-            request_count: session.request_count,
-            last_used_at: session.last_used_at,
         }
     }
 }
@@ -73,10 +65,6 @@ pub struct Session {
     pub user: User,
     pub created_at: DateTime<Utc>,
     pub expires_at: DateTime<Utc>,
-    #[serde(default)]
-    pub request_count: u64,
-    #[serde(default)]
-    pub last_used_at: Option<DateTime<Utc>>,
 }
 
 impl Session {
@@ -94,8 +82,6 @@ impl Session {
             user,
             created_at: now,
             expires_at,
-            request_count: 0,
-            last_used_at: None,
         }
     }
 

--- a/shared/src/user/user.rs
+++ b/shared/src/user/user.rs
@@ -17,8 +17,6 @@ use super::Role;
         "role": "default",
         "default_collection": null,
         "created_at": "2026-01-01T12:00:00Z",
-        "last_used_at": null,
-        "request_count": 0,
         "oauth_picture_url": null,
         "oauth_avatar_blob_id": null,
         "avatar_blob_id": null
@@ -31,12 +29,6 @@ pub struct User {
     #[serde(default)]
     pub default_collection: Option<String>,
     pub created_at: DateTime<Utc>,
-    /// Latest `http_request_audit.created_at` for this user (none if no audited requests were linked).
-    #[serde(default)]
-    pub last_used_at: Option<DateTime<Utc>>,
-    /// Count of `http_request_audit` rows linked to this user.
-    #[serde(default)]
-    pub request_count: u64,
     /// Last `picture` claim URL seen from OIDC (used to detect when to re-fetch the cached avatar).
     #[serde(default)]
     pub oauth_picture_url: Option<String>,
@@ -57,8 +49,6 @@ impl User {
             role: Role::default(),
             default_collection: None,
             created_at: Utc::now(),
-            last_used_at: None,
-            request_count: 0,
             oauth_picture_url: None,
             oauth_avatar_blob_id: None,
             avatar_blob_id: None,


### PR DESCRIPTION
## Summary

Removes computed `request_count` and `last_used_at` from Surreal `user` and `session` tables (new migration) and from wire types `User`, `Session`, and `SessionBody`. Introduces shared `HttpAuditMetrics` and **GET** `.../metrics` routes beside each single-user or single-session handler, using existing `fn::http_audit_*` functions.

## Breaking change

Clients must stop reading audit counters from user/session resources and call the new metrics endpoints instead. Deploy with migration `20260508120000_drop_http_audit_computed_fields_user_session.surql`.

## Verification

- `cargo build`, `cargo clippy --all-targets`
- `cargo test openapi_snapshot_matches_committed_file`
- New HTTP tests for lean user/session JSON and metrics responses

Made with [Cursor](https://cursor.com)