### PR TITLE
chore: track backend/static placeholder and tighten gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,10 @@ target
 dist
 Cargo.lock
 backend/blobs
-backend/static
+backend/static/*
+!backend/static/.gitkeep
 .cursor
 venom*.log
 0000_migration_test
+node_modules/
+.env.development.local


### PR DESCRIPTION
## Summary

- Track `backend/static/.gitkeep` so the static directory exists in clones while ignoring built SPA assets under `backend/static/*`.
- Ignore `node_modules/` and `.env.development.local` at the repo root for local frontend development.

## Test plan

- [ ] Fresh clone contains `backend/static/` (empty except `.gitkeep`)
- [ ] `git status` stays clean after copying a frontend build into `backend/static/`
- [ ] Local `frontend2/app/.env.development.local` is not offered by `git status`


Made with [Cursor](https://cursor.com)