### PR TITLE
fix(frontend): resolve clippy warnings with -D warnings

### DIFF
--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -3,6 +3,13 @@ name = "frontend"
 version = "0.1.0"
 edition = "2021"
 
+# WASM binaries cannot be executed by the native `cargo test` harness.
+[[bin]]
+name = "frontend"
+path = "src/main.rs"
+test = false
+bench = false
+
 [dependencies]
 shared = { path = "../shared", features = ["frontend"] }
 yew = { version = "0.23.0", features = ["csr"] }

--- a/frontend/src/api/api.rs
+++ b/frontend/src/api/api.rs
@@ -56,14 +56,6 @@ impl Api {
         Self { client, navigator }
     }
 
-    fn build_path(path: &str) -> String {
-        if path.starts_with('/') {
-            path.to_string()
-        } else {
-            format!("/{}", path)
-        }
-    }
-
     fn handle_error(&self, err: NetworkClientError) -> ApiError {
         let api_error: ApiError = err.into();
         match api_error {

--- a/frontend/src/api/mod.rs
+++ b/frontend/src/api/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::module_inception)]
 mod api;
 pub use api::Api;
 

--- a/frontend/src/components/editor/editor.rs
+++ b/frontend/src/components/editor/editor.rs
@@ -120,7 +120,7 @@ impl Component for Editor {
 
             self.code_mirror_wrapper = Some(
                 CodeMirrorWrapper::new()
-                    .define_mode("generated", &ctx.props().syntax_parser.transactions())
+                    .define_mode("generated", ctx.props().syntax_parser.transactions())
                     .draw(
                         &self.editor_name,
                         self.onsave.as_ref(),

--- a/frontend/src/components/editor/mod.rs
+++ b/frontend/src/components/editor/mod.rs
@@ -1,4 +1,5 @@
 mod code_mirror_wrapper;
+#[allow(clippy::module_inception)]
 mod editor;
 mod syntax_parser;
 

--- a/frontend/src/components/editor/syntax_parser.rs
+++ b/frontend/src/components/editor/syntax_parser.rs
@@ -46,16 +46,16 @@ impl<'a> SyntaxParserBuilder<'a> {
             .entry(label)
             .and_modify(|existing_value| {
                 existing_value.push_str(key);
-                existing_value.push_str(":");
+                existing_value.push(':');
                 existing_value.push_str(value);
-                existing_value.push_str(";");
+                existing_value.push(';');
             })
             .or_insert_with(|| {
                 let mut new_value = String::new();
                 new_value.push_str(key);
-                new_value.push_str(":");
+                new_value.push(':');
                 new_value.push_str(value);
-                new_value.push_str(";");
+                new_value.push(';');
                 new_value
             });
         self

--- a/frontend/src/components/presenter/data.rs
+++ b/frontend/src/components/presenter/data.rs
@@ -62,7 +62,7 @@ impl SongData {
                 slide_len_counter += 1;
                 slide_idx_counter += 1;
             }
-            if slide_len_counter > 0 && map.get(&section.title.clone()).is_none() {
+            if slide_len_counter > 0 && !map.contains_key(&section.title) {
                 map.insert(section.title.clone(), (current_idx, slide_len_counter));
             }
         }
@@ -87,9 +87,9 @@ impl SongData {
 
             outline.push(OutlineData {
                 title: section.title.clone(),
-                text_idx: text_idx,
-                outline_idx: outline_idx,
-                len: len,
+                text_idx,
+                outline_idx,
+                len,
                 duplicate: seen.contains(&section.title.clone()),
                 has_text: text_idx != usize::MAX,
             });

--- a/frontend/src/components/presenter/mod.rs
+++ b/frontend/src/components/presenter/mod.rs
@@ -1,5 +1,6 @@
 mod data;
 mod outline;
+#[allow(clippy::module_inception)]
 mod presenter;
 mod query;
 mod settings;

--- a/frontend/src/components/presenter/presenter.rs
+++ b/frontend/src/components/presenter/presenter.rs
@@ -23,15 +23,15 @@ pub struct PresenterProps {
 pub fn presenter(props: &PresenterProps) -> Html {
     // Always start with defaults - don't load from localStorage
     // This ensures defaults are always respected on page load
-    let settings = use_state(|| SettingsData::default());
+    let settings = use_state(SettingsData::default);
     let song_data = use_state(|| None::<SongData>);
     let is_black = use_state(|| false);
     let current_outline_idx = use_state(|| 0);
     let current_text_idx = use_state(|| 0);
-    let current_text = use_state(|| String::new());
+    let current_text = use_state(String::new);
     let current_song_idx = use_state(|| 0);
     let current_song = use_state(|| None::<Song>);
-    let slide_sync = use_mut_ref(|| SlideSync::new());
+    let slide_sync = use_mut_ref(SlideSync::new);
 
     // Broadcast default settings on mount to overwrite any old localStorage values
     {
@@ -64,7 +64,7 @@ pub fn presenter(props: &PresenterProps) -> Html {
         let song_data = song_data.clone();
         let current_song = current_song.clone();
         move |(songs, settings)| {
-            if let Some(first_song) = songs.get(0) {
+            if let Some(first_song) = songs.first() {
                 song_data.set(Some(SongData::new(
                     first_song,
                     settings.max_lines_per_slide,
@@ -358,7 +358,7 @@ pub fn presenter(props: &PresenterProps) -> Html {
                     let liked = song.user_specific_addons.liked;
                     let api = api.clone();
                     wasm_bindgen_futures::spawn_local(async move {
-                        let _ = api.update_song_like_status(&id, !liked).await.unwrap();
+                        api.update_song_like_status(&id, !liked).await.unwrap();
                     });
                 }
             }

--- a/frontend/src/components/presenter/settings.rs
+++ b/frontend/src/components/presenter/settings.rs
@@ -144,7 +144,7 @@ pub fn settings(props: &SettingsProps) -> Html {
                         oninput={Callback::from(move |e: InputEvent| {
                             let input: HtmlInputElement = e.target_unchecked_into();
                             if let Ok(value) = input.value().parse::<u8>() {
-                                if value >= 1 && value <= 10 {
+                                if (1..=10).contains(&value) {
                                     set_max_lines_per_slide.emit(value);
                                 }
                             }

--- a/frontend/src/components/presenter/slide.rs
+++ b/frontend/src/components/presenter/slide.rs
@@ -13,7 +13,7 @@ pub enum SlideTextOrientation {
 }
 
 impl SlideTextOrientation {
-    pub fn to_str(&self) -> &'static str {
+    pub fn to_str(self) -> &'static str {
         match self {
             Self::Top => "text-orientation-top",
             Self::Center => "text-orientation-center",
@@ -21,7 +21,7 @@ impl SlideTextOrientation {
         }
     }
 
-    pub fn to_select_value(&self) -> &'static str {
+    pub fn to_select_value(self) -> &'static str {
         match self {
             Self::Top => "top",
             Self::Center => "center",
@@ -51,7 +51,7 @@ pub enum HorizontalContainerAlignment {
 }
 
 impl HorizontalContainerAlignment {
-    pub fn to_str(&self) -> &'static str {
+    pub fn to_str(self) -> &'static str {
         match self {
             Self::Left => "container-align-left",
             Self::Center => "container-align-center",
@@ -59,7 +59,7 @@ impl HorizontalContainerAlignment {
         }
     }
 
-    pub fn to_select_value(&self) -> &'static str {
+    pub fn to_select_value(self) -> &'static str {
         match self {
             Self::Left => "left",
             Self::Center => "center",
@@ -89,7 +89,7 @@ pub enum TextAlignment {
 }
 
 impl TextAlignment {
-    pub fn to_str(&self) -> &'static str {
+    pub fn to_str(self) -> &'static str {
         match self {
             Self::Left => "text-align-left",
             Self::Center => "text-align-center",
@@ -97,7 +97,7 @@ impl TextAlignment {
         }
     }
 
-    pub fn to_select_value(&self) -> &'static str {
+    pub fn to_select_value(self) -> &'static str {
         match self {
             Self::Left => "left",
             Self::Center => "center",
@@ -128,7 +128,7 @@ pub enum TextShadow {
 }
 
 impl TextShadow {
-    pub fn to_str(&self) -> &'static str {
+    pub fn to_str(self) -> &'static str {
         match self {
             Self::None => "text-shadow-none",
             Self::Subtle => "text-shadow-subtle",
@@ -137,7 +137,7 @@ impl TextShadow {
         }
     }
 
-    pub fn to_select_value(&self) -> &'static str {
+    pub fn to_select_value(self) -> &'static str {
         match self {
             Self::None => "none",
             Self::Subtle => "subtle",
@@ -170,7 +170,7 @@ pub enum TextTransform {
 }
 
 impl TextTransform {
-    pub fn to_str(&self) -> &'static str {
+    pub fn to_str(self) -> &'static str {
         match self {
             Self::None => "text-transform-none",
             Self::Uppercase => "text-transform-uppercase",
@@ -179,7 +179,7 @@ impl TextTransform {
         }
     }
 
-    pub fn to_select_value(&self) -> &'static str {
+    pub fn to_select_value(self) -> &'static str {
         match self {
             Self::None => "none",
             Self::Uppercase => "uppercase",

--- a/frontend/src/components/presenter/slide_sync.rs
+++ b/frontend/src/components/presenter/slide_sync.rs
@@ -6,8 +6,10 @@ use web_sys::window;
 
 const STORAGE_KEY: &str = "worshipviewer_slide_data";
 
+type StorageEventHandler = Rc<RefCell<Option<Closure<dyn FnMut(web_sys::StorageEvent)>>>>;
+
 pub struct SlideSync {
-    _closure: Rc<RefCell<Option<Closure<dyn FnMut(web_sys::StorageEvent)>>>>,
+    _closure: StorageEventHandler,
 }
 
 impl SlideSync {

--- a/frontend/src/components/setlist_editor.rs
+++ b/frontend/src/components/setlist_editor.rs
@@ -84,7 +84,7 @@ pub struct Item {
 
 fn item_from_link_and_song(link: &SongLink, song: &Song) -> Item {
     let title = song.data.title().to_string();
-    let original_key_label = song.data.key.as_ref().map(|key| format_key_label(key));
+    let original_key_label = song.data.key.as_ref().map(format_key_label);
     let key = link
         .key
         .clone()
@@ -114,9 +114,9 @@ fn move_item_to(mut items: Vec<Item>, from_idx: usize, target_idx: usize) -> Vec
 pub fn setlist_editor(props: &Props) -> Html {
     let title = use_state(|| props.setlist.title.clone());
 
-    let library_songs = use_state(|| vec![]);
+    let library_songs = use_state(std::vec::Vec::new);
     let library_loading = use_state(|| false);
-    let items = use_state(|| vec![]);
+    let items = use_state(std::vec::Vec::new);
     let search_query = use_state(String::new);
     let drag_index = use_state(|| None::<usize>);
     let drag_over_index = use_state(|| None::<usize>);
@@ -198,7 +198,7 @@ pub fn setlist_editor(props: &Props) -> Html {
                 *g = g.wrapping_add(1);
                 *g
             };
-            let query = song_library_query(&search);
+            let query = song_library_query(search);
             library_loading.set(true);
             wasm_bindgen_futures::spawn_local(async move {
                 let fetched = api.get_songs_query(query).await.unwrap_or_default();
@@ -408,9 +408,8 @@ pub fn setlist_editor(props: &Props) -> Html {
                                 <ul class="setlist">
                                     {
                                         for (*items).iter().enumerate().map(|(idx, item)| {
-                                            let total_items = total_items;
-                                            let current_drag_index = (*drag_index).clone();
-                                            let current_drag_over = (*drag_over_index).clone();
+                                            let current_drag_index = *drag_index ;
+                                            let current_drag_over = *drag_over_index ;
                                             let drag_index_handle = drag_index.clone();
                                             let drag_over_handle = drag_over_index.clone();
                                             let can_move_up = idx > 0;
@@ -465,7 +464,7 @@ pub fn setlist_editor(props: &Props) -> Html {
                                             let user_override = item
                                                 .key
                                                 .as_ref()
-                                                .map(|key| format_key_label(key));
+                                                .map(format_key_label);
                                             let select_value = user_override.clone().unwrap_or_else(|| default_key_value.clone());
                                             let onchange = {
                                                 let items = items.clone();
@@ -513,7 +512,7 @@ pub fn setlist_editor(props: &Props) -> Html {
                                             let on_drop = Callback::from(move |event: DragEvent| {
                                                 event.prevent_default();
                                                 event.stop_propagation();
-                                                if let Some(from_idx) = (*drag_index_for_drop).clone() {
+                                                if let Some(from_idx) = *drag_index_for_drop  {
                                                     let new_items = move_item_to((*items_for_drop).clone(), from_idx, index);
                                                     items_for_drop.set(new_items);
                                                 }
@@ -546,7 +545,7 @@ pub fn setlist_editor(props: &Props) -> Html {
                                             let drag_index_for_touch_end = drag_index_handle.clone();
                                             let drag_over_for_touch_end = drag_over_handle.clone();
                                             let on_touch_end = Callback::from(move |event: TouchEvent| {
-                                                if let Some(from_idx) = (*drag_index_for_touch_end).clone() {
+                                                if let Some(from_idx) = *drag_index_for_touch_end  {
                                                     let new_items = move_item_to((*items_for_touch_end).clone(), from_idx, index);
                                                     items_for_touch_end.set(new_items);
                                                 }
@@ -627,7 +626,7 @@ pub fn setlist_editor(props: &Props) -> Html {
                                     {
                                         if (*drag_index).is_some() {
                                             let target_idx = total_items;
-                                            let current_drag_over_end = (*drag_over_index).clone();
+                                            let current_drag_over_end = *drag_over_index ;
                                             let drag_over_for_over = drag_over_index.clone();
                                             let on_drag_over_end = Callback::from(move |event: DragEvent| {
                                                 event.prevent_default();
@@ -640,7 +639,7 @@ pub fn setlist_editor(props: &Props) -> Html {
                                             let on_drop_end = Callback::from(move |event: DragEvent| {
                                                 event.prevent_default();
                                                 event.stop_propagation();
-                                                if let Some(from_idx) = (*drag_index_for_drop).clone() {
+                                                if let Some(from_idx) = *drag_index_for_drop  {
                                                     let new_items = move_item_to((*items_for_drop).clone(), from_idx, target_idx);
                                                     items_for_drop.set(new_items);
                                                 }
@@ -657,7 +656,7 @@ pub fn setlist_editor(props: &Props) -> Html {
                                             let drag_over_for_touch_end = drag_over_index.clone();
                                             let items_for_touch_end = items.clone();
                                             let on_touch_end_end = Callback::from(move |event: TouchEvent| {
-                                                if let Some(from_idx) = (*drag_index_for_touch_end).clone() {
+                                                if let Some(from_idx) = *drag_index_for_touch_end  {
                                                     let new_items = move_item_to((*items_for_touch_end).clone(), from_idx, target_idx);
                                                     items_for_touch_end.set(new_items);
                                                 }
@@ -754,7 +753,7 @@ pub fn setlist_editor(props: &Props) -> Html {
                                                 .data
                                                 .key
                                                 .as_ref()
-                                                .map(|key| format_key_label(key));
+                                                .map(format_key_label);
                                             let key = song_key_label.clone().unwrap_or_else(|| "—".into());
                                             let occurrences = setlist_counts.get(&id).cloned().unwrap_or(0);
                                             let already_added = occurrences > 0;

--- a/frontend/src/components/song_viewer.rs
+++ b/frontend/src/components/song_viewer.rs
@@ -22,7 +22,7 @@ pub fn song_viewer(props: &Props) -> Html {
         props.override_key.as_ref(),
         props.override_representation.as_ref(),
         None,
-        Some(scale as f32),
+        Some(scale),
     );
     html! {
         <div

--- a/frontend/src/components/string_input.rs
+++ b/frontend/src/components/string_input.rs
@@ -40,12 +40,12 @@ pub fn string_input(props: &Props) -> Html {
     };
     let value = (*props.bind_handle).clone();
 
-    if props.options.len() > 0 {
+    if !props.options.is_empty() {
         let mut options = props
             .options
             .iter()
+            .filter(|&s| *s != value)
             .cloned()
-            .filter(|s| *s != value)
             .collect::<Vec<String>>();
 
         options.push(value.clone());

--- a/frontend/src/pages/collections.rs
+++ b/frontend/src/pages/collections.rs
@@ -9,7 +9,7 @@ use crate::api::use_api;
 
 #[function_component(CollectionsPage)]
 pub fn collection_page() -> Html {
-    let collections = use_state(|| Vec::<Collection>::new());
+    let collections = use_state(Vec::<Collection>::new);
     let api = use_api();
     let navigator = use_navigator().unwrap();
 

--- a/frontend/src/pages/player/mod.rs
+++ b/frontend/src/pages/player/mod.rs
@@ -1,5 +1,6 @@
 mod page;
 mod pages;
+#[allow(clippy::module_inception)]
 mod player;
 mod toc;
 

--- a/frontend/src/pages/player/page.rs
+++ b/frontend/src/pages/player/page.rs
@@ -26,7 +26,7 @@ pub fn page_components(props: &Props) -> Html {
                 <SongViewer
                     song={c.song.clone()}
                     override_key={props.override_key.clone()}
-                    override_representation={props.override_representation.clone()}
+                    override_representation={props.override_representation}
                 />
             }
         }

--- a/frontend/src/pages/player/pages.rs
+++ b/frontend/src/pages/player/pages.rs
@@ -52,7 +52,7 @@ pub fn pages_component(props: &Props) -> Html {
         props.half_page_scroll,
         props.item2.is_some(),
     );
-    let page_width = if props.half_page_scroll || !props.item2.is_some() {
+    let page_width = if props.half_page_scroll || props.item2.is_none() {
         content_dimensions.0
     } else {
         content_dimensions.0 / 2
@@ -76,7 +76,7 @@ pub fn pages_component(props: &Props) -> Html {
                         item={props.item.clone()}
                         font_size={font_size}
                         override_key={props.override_key.clone()}
-                        override_representation={props.override_representation.clone()}
+                        override_representation={props.override_representation}
                     />
                 </div>
                 if let Some(item) = props.item2.clone() {
@@ -88,7 +88,7 @@ pub fn pages_component(props: &Props) -> Html {
                             item={item}
                             font_size={font_size}
                             override_key={props.override_key.clone()}
-                            override_representation={props.override_representation.clone()}
+                            override_representation={props.override_representation}
                         />
                     </div>
                 }

--- a/frontend/src/pages/player/player.rs
+++ b/frontend/src/pages/player/player.rs
@@ -4,7 +4,7 @@ use crate::components::{Topbar, TopbarButton, TopbarSelect, TopbarSelectOption, 
 use crate::route::Route;
 use gloo::timers::callback::Timeout;
 use serde::Deserialize;
-use shared::player::{Orientation, PlayerBlobItem, PlayerItem, TocItem};
+use shared::player::{Orientation, PlayerBlobItem, PlayerItem};
 use shared::song::{ChordRepresentation, SimpleChord};
 use std::collections::HashMap;
 use stylist::{css, yew::Global, Style};
@@ -133,7 +133,7 @@ pub fn player_page() -> Html {
         };
 
         move |_: MouseEvent| {
-            if &id == "" {
+            if id.is_empty() {
                 return;
             }
             navigator
@@ -150,7 +150,7 @@ pub fn player_page() -> Html {
         let id = query.setlist.clone().unwrap_or("".to_string());
 
         move |_: MouseEvent| {
-            if &id == "" {
+            if id.is_empty() {
                 return;
             }
             navigator
@@ -418,9 +418,9 @@ pub fn player_page() -> Html {
                     html! {
                         <PagesComponent
                             item={player.item().0.clone()}
-                            item2={player.item().1.map(|item| item.clone())}
+                            item2={player.item().1.cloned()}
                             override_key={(*override_key).clone()}
-                            override_representation={(*override_representation).clone()}
+                            override_representation={*override_representation }
                             half_page_scroll={player.is_half_page_scroll()}
                             active={*active}
                         />
@@ -434,7 +434,7 @@ pub fn player_page() -> Html {
                     class={if let PlayerItem::Chords(_) = player.item().0 { "visible" } else { "invisible" }}
                 >
                     {
-                        vec!["default", "nashville"]
+                        ["default", "nashville"]
                             .iter()
                             .map(|option| html! {
                                 <option
@@ -450,12 +450,12 @@ pub fn player_page() -> Html {
                     class={if let PlayerItem::Chords(_) = player.item().0 { "visible" } else { "invisible" }}
                 >
                     {
-                        vec!["default", "A", "Bb", "B", "C", "Db", "D", "Eb", "E", "F", "F#", "G", "Ab"]
+                        ["default", "A", "Bb", "B", "C", "Db", "D", "Eb", "E", "F", "F#", "G", "Ab"]
                             .iter()
                             .map(|option| html! {
                                 <option
                                     value={&**option}
-                                    selected={ *option == (*override_key).as_ref().map(|key| SimpleChord::default().format(&key, &ChordRepresentation::Default).as_ref()).unwrap_or("default") }>
+                                    selected={ *option == (*override_key).as_ref().map(|key| SimpleChord::default().format(key, &ChordRepresentation::Default)).unwrap_or("default") }>
                                     {option}
                                 </option>})
                             .collect::<Html>()
@@ -486,7 +486,7 @@ pub fn player_page() -> Html {
             </div>
             <div class={if *active && player.toc().len() > 1 {"toc active"}else{"toc"}}>
                 <TableOfContentsComponent
-                    list={player.toc().iter().map(|item| item.clone()).collect::<Vec<TocItem>>()}
+                    list={player.toc().to_vec()}
                     select={index_jump_callback}
                 />
             </div>

--- a/frontend/src/pages/player/toc.rs
+++ b/frontend/src/pages/player/toc.rs
@@ -60,7 +60,7 @@ pub fn table_of_contents_component(props: &Props) -> Html {
                 let idx = item.idx;
                 move |_: MouseEvent| select.emit(idx)
             };
-            if *filter_sort == FilterSort::Real && item.nr.len() > 0 {
+            if *filter_sort == FilterSort::Real && !item.nr.is_empty() {
                 html! {
                     <li onclick={onclick}>{format!("{}. {}", &item.nr, &item.title)}</li>
                 }

--- a/frontend/src/pages/presenter.rs
+++ b/frontend/src/pages/presenter.rs
@@ -11,7 +11,7 @@ pub fn presenter_page() -> Html {
         .query::<PresenterQuery>()
         .unwrap_or(PresenterQuery::default());
 
-    let songs = use_state(|| Vec::<Song>::new());
+    let songs = use_state(Vec::<Song>::new);
     let api = use_api();
     {
         let songs = songs.clone();

--- a/frontend/src/pages/presenter_slides.rs
+++ b/frontend/src/pages/presenter_slides.rs
@@ -12,7 +12,7 @@ pub fn presenter_page() -> Html {
         expand: true,
     });
 
-    let slide_sync_ref = use_mut_ref(|| SlideSync::new());
+    let slide_sync_ref = use_mut_ref(SlideSync::new);
 
     use_effect_with((), {
         let slide_sync_ref = slide_sync_ref.clone();
@@ -45,10 +45,10 @@ pub fn presenter_page() -> Html {
             ondblclick={ondblclick}
         >
             <Slide
-                text={(*slide_props).text.clone()}
-                settings={(*slide_props).settings.clone()}
-                is_black={(*slide_props).is_black}
-                expand={(*slide_props).expand}
+                text={slide_props.text.clone()}
+                settings={slide_props.settings.clone()}
+                is_black={slide_props.is_black}
+                expand={slide_props.expand}
             />
         </div>
     }

--- a/frontend/src/pages/setlists.rs
+++ b/frontend/src/pages/setlists.rs
@@ -8,7 +8,7 @@ use yew_router::prelude::*;
 
 #[function_component(SetlistsPage)]
 pub fn setlists_page() -> Html {
-    let setlists = use_state(|| Vec::<Setlist>::new());
+    let setlists = use_state(Vec::<Setlist>::new);
     let api = use_api();
 
     {

--- a/frontend/src/pages/songs.rs
+++ b/frontend/src/pages/songs.rs
@@ -8,7 +8,7 @@ use yew_router::prelude::*;
 
 #[function_component(SongsPage)]
 pub fn songs_page() -> Html {
-    let songs = use_state(|| Vec::<Song>::new());
+    let songs = use_state(Vec::<Song>::new);
     let api = use_api();
 
     {

--- a/frontend/src/route.rs
+++ b/frontend/src/route.rs
@@ -74,10 +74,7 @@ impl Navable for Route {
         html! {
             <Layout<Route>
                 nav_routes={Route::route_items()}
-                fullscreen={match route {
-                    Route::Player | Route::Editor | Route::SetlistEditor | Route::Login | Route::Logout | Route::Presenter | Route::PresenterSlides => true,
-                    _ => false,
-                }}
+                fullscreen={matches!(route, Route::Player | Route::Editor | Route::SetlistEditor | Route::Login | Route::Logout | Route::Presenter | Route::PresenterSlides)}
             >{
                 match route {
                     Route::Index => html! { <IndexPage /> },


### PR DESCRIPTION
## Summary
- Resolve all frontend Clippy warnings when building for `wasm32-unknown-unknown` with `-D warnings`
- Disable native `cargo test` on the WASM binary target in `Cargo.toml`
- Remove unused `build_path` helper from the API client

## Test plan
- [x] `cargo clippy --manifest-path frontend/Cargo.toml --target wasm32-unknown-unknown -- -D warnings`
- [ ] Verify frontend WASM build still succeeds (`trunk build` or project build script)