### PR TITLE
fix(backend): align SurrealDB queries with 3.x record binding

### DIFF
--- a/backend/src/resources/collection/surreal_repo.rs
+++ b/backend/src/resources/collection/surreal_repo.rs
@@ -125,11 +125,12 @@ impl CollectionRepository for SurrealCollectionRepo {
         id: &str,
     ) -> Result<Vec<SongLinkOwned>, AppError> {
         let db = self.inner();
-        let resource = resource_id("collection", id)?;
+        let (tb, sid) = resource_id("collection", id)?;
         let mut response = db
             .db
-            .query("SELECT owner, songs FROM collection WHERE id = $id")
-            .bind(("id", RecordId::new(resource.0.clone(), resource.1.clone())))
+            .query("SELECT owner, songs FROM type::record($tb, $sid)")
+            .bind(("tb", tb))
+            .bind(("sid", sid))
             .await?;
 
         let record = response

--- a/backend/src/resources/common.rs
+++ b/backend/src/resources/common.rs
@@ -130,7 +130,7 @@ pub struct SongLinkListRow {
 
 /// Load full [`Song`] values for setlist/collection link rows (`array<object>` with `id: record<song>`).
 ///
-/// SurrealDB 3.0.x does not apply multi-part `FETCH` paths per array element the way 2.x did, so we batch `song` rows.
+/// SurrealDB 3.0.x does not apply multi-part `FETCH` paths per array element the way 2.x did, so we batch-load `song` rows by record-id array (`SELECT * FROM $ids`).
 pub async fn song_links_to_owned(
     db: &Surreal<Any>,
     links: Vec<SongLinkRecord>,
@@ -140,7 +140,7 @@ pub async fn song_links_to_owned(
     }
     let ids: Vec<RecordId> = links.iter().map(|l| l.id.clone()).collect();
     let mut response = db
-        .query("SELECT * FROM song WHERE id INSIDE $ids")
+        .query("SELECT * FROM $ids")
         .bind(("ids", ids))
         .await
         .map_err(|e| crate::log_and_convert!(AppError::database, "song.batch_by_id", e))?;

--- a/backend/src/resources/setlist/surreal_repo.rs
+++ b/backend/src/resources/setlist/surreal_repo.rs
@@ -121,11 +121,12 @@ impl SetlistRepository for SurrealSetlistRepo {
         id: &str,
     ) -> Result<Vec<SongLinkOwned>, AppError> {
         let db = self.inner();
-        let resource = resource_id("setlist", id)?;
+        let (tb, sid) = resource_id("setlist", id)?;
         let mut response = db
             .db
-            .query("SELECT owner, songs FROM setlist WHERE id = $id")
-            .bind(("id", RecordId::new(resource.0.clone(), resource.1.clone())))
+            .query("SELECT owner, songs FROM type::record($tb, $sid)")
+            .bind(("tb", tb))
+            .bind(("sid", sid))
             .await?;
 
         let record = response

--- a/backend/src/resources/song/surreal_repo.rs
+++ b/backend/src/resources/song/surreal_repo.rs
@@ -114,11 +114,7 @@ async fn songs_by_ids(
     if ids.is_empty() {
         return Ok(HashMap::new());
     }
-    let mut response = db
-        .db
-        .query("SELECT * FROM $ids")
-        .bind(("ids", ids))
-        .await?;
+    let mut response = db.db.query("SELECT * FROM $ids").bind(("ids", ids)).await?;
     let records: Vec<SongRecord> = response.take(0)?;
     let mut by_id = HashMap::with_capacity(records.len());
     for r in records {

--- a/backend/src/resources/song/surreal_repo.rs
+++ b/backend/src/resources/song/surreal_repo.rs
@@ -116,7 +116,7 @@ async fn songs_by_ids(
     }
     let mut response = db
         .db
-        .query("SELECT * FROM song WHERE id INSIDE $ids")
+        .query("SELECT * FROM $ids")
         .bind(("ids", ids))
         .await?;
     let records: Vec<SongRecord> = response.take(0)?;

--- a/backend/src/resources/user/session/surreal_repo.rs
+++ b/backend/src/resources/user/session/surreal_repo.rs
@@ -29,10 +29,11 @@ impl SurrealSessionRepo {
 #[async_trait]
 impl SessionRepository for SurrealSessionRepo {
     async fn get_session(&self, id: &str) -> Result<Session, AppError> {
+        let rid = RecordId::new("session", id.to_string());
         self.inner()
             .db
-            .query("SELECT * FROM session WHERE id = $id FETCH user")
-            .bind(("id", RecordId::new("session", id.to_string())))
+            .query("SELECT * FROM $rid FETCH user")
+            .bind(("rid", rid))
             .await?
             .take::<Option<SessionRecord>>(0)?
             .map(SessionRecord::into_session)
@@ -40,10 +41,11 @@ impl SessionRepository for SurrealSessionRepo {
     }
 
     async fn get_session_for_user(&self, id: &str, user_id: &str) -> Result<Session, AppError> {
+        let rid = RecordId::new("session", id.to_string());
         self.inner()
             .db
-            .query("SELECT * FROM session WHERE id = $id AND user = $user FETCH user")
-            .bind(("id", RecordId::new("session", id.to_string())))
+            .query("SELECT * FROM $rid WHERE user = $user FETCH user")
+            .bind(("rid", rid))
             .bind(("user", RecordId::new("user", user_id.to_owned())))
             .await?
             .take::<Option<SessionRecord>>(0)?


### PR DESCRIPTION
## Summary

Updates Surreal-backed repositories to query patterns that work with SurrealDB 3.x record binding:

- **Collection / setlist**: resolve ids with `type::record($tb, $sid)` instead of `WHERE id = $id` with a bound `RecordId`.
- **Songs**: batch fetch via `SELECT * FROM $ids` for link arrays (replacing `FROM song WHERE id INSIDE $ids`).
- **Sessions**: load from the bound record id (`SELECT * FROM $rid` …) with `FETCH user`.

## Verification

- `cargo check` (backend) passes locally.

Made with [Cursor](https://cursor.com)