### PR TITLE
feat(api)!: rename GET /users/me/session to /users/me/sessions/current

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7997,85 +7997,6 @@
         ]
       }
     },
-    "/api/v1/users/me/session": {
-      "get": {
-        "operationId": "get_current_session_for_user",
-        "parameters": [
-          {
-            "description": "Optional `user` to embed full user (default: `id`+`email` link).",
-            "in": "query",
-            "name": "expand",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionBody"
-                }
-              }
-            },
-            "description": "Returns the session credential used for this request"
-          },
-          "401": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Problem"
-                }
-              }
-            },
-            "description": "Authentication required"
-          },
-          "404": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Problem"
-                }
-              }
-            },
-            "description": "Session not found"
-          },
-          "429": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Problem"
-                }
-              }
-            },
-            "description": "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers"
-          },
-          "500": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Problem"
-                }
-              }
-            },
-            "description": "Failed to fetch session"
-          }
-        },
-        "security": [
-          {
-            "SessionCookie": []
-          },
-          {
-            "SessionToken": []
-          }
-        ],
-        "tags": [
-          "Users"
-        ]
-      }
-    },
     "/api/v1/users/me/sessions": {
       "get": {
         "operationId": "get_sessions_for_current_user",
@@ -8182,6 +8103,85 @@
               }
             },
             "description": "Failed to list sessions for current user"
+          }
+        },
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "SessionToken": []
+          }
+        ],
+        "tags": [
+          "Users"
+        ]
+      }
+    },
+    "/api/v1/users/me/sessions/current": {
+      "get": {
+        "operationId": "get_current_session_for_user",
+        "parameters": [
+          {
+            "description": "Optional `user` to embed full user (default: `id`+`email` link).",
+            "in": "query",
+            "name": "expand",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionBody"
+                }
+              }
+            },
+            "description": "Returns the session credential used for this request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Session not found"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Failed to fetch session"
           }
         },
         "security": [

--- a/backend/src/resources/user/session/rest.rs
+++ b/backend/src/resources/user/session/rest.rs
@@ -34,7 +34,7 @@ struct ExpandQuery {
 
 #[utoipa::path(
     get,
-    path = "/api/v1/users/me/session",
+    path = "/api/v1/users/me/sessions/current",
     params(
         ("expand" = Option<String>, Query, description = "Optional `user` to embed full user (default: `id`+`email` link)."),
     ),
@@ -51,7 +51,7 @@ struct ExpandQuery {
         ("SessionToken" = [])
     )
 )]
-#[get("/me/session")]
+#[get("/me/sessions/current")]
 pub async fn get_current_session_for_user(
     req: HttpRequest,
     svc: Data<SessionServiceHandle>,

--- a/backend/tests/3_sessions.yml
+++ b/backend/tests/3_sessions.yml
@@ -99,12 +99,12 @@ testcases:
           - result.statuscode ShouldEqual 200
           - result.bodyjson.id ShouldEqual "admin"
 
-  # Matches `get-me-session-admin` via GET /users/me/session (credential used on the wire).
+  # Matches `get-me-session-admin` via GET /users/me/sessions/current (credential used on the wire).
   - name: get-me-current-session-admin
     steps:
       - type: http
         method: GET
-        url: "{{.base_url}}/api/v1/users/me/session"
+        url: "{{.base_url}}/api/v1/users/me/sessions/current"
         headers:
           Authorization: "Bearer {{.token_admin}}"
         assertions:

--- a/shared/src/api/mod.rs
+++ b/shared/src/api/mod.rs
@@ -128,7 +128,7 @@ impl<C: HttpClient> ApiClient<C> {
     pub async fn get_my_current_session(&self) -> Result<SessionBody, NetworkClientError> {
         self.client
             .get(&append_query_param(
-                "api/v1/users/me/session".to_string(),
+                "api/v1/users/me/sessions/current".to_string(),
                 "expand",
                 "user",
             ))


### PR DESCRIPTION
## Summary

Renames the current-session credential endpoint from `GET /api/v1/users/me/session` to `GET /api/v1/users/me/sessions/current` for consistency with the sessions resource.

## Changes

- Actix route and OpenAPI (`utoipa`) updated in session REST handler.
- Shared API client `get_my_current_session` updated (frontend uses this path).
- Integration test `3_sessions.yml` updated.
- Regenerated committed `backend/openapi.json`.

## Breaking change

Callers using the old path receive **404**; they must migrate to `/api/v1/users/me/sessions/current`.

## Verification

- `cargo test openapi` (backend) passed after regenerating OpenAPI.

Made with [Cursor](https://cursor.com)