### PR TITLE
fix(shared): resolve clippy warnings with -D warnings

### DIFF
--- a/shared/src/blob/mod.rs
+++ b/shared/src/blob/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::module_inception)]
 mod blob;
 mod file_type;
 

--- a/shared/src/collection/mod.rs
+++ b/shared/src/collection/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::module_inception)]
 mod collection;
 
 pub use collection::{Collection, CreateCollection, PatchCollection, UpdateCollection};

--- a/shared/src/like/mod.rs
+++ b/shared/src/like/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::module_inception)]
 mod like;
 
 pub use like::{Like, LikeStatus};

--- a/shared/src/patch.rs
+++ b/shared/src/patch.rs
@@ -7,17 +7,12 @@ use serde::{Deserialize, Deserializer};
 /// Use with `#[serde(default)]` on the field so that a missing JSON key deserializes
 /// to `Patch::Missing`, `null` becomes `Patch::Null`, and any other value becomes
 /// `Patch::Value(v)`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum Patch<T> {
+    #[default]
     Missing,
     Null,
     Value(T),
-}
-
-impl<T> Default for Patch<T> {
-    fn default() -> Self {
-        Self::Missing
-    }
 }
 
 impl<'de, T: Deserialize<'de>> Deserialize<'de> for Patch<T> {

--- a/shared/src/player/mod.rs
+++ b/shared/src/player/mod.rs
@@ -1,4 +1,5 @@
 mod orientation;
+#[allow(clippy::module_inception)]
 mod player;
 mod player_item;
 mod scroll_type;

--- a/shared/src/player/player.rs
+++ b/shared/src/player/player.rs
@@ -46,10 +46,8 @@ impl Player {
     pub fn song_id(&self) -> Option<String> {
         self.toc
             .iter()
-            .filter(|item| item.idx <= self.index())
-            .last()
-            .map(|item| item.id.clone())
-            .flatten()
+            .rfind(|item| item.idx <= self.index())
+            .and_then(|item| item.id.clone())
     }
 
     pub fn set_like_mut(&mut self, id: &str, liked: bool) {
@@ -91,7 +89,7 @@ impl Player {
         new.between_items = false;
 
         if let ScrollType::Book = new.scroll_type {
-            if new.index() % 2 == 0 {
+            if new.index().is_multiple_of(2) {
                 new.decrement();
             }
         }
@@ -112,15 +110,15 @@ impl Player {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.items.len() == 0
+        self.items.is_empty()
     }
 
     pub fn orientation(&self) -> Orientation {
-        self.orientation.clone()
+        self.orientation
     }
 
     pub fn item(&self) -> (&PlayerItem, Option<&PlayerItem>) {
-        if self.items.len() == 0 {
+        if self.items.is_empty() {
             return (empty_item(), None);
         }
         let current = match self.scroll_type {
@@ -128,7 +126,7 @@ impl Player {
                 &self.items[self.index]
             }
             ScrollType::TwoHalfPage => {
-                if self.index % 2 == 0 && self.index != 0 && self.index < self.max_index() {
+                if self.index.is_multiple_of(2) && self.index != 0 && self.index < self.max_index() {
                     &self.items[self.index + 1]
                 } else {
                     &self.items[self.index]
@@ -243,7 +241,7 @@ impl Player {
             index = new.max_index();
         }
         new.index = index;
-        if new.scroll_type == ScrollType::Book && new.index % 2 == 0 {
+        if new.scroll_type == ScrollType::Book && new.index.is_multiple_of(2) {
             new.decrement();
         }
         new
@@ -257,7 +255,7 @@ impl Player {
         let mut new = self.clone();
 
         let new_scroll_type = new.scroll_type_cache_other_orientation;
-        new.scroll_type_cache_other_orientation = new.scroll_type.clone();
+        new.scroll_type_cache_other_orientation = new.scroll_type;
         new = new.set_scroll_type(new_scroll_type);
         new.orientation = orientation;
 
@@ -269,30 +267,27 @@ impl Add for Player {
     type Output = Self;
 
     fn add(self, other: Self) -> Self {
-        if self.items.len() == 0 {
+        if self.items.is_empty() {
             return other;
         }
-        let last_self_item = self.items[self.items.len() - 1].clone();
+        let self_len = self.items.len();
+        let last_self_item = self.items.last().expect("non-empty").clone();
         Self {
             toc: self
                 .toc
                 .into_iter()
-                .chain(other.toc.iter().map(|item| {
-                    let item = TocItem {
-                        idx: if self.items.len() > 0
-                            && other.items.len() > 0
-                            && self.items[self.items.len() - 1] == other.items[0]
-                        {
-                            item.idx + self.items.len() - 1
-                        } else {
-                            item.idx + self.items.len()
-                        },
-                        title: item.title.clone(),
-                        id: item.id.clone(),
-                        nr: item.nr.clone(),
-                        liked: item.liked,
-                    };
-                    item
+                .chain(other.toc.iter().map(|item| TocItem {
+                    idx: if !other.items.is_empty()
+                        && self.items.last() == other.items.first()
+                    {
+                        item.idx + self_len.saturating_sub(1)
+                    } else {
+                        item.idx + self_len
+                    },
+                    title: item.title.clone(),
+                    id: item.id.clone(),
+                    nr: item.nr.clone(),
+                    liked: item.liked,
                 }))
                 .collect::<Vec<TocItem>>(),
             items: self
@@ -328,12 +323,12 @@ impl From<SongLinkOwned> for Player {
                         })
                     })
                     .collect::<Vec<PlayerItem>>();
-                if link.song.data.sections.len() > 0 || items.len() == 0 {
+                if !link.song.data.sections.is_empty() || items.is_empty() {
                     let mut song = link.song.clone();
                     if let Some(key) = link.key {
                         song.data.transpose(key);
                     }
-                    items.push(PlayerItem::Chords(super::PlayerChordsItem { song }))
+                    items.push(PlayerItem::Chords(Box::new(super::PlayerChordsItem { song })))
                 }
                 items
             },

--- a/shared/src/player/player.rs
+++ b/shared/src/player/player.rs
@@ -126,7 +126,8 @@ impl Player {
                 &self.items[self.index]
             }
             ScrollType::TwoHalfPage => {
-                if self.index.is_multiple_of(2) && self.index != 0 && self.index < self.max_index() {
+                if self.index.is_multiple_of(2) && self.index != 0 && self.index < self.max_index()
+                {
                     &self.items[self.index + 1]
                 } else {
                     &self.items[self.index]
@@ -277,9 +278,7 @@ impl Add for Player {
                 .toc
                 .into_iter()
                 .chain(other.toc.iter().map(|item| TocItem {
-                    idx: if !other.items.is_empty()
-                        && self.items.last() == other.items.first()
-                    {
+                    idx: if !other.items.is_empty() && self.items.last() == other.items.first() {
                         item.idx + self_len.saturating_sub(1)
                     } else {
                         item.idx + self_len
@@ -328,7 +327,9 @@ impl From<SongLinkOwned> for Player {
                     if let Some(key) = link.key {
                         song.data.transpose(key);
                     }
-                    items.push(PlayerItem::Chords(Box::new(super::PlayerChordsItem { song })))
+                    items.push(PlayerItem::Chords(Box::new(super::PlayerChordsItem {
+                        song,
+                    })))
                 }
                 items
             },

--- a/shared/src/player/player_item.rs
+++ b/shared/src/player/player_item.rs
@@ -8,7 +8,7 @@ use utoipa::ToSchema;
 #[cfg_attr(feature = "backend", derive(ToSchema))]
 pub enum PlayerItem {
     Blob(PlayerBlobItem),
-    Chords(PlayerChordsItem),
+    Chords(Box<PlayerChordsItem>),
 }
 
 /// Sheet-music or image item in a player sequence (`type`: `"blob"`).

--- a/shared/src/player/scroll_type.rs
+++ b/shared/src/player/scroll_type.rs
@@ -80,7 +80,7 @@ impl ScrollType {
         }
     }
 
-    fn to_wire(&self) -> &'static str {
+    fn to_wire(self) -> &'static str {
         match self {
             Self::OnePage => "one_page",
             Self::HalfPage => "half_page",

--- a/shared/src/setlist/mod.rs
+++ b/shared/src/setlist/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::module_inception)]
 mod setlist;
 
 pub use setlist::{CreateSetlist, PatchSetlist, Setlist, UpdateSetlist};

--- a/shared/src/song/mod.rs
+++ b/shared/src/song/mod.rs
@@ -1,4 +1,5 @@
 mod link;
+#[allow(clippy::module_inception)]
 mod song;
 #[cfg(feature = "backend")]
 mod song_data_schema;

--- a/shared/src/team/mod.rs
+++ b/shared/src/team/mod.rs
@@ -1,4 +1,5 @@
 mod invitation;
+#[allow(clippy::module_inception)]
 mod team;
 
 pub use invitation::TeamInvitation;

--- a/shared/src/user/mod.rs
+++ b/shared/src/user/mod.rs
@@ -2,6 +2,7 @@ mod metrics;
 mod request;
 mod role;
 mod session;
+#[allow(clippy::module_inception)]
 mod user;
 
 pub use metrics::HttpAuditMetrics;


### PR DESCRIPTION
## Summary
- Fix all `cargo clippy --all-features -- -D warnings` issues in the `shared` crate
- Allow intentional `module_inception` layout in domain modules
- Apply idiomatic fixes in `player` (e.g. `rfind`, `is_multiple_of`, `Box` for large enum variant) and derive `Default` on `Patch`

## Test plan
- [x] `cargo clippy --all-features -- -D warnings` in `shared/`
- [x] `cargo test` in `shared/`
- [x] `cargo clippy -- -D warnings` in `backend/` (depends on `shared`)