### PR TITLE
feat(team): database-backed GET /teams search

### DIFF
--- a/backend/db-migrations/20260509120000_team_name_fulltext_search.surql
+++ b/backend/db-migrations/20260509120000_team_name_fulltext_search.surql
@@ -1,0 +1,3 @@
+-- Full-text search on team names (same analyzer/BM25 as setlist/collection titles).
+
+DEFINE INDEX OVERWRITE team_name_search_idx ON team FIELDS name FULLTEXT ANALYZER text_search BM25(1.2,0.75) CONCURRENTLY;

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -6526,7 +6526,7 @@
             }
           },
           {
-            "description": "Optional case-insensitive substring on team name or id. Whitespace-only is treated as absent.",
+            "description": "Optional search: full-text on team name; case-insensitive substring on team id, personal owner email, and member emails. Whitespace-only is treated as absent.",
             "in": "query",
             "name": "q",
             "required": false,

--- a/backend/src/http_tests.rs
+++ b/backend/src/http_tests.rs
@@ -910,6 +910,7 @@ mod session_admin_gates {
     }
 
     /// BLC-SESS-003: `SessionBody` omits audit metrics; `GET /users/me/session/metrics` returns them.
+    /// Current session is exposed as `GET /users/me/sessions/current` (credential on the wire).
     #[actix_web::test]
     async fn blc_sess_003_current_session_omits_metrics_get_metrics_ok() {
         let db = test_db().await.unwrap();
@@ -920,7 +921,7 @@ mod session_admin_gates {
         let app = test::init_service(build_app(db.clone())).await;
 
         let req_s = test::TestRequest::get()
-            .uri("/api/v1/users/me/session")
+            .uri("/api/v1/users/me/sessions/current")
             .insert_header(("Authorization", format!("Bearer {token}")))
             .to_request();
         let body: serde_json::Value = test::call_and_read_body_json(&app, req_s).await;

--- a/backend/src/resources/team/invitation/service.rs
+++ b/backend/src/resources/team/invitation/service.rs
@@ -422,6 +422,25 @@ mod tests {
             unreachable!("not used in invitation tests")
         }
 
+        async fn count_teams_for_user_search(
+            &self,
+            _user_id: &str,
+            _is_admin: bool,
+            _q_trimmed: &str,
+        ) -> Result<u64, AppError> {
+            unreachable!("not used in invitation tests")
+        }
+
+        async fn fetch_teams_for_user_search(
+            &self,
+            _user_id: &str,
+            _is_admin: bool,
+            _pagination: &shared::api::ListQuery,
+            _q_trimmed: &str,
+        ) -> Result<Vec<TeamFetched>, AppError> {
+            unreachable!("not used in invitation tests")
+        }
+
         async fn update_team_name(
             &self,
             _resource: (String, String),

--- a/backend/src/resources/team/repository.rs
+++ b/backend/src/resources/team/repository.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use surrealdb::types::RecordId;
 
+use shared::api::ListQuery;
 use shared::team::Team;
 
 use crate::error::AppError;
@@ -19,6 +20,23 @@ pub trait TeamRepository: Send + Sync {
         &self,
         user_id: &str,
         is_admin: bool,
+    ) -> Result<Vec<TeamFetched>, AppError>;
+
+    /// Count teams visible to the user matching `q_trimmed` (full-text name + substring on id and related user emails).
+    async fn count_teams_for_user_search(
+        &self,
+        user_id: &str,
+        is_admin: bool,
+        q_trimmed: &str,
+    ) -> Result<u64, AppError>;
+
+    /// Search teams visible to the user; `q_trimmed` must be non-empty. Paging via `pagination`.
+    async fn fetch_teams_for_user_search(
+        &self,
+        user_id: &str,
+        is_admin: bool,
+        pagination: &ListQuery,
+        q_trimmed: &str,
     ) -> Result<Vec<TeamFetched>, AppError>;
 
     /// Fetch a single team by ID (accepts plain ID or `team:id` format), with FETCHed users.

--- a/backend/src/resources/team/rest.rs
+++ b/backend/src/resources/team/rest.rs
@@ -32,7 +32,7 @@ pub fn scope() -> Scope {
     params(
         ("page" = Option<u32>, Query, description = "Page index, zero-based; defaults to 0.", minimum = 0, nullable = true),
         ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50 when omitted.", minimum = 1, maximum = 500, example = 50, nullable = true),
-        ("q" = Option<String>, Query, description = "Optional case-insensitive substring on team name or id. Whitespace-only is treated as absent."),
+        ("q" = Option<String>, Query, description = "Optional search: full-text on team name; case-insensitive substring on team id, personal owner email, and member emails. Whitespace-only is treated as absent."),
     ),
     responses(
         (status = 200, description = "Teams readable by the current user; platform admins receive all teams (except internal public). `X-Total-Count` is the total before paging.", body = [Team]),
@@ -62,8 +62,15 @@ async fn get_teams(
     let q_link = query.clone();
     let cur_page = query.page.unwrap_or(0);
     let page_size = query.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
-    let teams = filter_teams_by_q(svc.list_teams_for_user(&acting).await?, &query);
-    let (teams_page, total) = ListQuery::paginate_vec(teams, &query);
+    let q_trimmed = query.q.as_ref().map(|s| s.trim()).filter(|s| !s.is_empty());
+    let (teams_page, total) = if let Some(qt) = q_trimmed {
+        let total = svc.count_teams_for_user_search(&acting, qt).await?;
+        let teams = svc.list_teams_for_user_search(&acting, &query, qt).await?;
+        (teams, total)
+    } else {
+        let teams = svc.list_teams_for_user(&acting).await?;
+        ListQuery::paginate_vec(teams, &query)
+    };
     Ok(HttpResponse::Ok()
         .insert_header((
             header::HeaderName::from_static("x-total-count"),
@@ -241,21 +248,4 @@ async fn delete_team(
 ) -> Result<HttpResponse, AppError> {
     svc.delete_team_for_user(&ctx, &id).await?;
     Ok(HttpResponse::NoContent().finish())
-}
-
-fn filter_teams_by_q(mut teams: Vec<Team>, query: &ListQuery) -> Vec<Team> {
-    let Some(needle) = query.q.as_ref().and_then(|s| {
-        let t = s.trim();
-        if t.is_empty() {
-            None
-        } else {
-            Some(t.to_lowercase())
-        }
-    }) else {
-        return teams;
-    };
-    teams.retain(|t| {
-        t.name.to_lowercase().contains(&needle) || t.id.to_lowercase().contains(&needle)
-    });
-    teams
 }

--- a/backend/src/resources/team/service.rs
+++ b/backend/src/resources/team/service.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use surrealdb::types::RecordId;
 
+use shared::api::ListQuery;
 use shared::patch::Patch;
 use shared::team::{CreateTeam, PatchTeam, Team, UpdateTeam};
 use shared::user::User;
@@ -78,6 +79,36 @@ impl<R: TeamRepository> TeamService<R> {
             _ => a.id.cmp(&b.id),
         });
         Ok(list)
+    }
+
+    /// `q_trimmed` must be non-empty. Uses database search and pagination (see [`TeamRepository::fetch_teams_for_user_search`]).
+    #[instrument(level = "debug", err, skip(self, user, pagination))]
+    pub async fn list_teams_for_user_search(
+        &self,
+        user: &User,
+        pagination: &ListQuery,
+        q_trimmed: &str,
+    ) -> Result<Vec<Team>, AppError> {
+        let rows = self
+            .repo
+            .fetch_teams_for_user_search(&user.id, false, pagination, q_trimmed)
+            .await?;
+        let mut list = Vec::with_capacity(rows.len());
+        for row in rows {
+            list.push(row.into_team()?);
+        }
+        Ok(list)
+    }
+
+    #[instrument(level = "debug", err, skip(self, user))]
+    pub async fn count_teams_for_user_search(
+        &self,
+        user: &User,
+        q_trimmed: &str,
+    ) -> Result<u64, AppError> {
+        self.repo
+            .count_teams_for_user_search(&user.id, false, q_trimmed)
+            .await
     }
 
     #[instrument(level = "debug", err, skip(self, user))]
@@ -270,6 +301,7 @@ impl TeamServiceHandle {
 
 #[cfg(test)]
 mod tests {
+    use shared::api::ListQuery;
     use shared::team::{CreateTeam, TeamMemberInput, TeamRole, TeamUserRef, UpdateTeam};
 
     use crate::error::AppError;
@@ -1097,5 +1129,37 @@ mod tests {
             new_path_ids, old_path_ids,
             "DB-filtered list must match Rust-side filter"
         );
+    }
+
+    /// `q` with email substring finds teams via owner (personal) and member `user` records (shared).
+    #[tokio::test]
+    async fn team_search_db_email_substring_matches_personal_and_shared_membership() {
+        let db = test_db().await.expect("db");
+        let u = create_user(&db, "team-search-email@test.local")
+            .await
+            .expect("u");
+        let svc = team_service(&db);
+        svc.create_shared_team_for_user(
+            &u,
+            CreateTeam {
+                name: "OnlyShared".into(),
+                members: vec![],
+            },
+        )
+        .await
+        .expect("shared");
+
+        let needle = "team-search-email@test.local";
+        let query = ListQuery::default().with_q(needle);
+        let total = svc
+            .count_teams_for_user_search(&u, needle)
+            .await
+            .expect("count");
+        let page = svc
+            .list_teams_for_user_search(&u, &query, needle)
+            .await
+            .expect("search");
+        assert_eq!(page.len() as u64, total);
+        assert_eq!(total, 2, "personal (owner email) + shared (member email)");
     }
 }

--- a/backend/src/resources/team/surreal_repo.rs
+++ b/backend/src/resources/team/surreal_repo.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use surrealdb::types::RecordId;
+use serde::Deserialize;
+use surrealdb::types::{RecordId, SurrealValue};
 
+use shared::api::ListQuery;
 use shared::team::Team;
 
 use crate::database::Database;
@@ -13,6 +15,14 @@ use super::model::{
     user_thing,
 };
 use super::repository::TeamRepository;
+
+/// Match `q` against name (full-text), id, personal owner email, or any member email.
+const TEAM_SEARCH_PREDICATE: &str = "(
+    name @0@ $q
+    OR string::contains(string::lowercase(type::string(id)), $needle)
+    OR (owner != NONE AND string::contains(string::lowercase((SELECT VALUE email FROM ONLY $this.owner)), $needle))
+    OR array::len(members[WHERE string::contains(string::lowercase((SELECT VALUE email FROM ONLY $this.user)), $needle)]) > 0
+)";
 
 #[derive(Clone)]
 pub struct SurrealTeamRepo {
@@ -70,6 +80,118 @@ impl TeamRepository for SurrealTeamRepo {
                 .await?
                 .take::<Vec<TeamFetched>>(0)?)
         }
+    }
+
+    async fn count_teams_for_user_search(
+        &self,
+        user_id: &str,
+        is_admin: bool,
+        q_trimmed: &str,
+    ) -> Result<u64, AppError> {
+        #[derive(Deserialize, SurrealValue)]
+        struct CountResult {
+            count: u64,
+        }
+
+        let public_thing = super::model::public_team_thing();
+        let db = self.inner();
+
+        let mut sql = String::from("SELECT count() FROM team WHERE ");
+        if is_admin {
+            sql.push_str("id != $public AND ");
+        } else {
+            let ut = user_thing(user_id);
+            sql.push_str(
+                "id != $public AND (owner = $user OR array::len(members[WHERE user = $user]) > 0) AND ",
+            );
+            sql.push_str(TEAM_SEARCH_PREDICATE);
+            sql.push_str(" GROUP ALL");
+            let mut response = db
+                .db
+                .query(&sql)
+                .bind(("public", public_thing))
+                .bind(("user", ut))
+                .bind(("q", q_trimmed.to_owned()))
+                .bind(("needle", q_trimmed.to_lowercase()))
+                .await?;
+            crate::database::surreal_take_errors(
+                "team.count_teams_for_user_search",
+                &mut response,
+            )?;
+            return Ok(response
+                .take::<Vec<CountResult>>(0)?
+                .into_iter()
+                .next()
+                .map(|r| r.count)
+                .unwrap_or(0));
+        }
+        sql.push_str(TEAM_SEARCH_PREDICATE);
+        sql.push_str(" GROUP ALL");
+        let mut response = db
+            .db
+            .query(&sql)
+            .bind(("public", public_thing))
+            .bind(("q", q_trimmed.to_owned()))
+            .bind(("needle", q_trimmed.to_lowercase()))
+            .await?;
+        crate::database::surreal_take_errors("team.count_teams_for_user_search", &mut response)?;
+        Ok(response
+            .take::<Vec<CountResult>>(0)?
+            .into_iter()
+            .next()
+            .map(|r| r.count)
+            .unwrap_or(0))
+    }
+
+    async fn fetch_teams_for_user_search(
+        &self,
+        user_id: &str,
+        is_admin: bool,
+        pagination: &ListQuery,
+        q_trimmed: &str,
+    ) -> Result<Vec<TeamFetched>, AppError> {
+        let public_thing = super::model::public_team_thing();
+        let db = self.inner();
+        let (offset, limit) = pagination.effective_offset_limit();
+
+        let mut sql = String::from("SELECT *, (search::score(0) ?? 0) AS score FROM team WHERE ");
+        if is_admin {
+            sql.push_str("id != $public AND ");
+        } else {
+            let ut = user_thing(user_id);
+            sql.push_str(
+                "id != $public AND (owner = $user OR array::len(members[WHERE user = $user]) > 0) AND ",
+            );
+            sql.push_str(TEAM_SEARCH_PREDICATE);
+            sql.push_str(
+                " ORDER BY score DESC, id ASC LIMIT $limit START $start FETCH owner, members.user",
+            );
+            return Ok(db
+                .db
+                .query(&sql)
+                .bind(("public", public_thing))
+                .bind(("user", ut))
+                .bind(("q", q_trimmed.to_owned()))
+                .bind(("needle", q_trimmed.to_lowercase()))
+                .bind(("limit", limit))
+                .bind(("start", offset))
+                .await?
+                .take::<Vec<TeamFetched>>(0)?);
+        }
+        sql.push_str(TEAM_SEARCH_PREDICATE);
+        sql.push_str(
+            " ORDER BY score DESC, id ASC LIMIT $limit START $start FETCH owner, members.user",
+        );
+        Ok(db
+            .db
+            .query(&sql)
+            .bind(("public", public_thing))
+            .bind(("q", q_trimmed.to_owned()))
+            .bind(("needle", q_trimmed.to_lowercase()))
+            .bind(("limit", limit))
+            .bind(("start", offset))
+            .await?
+            .take::<Vec<TeamFetched>>(0)?)
     }
 
     async fn fetch_team(&self, id: &str) -> Result<Option<TeamFetched>, AppError> {

--- a/backend/src/resources/user/service.rs
+++ b/backend/src/resources/user/service.rs
@@ -442,6 +442,25 @@ mod tests {
             unreachable!("not used in user tests")
         }
 
+        async fn count_teams_for_user_search(
+            &self,
+            _user_id: &str,
+            _is_admin: bool,
+            _q_trimmed: &str,
+        ) -> Result<u64, AppError> {
+            unreachable!("not used in user tests")
+        }
+
+        async fn fetch_teams_for_user_search(
+            &self,
+            _user_id: &str,
+            _is_admin: bool,
+            _pagination: &shared::api::ListQuery,
+            _q_trimmed: &str,
+        ) -> Result<Vec<TeamFetched>, AppError> {
+            unreachable!("not used in user tests")
+        }
+
         async fn fetch_team(&self, _id: &str) -> Result<Option<TeamFetched>, AppError> {
             unreachable!("not used in user tests")
         }

--- a/backend/tests/1_teams.yml
+++ b/backend/tests/1_teams.yml
@@ -262,6 +262,18 @@ testcases:
           - result.bodyjson ShouldHaveLength 1
           - result.bodyjson.bodyjson0.id ShouldEqual "{{.team-lead-create-shared-a.shared_team_a_id}}"
 
+  # BLC: BLC-LP-003 — substring on owner / member user emails (database search)
+  - name: team-list-q-match-owner-and-member-email
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/teams?q=team-lead@test.com"
+        headers:
+          Authorization: "Bearer {{.team-create-lead-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 3
+
   # BLC: BLC-LP-003, BLC-LP-008
   - name: team-list-q-no-matches
     steps:

--- a/docs/business-logic-constraints/list-pagination.md
+++ b/docs/business-logic-constraints/list-pagination.md
@@ -6,7 +6,7 @@ Applies to **GET** list routes that support paging, including **`/users`** (admi
 
 - **BLC-LP-001:** **`page`** — 0-based index of the page.
 - **BLC-LP-002:** **`page_size`** — maximum number of items per page.
-- **BLC-LP-003:** **`q`** — optional search filter: **`/songs`** (full-text: titles, artists, lyrics per analyzer rules), **`/collections`** and **`/setlists`** (**title**), **`/users`** (admin list: **email** or **user id** substring, case-insensitive), **`/teams`** (**name** or **team id** substring, case-insensitive), **`/users/me/sessions`** and **`/users/{id}/sessions`** (substring on **session id**, **user id**, or **user email**), **`/blobs`** (**OCR** substring, case-insensitive). Whitespace-only **`q`** is treated as absent everywhere.
+- **BLC-LP-003:** **`q`** — optional search filter: **`/songs`** (full-text: titles, artists, lyrics per analyzer rules), **`/collections`** and **`/setlists`** (**title**), **`/users`** (admin list: **email** or **user id** substring, case-insensitive), **`/teams`** (full-text **name**; case-insensitive substring on **team id**, personal **owner** email, and **member** emails), **`/users/me/sessions`** and **`/users/{id}/sessions`** (substring on **session id**, **user id**, or **user email**), **`/blobs`** (**OCR** substring, case-insensitive). Whitespace-only **`q`** is treated as absent everywhere.
 
 ## Validation
 


### PR DESCRIPTION
## Summary

Implements list search for `GET /api/v1/teams?q=` in SurrealDB instead of filtering in memory.

- **Migration:** full-text index on `team.name` (same `text_search` analyzer and BM25 settings as setlists/collections).
- **When `q` is non-empty:** `COUNT` + paged `SELECT` with visibility unchanged (non-admin path only, same as today). Matches full-text **name**, substring **team id**, personal **owner** email, and **member** user emails.
- **When `q` is absent or whitespace:** unchanged path (`list_teams_for_user` + `paginate_vec`, personal teams first).
- **Docs/tests:** BLC list-pagination note, OpenAPI `q` description, Venom case for email search, integration test for DB search.

## Notes

`ORDER BY` / `LIMIT` / `START` are placed before `FETCH` for SurrealDB 3 compatibility.

Made with [Cursor](https://cursor.com)