### PR TITLE
fix(collections): reject PUT/PATCH that remove songs (BLC-COLL-024)

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3736,6 +3736,16 @@
             },
             "description": "Collection not found"
           },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Request would remove a song from the collection (BLC-COLL-024)"
+          },
           "412": {
             "content": {
               "application/problem+json": {
@@ -3842,6 +3852,16 @@
               }
             },
             "description": "Collection not found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Request would remove a song from the collection (BLC-COLL-024)"
           },
           "412": {
             "content": {

--- a/backend/src/resources/collection/rest.rs
+++ b/backend/src/resources/collection/rest.rs
@@ -271,6 +271,7 @@ async fn create_collection(
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
         (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Collection not found", body = Problem, content_type = "application/problem+json"),
+        (status = 409, description = "Request would remove a song from the collection (BLC-COLL-024)", body = Problem, content_type = "application/problem+json"),
         (status = 412, description = "`If-Match` does not match current weak ETag", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to update collection", body = Problem, content_type = "application/problem+json")
     ),
@@ -315,6 +316,7 @@ async fn update_collection(
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
         (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Collection not found", body = Problem, content_type = "application/problem+json"),
+        (status = 409, description = "Request would remove a song from the collection (BLC-COLL-024)", body = Problem, content_type = "application/problem+json"),
         (status = 412, description = "`If-Match` does not match current weak ETag", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to patch collection", body = Problem, content_type = "application/problem+json")
     ),

--- a/backend/src/resources/collection/service.rs
+++ b/backend/src/resources/collection/service.rs
@@ -1,21 +1,40 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use shared::MoveOwner;
 use shared::api::ListQuery;
 use shared::collection::{Collection, CreateCollection, PatchCollection};
 use shared::player::Player;
-use shared::song::Song;
+use shared::song::{Link as SongLink, Song};
 use tracing::instrument;
 
 use crate::auth::AuthorizationContext;
 use crate::database::Database;
 use crate::error::AppError;
-use crate::resources::common::{player_from_song_links, resolve_owner_team};
+use crate::resources::common::{player_from_song_links, resolve_owner_team, song_thing};
 use crate::resources::song::LikedSongIds;
 use crate::resources::team::{parse_owner_record_id, thing_record_key};
 
 use super::repository::CollectionRepository;
 use super::surreal_repo::SurrealCollectionRepo;
+
+fn song_link_id_key(id: &str) -> String {
+    thing_record_key(&song_thing(id))
+}
+
+/// BLC-COLL-024: existing song ids must remain present (add/reorder/nr/key changes only).
+fn ensure_no_song_removals(current: &[SongLink], proposed: &[SongLink]) -> Result<(), AppError> {
+    let proposed_keys: HashSet<String> = proposed.iter().map(|l| song_link_id_key(&l.id)).collect();
+    let removes = current
+        .iter()
+        .any(|l| !proposed_keys.contains(&song_link_id_key(&l.id)));
+    if removes {
+        return Err(AppError::conflict(
+            "cannot remove songs from a collection via PUT or PATCH; delete the song instead",
+        ));
+    }
+    Ok(())
+}
 
 #[derive(Clone)]
 pub struct CollectionService<R, L> {
@@ -125,6 +144,8 @@ impl<R: CollectionRepository, L: LikedSongIds> CollectionService<R, L> {
         owner: Option<String>,
     ) -> Result<Collection, AppError> {
         let write_teams = ctx.write_teams();
+        let current = self.repo.get_collection(&write_teams, id).await?;
+        ensure_no_song_removals(&current.songs, &collection.songs)?;
         let owner = resolve_owner_team(&write_teams, owner)?;
         self.repo
             .update_collection(&write_teams, id, collection, owner)
@@ -702,6 +723,170 @@ mod tests {
         assert_eq!(patched.title, col.title, "title must be unchanged");
     }
 
+    /// BLC-COLL-024: PUT cannot drop an existing song id from `songs`.
+    #[tokio::test]
+    async fn blc_coll_024_put_cannot_remove_song() {
+        let (db, owner, _cm, _guest, _nm, _tid) = four_user_coll_fixture().await;
+        let svc = CollectionServiceHandle::build(db.clone());
+        let owner_p = auth_ctx_for_user(&db, &owner).await.expect("auth");
+        let s1 = create_song_with_title(&db, &owner, "Keep Me")
+            .await
+            .expect("s1");
+        let s2 = create_song_with_title(&db, &owner, "Also Keep")
+            .await
+            .expect("s2");
+        let col = svc
+            .create_collection_for_user(
+                &owner_p,
+                CreateCollection {
+                    owner: None,
+                    title: "NoRemove".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![
+                        shared::song::Link {
+                            id: s1.id.clone(),
+                            nr: Some("1".into()),
+                            key: None,
+                        },
+                        shared::song::Link {
+                            id: s2.id.clone(),
+                            nr: Some("2".into()),
+                            key: None,
+                        },
+                    ],
+                },
+            )
+            .await
+            .expect("create");
+
+        let r = svc
+            .update_collection_for_user(
+                &owner_p,
+                &col.id,
+                CreateCollection {
+                    owner: None,
+                    title: "NoRemove".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![shared::song::Link {
+                        id: s2.id.clone(),
+                        nr: Some("2".into()),
+                        key: None,
+                    }],
+                },
+                None,
+            )
+            .await;
+        assert!(matches!(r, Err(AppError::Conflict(_))));
+
+        let still = svc
+            .get_collection_for_user(&owner_p, &col.id)
+            .await
+            .expect("unchanged");
+        assert_eq!(still.songs.len(), 2);
+    }
+
+    /// BLC-COLL-024: PATCH cannot drop an existing song id from `songs`.
+    #[tokio::test]
+    async fn blc_coll_024_patch_cannot_remove_song() {
+        use shared::collection::PatchCollection;
+
+        let (db, owner, _cm, _guest, _nm, _tid) = four_user_coll_fixture().await;
+        let svc = CollectionServiceHandle::build(db.clone());
+        let owner_p = auth_ctx_for_user(&db, &owner).await.expect("auth");
+        let s1 = create_song_with_title(&db, &owner, "Patch Keep")
+            .await
+            .expect("s1");
+        let col = svc
+            .create_collection_for_user(
+                &owner_p,
+                CreateCollection {
+                    owner: None,
+                    title: "PatchNoRemove".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![shared::song::Link {
+                        id: s1.id.clone(),
+                        nr: Some("1".into()),
+                        key: None,
+                    }],
+                },
+            )
+            .await
+            .expect("create");
+
+        let r = svc
+            .patch_collection_for_user(
+                &owner_p,
+                &col.id,
+                PatchCollection {
+                    title: None,
+                    cover: None,
+                    songs: Some(vec![]),
+                    owner: None,
+                },
+            )
+            .await;
+        assert!(matches!(r, Err(AppError::Conflict(_))));
+    }
+
+    /// BLC-COLL-024: PUT may add songs and update metadata on existing entries.
+    #[tokio::test]
+    async fn blc_coll_024_put_may_add_and_update_existing() {
+        let (db, owner, _cm, _guest, _nm, _tid) = four_user_coll_fixture().await;
+        let svc = CollectionServiceHandle::build(db.clone());
+        let owner_p = auth_ctx_for_user(&db, &owner).await.expect("auth");
+        let s1 = create_song_with_title(&db, &owner, "First")
+            .await
+            .expect("s1");
+        let s2 = create_song_with_title(&db, &owner, "Second")
+            .await
+            .expect("s2");
+        let col = svc
+            .create_collection_for_user(
+                &owner_p,
+                CreateCollection {
+                    owner: None,
+                    title: "Grow".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![shared::song::Link {
+                        id: s1.id.clone(),
+                        nr: Some("1".into()),
+                        key: None,
+                    }],
+                },
+            )
+            .await
+            .expect("create");
+
+        let updated = svc
+            .update_collection_for_user(
+                &owner_p,
+                &col.id,
+                CreateCollection {
+                    owner: None,
+                    title: "Grow".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![
+                        shared::song::Link {
+                            id: s2.id.clone(),
+                            nr: Some("2".into()),
+                            key: None,
+                        },
+                        shared::song::Link {
+                            id: s1.id.clone(),
+                            nr: Some("1a".into()),
+                            key: None,
+                        },
+                    ],
+                },
+                None,
+            )
+            .await
+            .expect("add + reorder + nr update");
+        assert_eq!(updated.songs.len(), 2);
+        assert_eq!(updated.songs[0].id, s2.id);
+        assert_eq!(updated.songs[1].nr.as_deref(), Some("1a"));
+    }
+
     /// PATCH-COLL-003: PATCH on a non-existent collection returns NotFound.
     #[tokio::test]
     async fn patch_collection_not_found() {
@@ -760,21 +945,30 @@ mod tests {
             let include_cover = (mask & 0b010) != 0;
             let include_songs = (mask & 0b100) != 0;
 
+            let patch = PatchCollection {
+                title: include_title.then_some("PatchedTitle".into()),
+                cover: include_cover.then_some("newheart".into()),
+                songs: include_songs.then_some(vec![shared::song::Link {
+                    id: s2.id.clone(),
+                    nr: Some("9".into()),
+                    key: None,
+                }]),
+                owner: None,
+            };
+
+            if include_songs {
+                let r = svc
+                    .patch_collection_for_user(&owner_p, &created.id, patch)
+                    .await;
+                assert!(
+                    matches!(r, Err(AppError::Conflict(_))),
+                    "mask={mask:03b}: replacing songs must not remove existing ids"
+                );
+                continue;
+            }
+
             let patched = svc
-                .patch_collection_for_user(
-                    &owner_p,
-                    &created.id,
-                    PatchCollection {
-                        title: include_title.then_some("PatchedTitle".into()),
-                        cover: include_cover.then_some("newheart".into()),
-                        songs: include_songs.then_some(vec![shared::song::Link {
-                            id: s2.id.clone(),
-                            nr: Some("9".into()),
-                            key: None,
-                        }]),
-                        owner: None,
-                    },
-                )
+                .patch_collection_for_user(&owner_p, &created.id, patch)
                 .await
                 .expect("patch");
 
@@ -793,17 +987,10 @@ mod tests {
                 patched.cover, expected_cover,
                 "mask={mask:03b}: cover mismatch"
             );
-            if include_songs {
-                assert_eq!(
-                    patched.songs[0].id, s2.id,
-                    "mask={mask:03b}: songs mismatch"
-                );
-            } else {
-                assert_eq!(
-                    patched.songs[0].id, s1.id,
-                    "mask={mask:03b}: songs should remain unchanged"
-                );
-            }
+            assert_eq!(
+                patched.songs[0].id, s1.id,
+                "mask={mask:03b}: songs should remain unchanged"
+            );
         }
     }
 

--- a/backend/tests/5_collections.yml
+++ b/backend/tests/5_collections.yml
@@ -849,13 +849,34 @@ testcases:
             "title": "Updated Collection",
             "cover": "cover-updated",
             "songs": [
+              { "id": "{{.create-collection-song-one.songid}}", "nr": "1" },
               { "id": "{{.create-collection-song-two.songid}}", "nr": "10" }
             ]
           }
         assertions:
           - result.statuscode ShouldEqual 200
           - result.bodyjson.title ShouldEqual "Updated Collection"
-          - result.bodyjson.songs ShouldHaveLength 1
+          - result.bodyjson.songs ShouldHaveLength 2
+
+  # BLC: BLC-COLL-024
+  - name: put-collection-remove-song-rejected
+    steps:
+      - type: http
+        method: PUT
+        url: "{{.base_url}}/api/v1/collections/{{.post-collection-success.collectionid}}"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+          Content-Type: application/json
+        body: |
+          {
+            "title": "Updated Collection",
+            "cover": "cover-updated",
+            "songs": [
+              { "id": "{{.create-collection-song-two.songid}}", "nr": "10" }
+            ]
+          }
+        assertions:
+          - result.statuscode ShouldEqual 409
 
   # BLC: BLC-COLL-008, BLC-COLL-003
   - name: put-collection-success-write-user

--- a/docs/business-logic-constraints/collection.md
+++ b/docs/business-logic-constraints/collection.md
@@ -25,6 +25,7 @@
 - **BLC-COLL-023:** WHEN **PATCH /collections/{id}** runs THEN only fields present in the body are updated; omitted fields are unchanged; unknown fields are rejected (**`deny_unknown_fields`**), matching **BLC-SONG-019**. Optimistic concurrency uses **`If-Match`** with the resource **ETag**.
 - **BLC-COLL-015:** WHEN **DELETE** succeeds THEN the collection no longer appears under the same rules as other reads.
 - **BLC-COLL-016:** WHEN a song IS appended to a collection automatically (e.g. after creating a song with a default collection) THEN the caller MUST be allowed to **edit** that collection’s owning team’s library.
+- **BLC-COLL-024:** WHEN **PUT** or **PATCH** would drop a **song** id that is currently in the collection’s **`songs`** list (same id regardless of **nr** / **key**) THEN the API responds **409 Conflict**. Callers MAY add songs, reorder entries, or change **nr** / **key** on existing ids. Removing a song from collections MUST be done by **DELETE** `/songs/{id}` (server cascade updates collection **`songs`**).
 
 ## Cascading deletes
 


### PR DESCRIPTION
## Summary
- Add **BLC-COLL-024**: `PUT` and `PATCH` on collections must not drop existing song ids from `songs` (returns **409 Conflict**).
- Enforce in `CollectionService::update_collection_for_user` after a write-scoped load so ACL behavior stays **404** for unauthorized callers.
- Song removal from collections remains via **`DELETE /songs/{id}`** (existing DB cascade).

## Test plan
- [x] Unit tests: `blc_coll_024_put_cannot_remove_song`, `blc_coll_024_patch_cannot_remove_song`, `blc_coll_024_put_may_add_and_update_existing`
- [ ] `cargo test -p backend collection::service::`
- [ ] Venom: `backend/tests/5_collections.yml` (`put-collection-remove-song-rejected` expects 409)