### PR TITLE
Collections: block song removal via PUT/PATCH and non-empty DELETE (BLC-COLL-024, 025)

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3736,6 +3736,16 @@
             },
             "description": "Collection not found"
           },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Request would remove a song from the collection (BLC-COLL-024)"
+          },
           "412": {
             "content": {
               "application/problem+json": {
@@ -3842,6 +3852,16 @@
               }
             },
             "description": "Collection not found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Request would remove a song from the collection (BLC-COLL-024)"
           },
           "412": {
             "content": {

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3539,6 +3539,16 @@
             },
             "description": "Collection not found"
           },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Collection still contains songs (BLC-COLL-025)"
+          },
           "412": {
             "content": {
               "application/problem+json": {

--- a/backend/src/resources/collection/rest.rs
+++ b/backend/src/resources/collection/rest.rs
@@ -271,6 +271,7 @@ async fn create_collection(
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
         (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Collection not found", body = Problem, content_type = "application/problem+json"),
+        (status = 409, description = "Request would remove a song from the collection (BLC-COLL-024)", body = Problem, content_type = "application/problem+json"),
         (status = 412, description = "`If-Match` does not match current weak ETag", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to update collection", body = Problem, content_type = "application/problem+json")
     ),
@@ -315,6 +316,7 @@ async fn update_collection(
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
         (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Collection not found", body = Problem, content_type = "application/problem+json"),
+        (status = 409, description = "Request would remove a song from the collection (BLC-COLL-024)", body = Problem, content_type = "application/problem+json"),
         (status = 412, description = "`If-Match` does not match current weak ETag", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to patch collection", body = Problem, content_type = "application/problem+json")
     ),

--- a/backend/src/resources/collection/rest.rs
+++ b/backend/src/resources/collection/rest.rs
@@ -391,6 +391,7 @@ async fn move_collection(
         (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
         (status = 429, description = "API rate limit exceeded; see `Retry-After` and `X-RateLimit-*` response headers", body = Problem, content_type = "application/problem+json"),
         (status = 404, description = "Collection not found", body = Problem, content_type = "application/problem+json"),
+        (status = 409, description = "Collection still contains songs (BLC-COLL-025)", body = Problem, content_type = "application/problem+json"),
         (status = 412, description = "`If-Match` does not match current weak ETag", body = Problem, content_type = "application/problem+json"),
         (status = 500, description = "Failed to delete collection", body = Problem, content_type = "application/problem+json")
     ),

--- a/backend/src/resources/collection/service.rs
+++ b/backend/src/resources/collection/service.rs
@@ -1,21 +1,40 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use shared::MoveOwner;
 use shared::api::ListQuery;
 use shared::collection::{Collection, CreateCollection, PatchCollection};
 use shared::player::Player;
-use shared::song::Song;
+use shared::song::{Link as SongLink, Song};
 use tracing::instrument;
 
 use crate::auth::AuthorizationContext;
 use crate::database::Database;
 use crate::error::AppError;
-use crate::resources::common::{player_from_song_links, resolve_owner_team};
+use crate::resources::common::{player_from_song_links, resolve_owner_team, song_thing};
 use crate::resources::song::LikedSongIds;
 use crate::resources::team::{parse_owner_record_id, thing_record_key};
 
 use super::repository::CollectionRepository;
 use super::surreal_repo::SurrealCollectionRepo;
+
+fn song_link_id_key(id: &str) -> String {
+    thing_record_key(&song_thing(id))
+}
+
+/// BLC-COLL-024: existing song ids must remain present (add/reorder/nr/key changes only).
+fn ensure_no_song_removals(current: &[SongLink], proposed: &[SongLink]) -> Result<(), AppError> {
+    let proposed_keys: HashSet<String> = proposed.iter().map(|l| song_link_id_key(&l.id)).collect();
+    let removes = current
+        .iter()
+        .any(|l| !proposed_keys.contains(&song_link_id_key(&l.id)));
+    if removes {
+        return Err(AppError::conflict(
+            "cannot remove songs from a collection via PUT or PATCH; delete the song instead",
+        ));
+    }
+    Ok(())
+}
 
 #[derive(Clone)]
 pub struct CollectionService<R, L> {
@@ -125,6 +144,8 @@ impl<R: CollectionRepository, L: LikedSongIds> CollectionService<R, L> {
         owner: Option<String>,
     ) -> Result<Collection, AppError> {
         let write_teams = ctx.write_teams();
+        let current = self.repo.get_collection(&write_teams, id).await?;
+        ensure_no_song_removals(&current.songs, &collection.songs)?;
         let owner = resolve_owner_team(&write_teams, owner)?;
         self.repo
             .update_collection(&write_teams, id, collection, owner)
@@ -702,6 +723,170 @@ mod tests {
         assert_eq!(patched.title, col.title, "title must be unchanged");
     }
 
+    /// BLC-COLL-024: PUT cannot drop an existing song id from `songs`.
+    #[tokio::test]
+    async fn blc_coll_024_put_cannot_remove_song() {
+        let (db, owner, _cm, _guest, _nm, _tid) = four_user_coll_fixture().await;
+        let svc = CollectionServiceHandle::build(db.clone());
+        let owner_p = auth_ctx_for_user(&db, &owner).await.expect("auth");
+        let s1 = create_song_with_title(&db, &owner, "Keep Me")
+            .await
+            .expect("s1");
+        let s2 = create_song_with_title(&db, &owner, "Also Keep")
+            .await
+            .expect("s2");
+        let col = svc
+            .create_collection_for_user(
+                &owner_p,
+                CreateCollection {
+                    owner: None,
+                    title: "NoRemove".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![
+                        shared::song::Link {
+                            id: s1.id.clone(),
+                            nr: Some("1".into()),
+                            key: None,
+                        },
+                        shared::song::Link {
+                            id: s2.id.clone(),
+                            nr: Some("2".into()),
+                            key: None,
+                        },
+                    ],
+                },
+            )
+            .await
+            .expect("create");
+
+        let r = svc
+            .update_collection_for_user(
+                &owner_p,
+                &col.id,
+                CreateCollection {
+                    owner: None,
+                    title: "NoRemove".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![shared::song::Link {
+                        id: s2.id.clone(),
+                        nr: Some("2".into()),
+                        key: None,
+                    }],
+                },
+                None,
+            )
+            .await;
+        assert!(matches!(r, Err(AppError::Conflict(_))));
+
+        let still = svc
+            .get_collection_for_user(&owner_p, &col.id)
+            .await
+            .expect("unchanged");
+        assert_eq!(still.songs.len(), 2);
+    }
+
+    /// BLC-COLL-024: PATCH cannot drop an existing song id from `songs`.
+    #[tokio::test]
+    async fn blc_coll_024_patch_cannot_remove_song() {
+        use shared::collection::PatchCollection;
+
+        let (db, owner, _cm, _guest, _nm, _tid) = four_user_coll_fixture().await;
+        let svc = CollectionServiceHandle::build(db.clone());
+        let owner_p = auth_ctx_for_user(&db, &owner).await.expect("auth");
+        let s1 = create_song_with_title(&db, &owner, "Patch Keep")
+            .await
+            .expect("s1");
+        let col = svc
+            .create_collection_for_user(
+                &owner_p,
+                CreateCollection {
+                    owner: None,
+                    title: "PatchNoRemove".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![shared::song::Link {
+                        id: s1.id.clone(),
+                        nr: Some("1".into()),
+                        key: None,
+                    }],
+                },
+            )
+            .await
+            .expect("create");
+
+        let r = svc
+            .patch_collection_for_user(
+                &owner_p,
+                &col.id,
+                PatchCollection {
+                    title: None,
+                    cover: None,
+                    songs: Some(vec![]),
+                    owner: None,
+                },
+            )
+            .await;
+        assert!(matches!(r, Err(AppError::Conflict(_))));
+    }
+
+    /// BLC-COLL-024: PUT may add songs and update metadata on existing entries.
+    #[tokio::test]
+    async fn blc_coll_024_put_may_add_and_update_existing() {
+        let (db, owner, _cm, _guest, _nm, _tid) = four_user_coll_fixture().await;
+        let svc = CollectionServiceHandle::build(db.clone());
+        let owner_p = auth_ctx_for_user(&db, &owner).await.expect("auth");
+        let s1 = create_song_with_title(&db, &owner, "First")
+            .await
+            .expect("s1");
+        let s2 = create_song_with_title(&db, &owner, "Second")
+            .await
+            .expect("s2");
+        let col = svc
+            .create_collection_for_user(
+                &owner_p,
+                CreateCollection {
+                    owner: None,
+                    title: "Grow".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![shared::song::Link {
+                        id: s1.id.clone(),
+                        nr: Some("1".into()),
+                        key: None,
+                    }],
+                },
+            )
+            .await
+            .expect("create");
+
+        let updated = svc
+            .update_collection_for_user(
+                &owner_p,
+                &col.id,
+                CreateCollection {
+                    owner: None,
+                    title: "Grow".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![
+                        shared::song::Link {
+                            id: s2.id.clone(),
+                            nr: Some("2".into()),
+                            key: None,
+                        },
+                        shared::song::Link {
+                            id: s1.id.clone(),
+                            nr: Some("1a".into()),
+                            key: None,
+                        },
+                    ],
+                },
+                None,
+            )
+            .await
+            .expect("add + reorder + nr update");
+        assert_eq!(updated.songs.len(), 2);
+        assert_eq!(updated.songs[0].id, s2.id);
+        assert_eq!(updated.songs[1].nr.as_deref(), Some("1a"));
+    }
+
     /// PATCH-COLL-003: PATCH on a non-existent collection returns NotFound.
     #[tokio::test]
     async fn patch_collection_not_found() {
@@ -760,21 +945,30 @@ mod tests {
             let include_cover = (mask & 0b010) != 0;
             let include_songs = (mask & 0b100) != 0;
 
+            let patch = PatchCollection {
+                title: include_title.then_some("PatchedTitle".into()),
+                cover: include_cover.then_some("newheart".into()),
+                songs: include_songs.then_some(vec![shared::song::Link {
+                    id: s2.id.clone(),
+                    nr: Some("9".into()),
+                    key: None,
+                }]),
+                owner: None,
+            };
+
+            if include_songs {
+                let r = svc
+                    .patch_collection_for_user(&owner_p, &created.id, patch)
+                    .await;
+                assert!(
+                    matches!(r, Err(AppError::Conflict(_))),
+                    "mask={mask:03b}: replacing songs must not remove existing ids"
+                );
+                continue;
+            }
+
             let patched = svc
-                .patch_collection_for_user(
-                    &owner_p,
-                    &created.id,
-                    PatchCollection {
-                        title: include_title.then_some("PatchedTitle".into()),
-                        cover: include_cover.then_some("newheart".into()),
-                        songs: include_songs.then_some(vec![shared::song::Link {
-                            id: s2.id.clone(),
-                            nr: Some("9".into()),
-                            key: None,
-                        }]),
-                        owner: None,
-                    },
-                )
+                .patch_collection_for_user(&owner_p, &created.id, patch)
                 .await
                 .expect("patch");
 
@@ -793,17 +987,10 @@ mod tests {
                 patched.cover, expected_cover,
                 "mask={mask:03b}: cover mismatch"
             );
-            if include_songs {
-                assert_eq!(
-                    patched.songs[0].id, s2.id,
-                    "mask={mask:03b}: songs mismatch"
-                );
-            } else {
-                assert_eq!(
-                    patched.songs[0].id, s1.id,
-                    "mask={mask:03b}: songs should remain unchanged"
-                );
-            }
+            assert_eq!(
+                patched.songs[0].id, s1.id,
+                "mask={mask:03b}: songs should remain unchanged"
+            );
         }
     }
 

--- a/backend/src/resources/collection/service.rs
+++ b/backend/src/resources/collection/service.rs
@@ -495,9 +495,7 @@ mod tests {
         let db = test_db().await.expect("db");
         let svc = CollectionServiceHandle::build(db.clone());
         let song_svc = crate::resources::song::SongServiceHandle::build(db.clone());
-        let owner = create_user(&db, "coll-del-ok@test.local")
-            .await
-            .expect("o");
+        let owner = create_user(&db, "coll-del-ok@test.local").await.expect("o");
         let song = create_song_with_title(&db, &owner, "Allow Del")
             .await
             .expect("song");

--- a/backend/src/resources/collection/service.rs
+++ b/backend/src/resources/collection/service.rs
@@ -22,6 +22,16 @@ fn song_link_id_key(id: &str) -> String {
     thing_record_key(&song_thing(id))
 }
 
+/// BLC-COLL-025: collection must have no songs before DELETE.
+fn ensure_collection_empty_for_delete(songs: &[SongLink]) -> Result<(), AppError> {
+    if !songs.is_empty() {
+        return Err(AppError::conflict(
+            "cannot delete a collection that still contains songs; remove all songs first",
+        ));
+    }
+    Ok(())
+}
+
 /// BLC-COLL-024: existing song ids must remain present (add/reorder/nr/key changes only).
 fn ensure_no_song_removals(current: &[SongLink], proposed: &[SongLink]) -> Result<(), AppError> {
     let proposed_keys: HashSet<String> = proposed.iter().map(|l| song_link_id_key(&l.id)).collect();
@@ -198,6 +208,8 @@ impl<R: CollectionRepository, L: LikedSongIds> CollectionService<R, L> {
         ctx: &AuthorizationContext,
         id: &str,
     ) -> Result<Collection, AppError> {
+        let collection = self.get_collection_for_user(ctx, id).await?;
+        ensure_collection_empty_for_delete(&collection.songs)?;
         let write_teams = ctx.write_teams();
         self.repo.delete_collection(&write_teams, id).await
     }
@@ -317,6 +329,11 @@ mod tests {
             .await;
         assert!(matches!(put_guest, Err(AppError::NotFound(_))));
 
+        let song_svc = crate::resources::song::SongServiceHandle::build(db.clone());
+        song_svc
+            .delete_song_for_user(&owner_perms, &song.id)
+            .await
+            .expect("delete song");
         svc.delete_collection_for_user(&owner_perms, &col.id)
             .await
             .expect("delete");
@@ -438,6 +455,76 @@ mod tests {
             .update_collection_for_user(&guest_p, &col.id, make_collection("Hack"), None)
             .await;
         assert!(matches!(r, Err(AppError::NotFound(_))));
+    }
+
+    /// BLC-COLL-025: DELETE is rejected while the collection still has songs.
+    #[tokio::test]
+    async fn blc_coll_025_delete_non_empty_collection_rejected() {
+        let db = test_db().await.expect("db");
+        let svc = CollectionServiceHandle::build(db.clone());
+        let owner = create_user(&db, "coll-del-block@test.local")
+            .await
+            .expect("o");
+        let song = create_song_with_title(&db, &owner, "Block Del")
+            .await
+            .expect("song");
+        let owner_p = auth_ctx_for_user(&db, &owner).await.expect("auth");
+        let col = svc
+            .create_collection_for_user(
+                &owner_p,
+                CreateCollection {
+                    owner: None,
+                    title: "Non Empty".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![SongLink {
+                        id: song.id.clone(),
+                        nr: None,
+                        key: None,
+                    }],
+                },
+            )
+            .await
+            .expect("create");
+        let r = svc.delete_collection_for_user(&owner_p, &col.id).await;
+        assert!(matches!(r, Err(AppError::Conflict(_))));
+    }
+
+    /// BLC-COLL-025: DELETE succeeds after all songs are removed (via song DELETE cascade).
+    #[tokio::test]
+    async fn blc_coll_025_delete_after_songs_removed() {
+        let db = test_db().await.expect("db");
+        let svc = CollectionServiceHandle::build(db.clone());
+        let song_svc = crate::resources::song::SongServiceHandle::build(db.clone());
+        let owner = create_user(&db, "coll-del-ok@test.local")
+            .await
+            .expect("o");
+        let song = create_song_with_title(&db, &owner, "Allow Del")
+            .await
+            .expect("song");
+        let owner_p = auth_ctx_for_user(&db, &owner).await.expect("auth");
+        let col = svc
+            .create_collection_for_user(
+                &owner_p,
+                CreateCollection {
+                    owner: None,
+                    title: "Then Empty".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![SongLink {
+                        id: song.id.clone(),
+                        nr: None,
+                        key: None,
+                    }],
+                },
+            )
+            .await
+            .expect("create");
+        song_svc
+            .delete_song_for_user(&owner_p, &song.id)
+            .await
+            .expect("delete song");
+        svc.delete_collection_for_user(&owner_p, &col.id)
+            .await
+            .expect("delete collection");
     }
 
     /// BLC-COLL-007: guest cannot delete a collection they don't own.

--- a/backend/tests/5_collections.yml
+++ b/backend/tests/5_collections.yml
@@ -1089,7 +1089,7 @@ testcases:
           - result.statuscode ShouldEqual 200
           - result.bodyjson ShouldHaveLength 1
 
-  # BLC: BLC-COLL-004, BLC-COLL-013
+  # BLC: BLC-COLL-004, BLC-COLL-013, BLC-COLL-024
   - name: put-collection-invalid-song-entry
     steps:
       - type: http
@@ -1103,12 +1103,14 @@ testcases:
             "title": "Put Bad Song",
             "cover": "cover-bad-song",
             "songs": [
-              { "id": "song-missing-from-db", "nr": "1" }
+              { "id": "{{.create-collection-song-one.songid}}", "nr": "1" },
+              { "id": "{{.create-collection-song-two.songid}}", "nr": "2" },
+              { "id": "song-missing-from-db", "nr": "3" }
             ]
           }
         assertions:
           - result.statuscode ShouldEqual 200
-          - result.bodyjson.songs ShouldHaveLength 1
+          - result.bodyjson.songs ShouldHaveLength 3
 
   # Additional collections for delete scenarios
   - name: post-collection-for-delete
@@ -1123,9 +1125,7 @@ testcases:
           {
             "title": "Collection To Delete",
             "cover": "cover-delete",
-            "songs": [
-              { "id": "{{.create-collection-song-one.songid}}", "nr": "1" }
-            ]
+            "songs": []
           }
         assertions:
           - result.statuscode ShouldEqual 201
@@ -1145,8 +1145,28 @@ testcases:
           {
             "title": "Collection To Delete By Write",
             "cover": "cover-delete-write",
+            "songs": []
+          }
+        assertions:
+          - result.statuscode ShouldEqual 201
+        vars:
+          collectionid:
+            from: result.bodyjson.id
+
+  - name: post-collection-for-delete-blocked
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/collections"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+          Content-Type: application/json
+        body: |
+          {
+            "title": "Collection With Songs",
+            "cover": "cover-delete-blocked",
             "songs": [
-              { "id": "{{.create-collection-song-two.songid}}", "nr": "2" }
+              { "id": "{{.create-collection-song-one.songid}}", "nr": "1" }
             ]
           }
         assertions:
@@ -1155,8 +1175,37 @@ testcases:
           collectionid:
             from: result.bodyjson.id
 
+  # BLC: BLC-COLL-025
+  - name: delete-collection-non-empty-rejected
+    steps:
+      - type: http
+        method: DELETE
+        url: "{{.base_url}}/api/v1/collections/{{.post-collection-for-delete-blocked.collectionid}}"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 409
+
+  # BLC: BLC-COLL-025, BLC-SONG-015, BLC-COLL-019
+  - name: delete-collection-song-then-collection
+    steps:
+      - type: http
+        method: DELETE
+        url: "{{.base_url}}/api/v1/songs/{{.create-collection-song-one.songid}}"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 204
+      - type: http
+        method: DELETE
+        url: "{{.base_url}}/api/v1/collections/{{.post-collection-for-delete-blocked.collectionid}}"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 204
+
   # DELETE /api/v1/collections/{id}
-  # BLC: BLC-COLL-008, BLC-COLL-015
+  # BLC: BLC-COLL-008, BLC-COLL-015, BLC-COLL-025
   - name: delete-collection-success
     steps:
       - type: http
@@ -1167,7 +1216,7 @@ testcases:
         assertions:
           - result.statuscode ShouldEqual 204
 
-  # BLC: BLC-COLL-008, BLC-COLL-015, BLC-USER-011
+  # BLC: BLC-COLL-008, BLC-COLL-015, BLC-COLL-025, BLC-USER-011
   - name: delete-collection-success-write-user
     steps:
       - type: http

--- a/backend/tests/5_collections.yml
+++ b/backend/tests/5_collections.yml
@@ -849,13 +849,34 @@ testcases:
             "title": "Updated Collection",
             "cover": "cover-updated",
             "songs": [
+              { "id": "{{.create-collection-song-one.songid}}", "nr": "1" },
               { "id": "{{.create-collection-song-two.songid}}", "nr": "10" }
             ]
           }
         assertions:
           - result.statuscode ShouldEqual 200
           - result.bodyjson.title ShouldEqual "Updated Collection"
-          - result.bodyjson.songs ShouldHaveLength 1
+          - result.bodyjson.songs ShouldHaveLength 2
+
+  # BLC: BLC-COLL-024
+  - name: put-collection-remove-song-rejected
+    steps:
+      - type: http
+        method: PUT
+        url: "{{.base_url}}/api/v1/collections/{{.post-collection-success.collectionid}}"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+          Content-Type: application/json
+        body: |
+          {
+            "title": "Updated Collection",
+            "cover": "cover-updated",
+            "songs": [
+              { "id": "{{.create-collection-song-two.songid}}", "nr": "10" }
+            ]
+          }
+        assertions:
+          - result.statuscode ShouldEqual 409
 
   # BLC: BLC-COLL-008, BLC-COLL-003
   - name: put-collection-success-write-user

--- a/docs/business-logic-constraints/collection.md
+++ b/docs/business-logic-constraints/collection.md
@@ -23,9 +23,10 @@
 - **BLC-COLL-013:** WHEN **PUT** includes a **song** id that does not exist THEN the API MAY still return **200** and persist the slot; clients SHOULD validate ids.
 - **BLC-COLL-014:** WHEN **GET …/songs** includes an entry pointing at a song the caller cannot read THEN the collection **owner** MAY still receive **200** with an entry while per-song detail MAY be incomplete.
 - **BLC-COLL-023:** WHEN **PATCH /collections/{id}** runs THEN only fields present in the body are updated; omitted fields are unchanged; unknown fields are rejected (**`deny_unknown_fields`**), matching **BLC-SONG-019**. Optimistic concurrency uses **`If-Match`** with the resource **ETag**.
-- **BLC-COLL-015:** WHEN **DELETE** succeeds THEN the collection no longer appears under the same rules as other reads.
+- **BLC-COLL-015:** WHEN **DELETE** succeeds THEN the collection no longer appears under the same rules as other reads. **DELETE** succeeds only when the collection’s **`songs`** list is empty (**BLC-COLL-025**).
 - **BLC-COLL-016:** WHEN a song IS appended to a collection automatically (e.g. after creating a song with a default collection) THEN the caller MUST be allowed to **edit** that collection’s owning team’s library.
 - **BLC-COLL-024:** WHEN **PUT** or **PATCH** would drop a **song** id that is currently in the collection’s **`songs`** list (same id regardless of **nr** / **key**) THEN the API responds **409 Conflict**. Callers MAY add songs, reorder entries, or change **nr** / **key** on existing ids. Removing a song from collections MUST be done by **DELETE** `/songs/{id}` (server cascade updates collection **`songs`**).
+- **BLC-COLL-025:** WHEN **DELETE** `/collections/{id}` runs AND the collection’s **`songs`** list is non-empty THEN the API responds **409 Conflict**. Callers MUST remove every song from the collection first (**DELETE** `/songs/{id}` cascades and clears slots per **BLC-COLL-019** / **BLC-COLL-024**). Team or user teardown cascades (**BLC-COLL-018**) are out of scope for this rule.
 
 ## Cascading deletes
 

--- a/docs/business-logic-constraints/collection.md
+++ b/docs/business-logic-constraints/collection.md
@@ -25,6 +25,7 @@
 - **BLC-COLL-023:** WHEN **PATCH /collections/{id}** runs THEN only fields present in the body are updated; omitted fields are unchanged; unknown fields are rejected (**`deny_unknown_fields`**), matching **BLC-SONG-019**. Optimistic concurrency uses **`If-Match`** with the resource **ETag**.
 - **BLC-COLL-015:** WHEN **DELETE** succeeds THEN the collection no longer appears under the same rules as other reads.
 - **BLC-COLL-016:** WHEN a song IS appended to a collection automatically (e.g. after creating a song with a default collection) THEN the caller MUST be allowed to **edit** that collection’s owning team’s library.
+- **BLC-COLL-024:** WHEN **PUT** or **PATCH** would drop a **song** id that is currently in the collection’s **`songs`** list (same id regardless of **nr** / **key**) THEN the API responds **409 Conflict**. Callers MAY add songs, reorder entries, or change **nr** / **key** on existing ids. Removing a song from collections MUST be done by **DELETE** `/songs/{id}` (server cascade updates collection **`songs`**).
 
 ## Cascading deletes
 


### PR DESCRIPTION
## Summary

- **BLC-COLL-024:** `PUT` and `PATCH` on a collection return **409 Conflict** if the request would drop any existing song id from `songs`. Callers may add, reorder, or update `nr` / `key`; removing a song from a collection must use `DELETE /songs/{id}` (cascade clears collection slots).
- **BLC-COLL-025:** `DELETE /collections/{id}` returns **409 Conflict** while `songs` is non-empty. Collections can only be deleted after all songs are removed (typically by deleting each song first).

Includes business-logic docs, OpenAPI **409** responses, Rust unit tests, and Venom integration tests.

## Test plan

- [x] `cargo test` in `backend/`
- [x] Venom: `venom run tests/*.yml` (with backend on `:8080`, `INITIAL_ADMIN_USER_EMAIL` + `INITIAL_ADMIN_USER_TEST_SESSION`)
- [ ] Confirm API clients handle **409** on collection delete and update flows