### PR TITLE
fix(cli): resolve clippy warnings with -D warnings

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -40,7 +40,7 @@ pub struct FileConfig {
 
 pub fn load_file_config() -> Result<FileConfig, Box<dyn std::error::Error>> {
     let home: PathBuf = home_dir().ok_or_else(|| {
-        io::Error::new(io::ErrorKind::Other, "failed to determine home directory")
+        io::Error::other("failed to determine home directory")
     })?;
 
     let path = home.join(".worshipviewer").join("config.toml");

--- a/cli/src/handlers/auth.rs
+++ b/cli/src/handlers/auth.rs
@@ -13,7 +13,7 @@ pub async fn handle_auth(
 ) -> Result<(), Box<dyn std::error::Error>> {
     match cmd {
         AuthCommand::OtpRequest { json } => {
-            let payload: OtpRequest = serde_json::from_str(&json)?;
+            let payload: OtpRequest = serde_json::from_str(json)?;
             if dry_run {
                 let planned = serde_json::json!({
                     "method": "POST",
@@ -27,7 +27,7 @@ pub async fn handle_auth(
             output::print_json(&serde_json::json!({"status": "ok"}), &output)
         }
         AuthCommand::OtpVerify { json } => {
-            let payload: OtpVerify = serde_json::from_str(&json)?;
+            let payload: OtpVerify = serde_json::from_str(json)?;
             if dry_run {
                 let planned = serde_json::json!({
                     "method": "POST",

--- a/cli/src/handlers/collections.rs
+++ b/cli/src/handlers/collections.rs
@@ -24,8 +24,8 @@ pub async fn handle_collections(
             }
         }
         CollectionsCommand::Get { id } => {
-            validate_resource_id(&id)?;
-            let collection = client.get_collection(&id).await?;
+            validate_resource_id(id)?;
+            let collection = client.get_collection(id).await?;
             output::print_json(&collection, &output)
         }
         CollectionsCommand::Songs {
@@ -42,12 +42,12 @@ pub async fn handle_collections(
             }
         }
         CollectionsCommand::Player { id } => {
-            validate_resource_id(&id)?;
-            let player = client.get_collection_player(&id).await?;
+            validate_resource_id(id)?;
+            let player = client.get_collection_player(id).await?;
             output::print_json(&player, &output)
         }
         CollectionsCommand::Create { json } => {
-            let payload: CreateCollection = serde_json::from_str(&json)?;
+            let payload: CreateCollection = serde_json::from_str(json)?;
             if dry_run {
                 let planned = serde_json::json!({
                     "method": "POST",
@@ -61,8 +61,8 @@ pub async fn handle_collections(
             output::print_json(&collection, &output)
         }
         CollectionsCommand::Update { id, json } => {
-            validate_resource_id(&id)?;
-            let payload: UpdateCollection = serde_json::from_str(&json)?;
+            validate_resource_id(id)?;
+            let payload: UpdateCollection = serde_json::from_str(json)?;
             if dry_run {
                 let planned = serde_json::json!({
                     "method": "PUT",
@@ -72,12 +72,12 @@ pub async fn handle_collections(
                 output::print_json(&planned, &output)?;
                 return Ok(());
             }
-            let collection = client.update_collection(&id, payload).await?;
+            let collection = client.update_collection(id, payload).await?;
             output::print_json(&collection, &output)
         }
         CollectionsCommand::Patch { id, json } => {
-            validate_resource_id(&id)?;
-            let payload: serde_json::Value = serde_json::from_str(&json)?;
+            validate_resource_id(id)?;
+            let payload: serde_json::Value = serde_json::from_str(json)?;
             if dry_run {
                 let planned = serde_json::json!({
                     "method": "PATCH",
@@ -106,7 +106,7 @@ pub async fn handle_collections(
             output::print_json(&collection, &output)
         }
         CollectionsCommand::Delete { id } => {
-            validate_resource_id(&id)?;
+            validate_resource_id(id)?;
             if dry_run {
                 let planned = serde_json::json!({
                     "method": "DELETE",
@@ -115,7 +115,7 @@ pub async fn handle_collections(
                 output::print_json(&planned, &output)?;
                 return Ok(());
             }
-            client.delete_collection(&id).await?;
+            client.delete_collection(id).await?;
             output::print_json(&serde_json::json!({"deleted": true}), &output)
         }
     }

--- a/cli/src/handlers/schema.rs
+++ b/cli/src/handlers/schema.rs
@@ -176,7 +176,7 @@ fn get_operation<'a>(
     let paths = openapi
         .get("paths")
         .and_then(|v| v.as_object())
-        .ok_or_else(|| "OpenAPI document missing paths")?;
+        .ok_or("OpenAPI document missing paths")?;
 
     let path_item = paths
         .get(path)

--- a/cli/src/handlers/songs.rs
+++ b/cli/src/handlers/songs.rs
@@ -30,17 +30,17 @@ pub async fn handle_songs(
             }
         }
         SongsCommand::Get { id } => {
-            validate_resource_id(&id)?;
-            let song = client.get_song(&id).await?;
+            validate_resource_id(id)?;
+            let song = client.get_song(id).await?;
             output::print_json(&song, &output)
         }
         SongsCommand::Player { id } => {
-            validate_resource_id(&id)?;
-            let player = client.get_song_player(&id).await?;
+            validate_resource_id(id)?;
+            let player = client.get_song_player(id).await?;
             output::print_json(&player, &output)
         }
         SongsCommand::Create { json } => {
-            let payload: CreateSong = serde_json::from_str(&json)?;
+            let payload: CreateSong = serde_json::from_str(json)?;
             if dry_run {
                 let planned = serde_json::json!({
                     "method": "POST",
@@ -54,8 +54,8 @@ pub async fn handle_songs(
             output::print_json(&song, &output)
         }
         SongsCommand::Update { id, json } => {
-            validate_resource_id(&id)?;
-            let payload: UpdateSong = serde_json::from_str(&json)?;
+            validate_resource_id(id)?;
+            let payload: UpdateSong = serde_json::from_str(json)?;
             if dry_run {
                 let planned = serde_json::json!({
                     "method": "PUT",
@@ -65,7 +65,7 @@ pub async fn handle_songs(
                 output::print_json(&planned, &output)?;
                 return Ok(());
             }
-            let song = client.update_song(&id, payload).await?;
+            let song = client.update_song(id, payload).await?;
             output::print_json(&song, &output)
         }
         SongsCommand::Patch { id, json } => {
@@ -99,7 +99,7 @@ pub async fn handle_songs(
             output::print_json(&song, &output)
         }
         SongsCommand::Delete { id } => {
-            validate_resource_id(&id)?;
+            validate_resource_id(id)?;
             if dry_run {
                 let planned = serde_json::json!({
                     "method": "DELETE",
@@ -108,16 +108,16 @@ pub async fn handle_songs(
                 output::print_json(&planned, &output)?;
                 return Ok(());
             }
-            client.delete_song(&id).await?;
+            client.delete_song(id).await?;
             output::print_json(&serde_json::json!({"deleted": true}), &output)
         }
         SongsCommand::LikeStatus { id } => {
-            validate_resource_id(&id)?;
-            let liked = client.get_song_like_status(&id).await?;
+            validate_resource_id(id)?;
+            let liked = client.get_song_like_status(id).await?;
             output::print_json(&serde_json::json!({ "liked": liked }), &output)
         }
         SongsCommand::UpdateLikeStatus { id, liked } => {
-            validate_resource_id(&id)?;
+            validate_resource_id(id)?;
             if dry_run {
                 let planned = if *liked {
                     serde_json::json!({
@@ -133,7 +133,7 @@ pub async fn handle_songs(
                 output::print_json(&planned, &output)?;
                 return Ok(());
             }
-            client.update_song_like_status(&id, *liked).await?;
+            client.update_song_like_status(id, *liked).await?;
             output::print_json(&serde_json::json!({ "liked": liked }), &output)
         }
     }


### PR DESCRIPTION
## Summary
- Fix all clippy findings in the `worshipviewer-cli` crate when run with `-D warnings`
- Remove needless borrows in auth, collections, and songs handlers
- Use `io::Error::other` in config loading and `ok_or` instead of `ok_or_else` in schema parsing

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` in `cli/` passes
- [ ] `cargo build` in `cli/` succeeds