### PR TITLE
fix(backend): store profile picture bytes in one blob write

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -16,6 +16,8 @@ rules:
   info-contact: off
   # Deprecated / query shapes referenced indirectly.
   oas3-unused-component: off
+  # Crashes Spectral 6 on utoipa `oneOf: [{ type: null }, …]` nullable fields (reads enum on null).
+  duplicated-entry-in-enum: off
 
   oas3-schema-properties-snake-case:
     description: Every property name under components.schemas must be snake_case ASCII

--- a/backend/src/resources/blob/service.rs
+++ b/backend/src/resources/blob/service.rs
@@ -167,14 +167,9 @@ impl<R: BlobRepository, S: BlobStorage> BlobService<R, S> {
         id: &str,
         data: &[u8],
     ) -> Result<(), AppError> {
-        // Reuse update_blob for the permission check: it scopes by write_teams and returns
-        // 404 if the caller has no write access, which is exactly the right behavior here.
-        let write_teams = ctx.write_teams();
-        let blob = self
-            .repo
-            .get_blob(&write_teams, id)
-            .await
-            .map_err(|_| AppError::NotFound("blob not found or write access denied".into()))?;
+        let blob = self.get_blob_for_user(ctx, id).await?;
+        let owner = parse_owner_record_id(&blob.owner)?;
+        ctx.require_write_access_to_owner(&owner)?;
         self.storage.write_blob_bytes(&blob, data)
     }
 

--- a/backend/src/resources/user/profile_picture.rs
+++ b/backend/src/resources/user/profile_picture.rs
@@ -49,7 +49,14 @@ pub fn avatar_dimensions(data: &[u8]) -> Result<(u32, u32), AppError> {
 }
 
 pub fn file_type_from_content_type(ct: &str) -> Result<FileType, AppError> {
-    match ct.trim().to_ascii_lowercase().as_str() {
+    let base = ct
+        .trim()
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase();
+    match base.as_str() {
         "image/jpeg" | "image/jpg" => Ok(FileType::JPEG),
         "image/png" => Ok(FileType::PNG),
         _ => Err(AppError::invalid_request(
@@ -147,5 +154,17 @@ mod tests {
     fn http_scheme_rejected() {
         let u = Url::parse("http://lh3.googleusercontent.com/x").unwrap();
         assert!(!oauth_picture_url_allowed(&u));
+    }
+
+    #[test]
+    fn content_type_strips_charset_suffix() {
+        assert_eq!(
+            file_type_from_content_type("image/jpeg; charset=binary").unwrap(),
+            FileType::JPEG
+        );
+        assert_eq!(
+            file_type_from_content_type("image/png; charset=UTF-8").unwrap(),
+            FileType::PNG
+        );
     }
 }

--- a/backend/src/resources/user/service.rs
+++ b/backend/src/resources/user/service.rs
@@ -187,8 +187,8 @@ impl UserServiceHandle {
             );
         }
 
-        let created = blob_svc
-            .create_blob_for_user(
+        let created = match blob_svc
+            .create_blob_with_data_for_user(
                 ctx,
                 CreateBlob {
                     owner: None,
@@ -197,21 +197,20 @@ impl UserServiceHandle {
                     height: h,
                     ocr: String::new(),
                 },
+                &bytes,
             )
-            .await?;
-
-        if let Err(e) = blob_svc
-            .upload_blob_data_for_user(ctx, &created.id, &bytes)
             .await
         {
-            tracing::warn!(
-                user_id = %ctx.user.id,
-                error = %e,
-                "failed to write oauth avatar bytes; cleaning up blob"
-            );
-            let _ = blob_svc.delete_blob_for_user(ctx, &created.id).await;
-            return Ok(());
-        }
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!(
+                    user_id = %ctx.user.id,
+                    error = %e,
+                    "failed to store oauth avatar blob"
+                );
+                return Ok(());
+            }
+        };
 
         if let Err(e) = self
             .repo
@@ -250,7 +249,7 @@ impl UserServiceHandle {
         }
 
         let created = blob_svc
-            .create_blob_for_user(
+            .create_blob_with_data_for_user(
                 ctx,
                 CreateBlob {
                     owner: None,
@@ -259,11 +258,8 @@ impl UserServiceHandle {
                     height: h,
                     ocr: String::new(),
                 },
+                body,
             )
-            .await?;
-
-        blob_svc
-            .upload_blob_data_for_user(ctx, &created.id, body)
             .await?;
 
         self.repo


### PR DESCRIPTION
## Summary
- Profile picture and OAuth avatar uploads now use `create_blob_with_data_for_user`, matching collection cover uploads (single write instead of empty blob + separate data PUT).
- `upload_blob_data_for_user` checks read access then `require_write_access_to_owner` on the blob owner.
- `file_type_from_content_type` ignores `; charset=…` suffixes (e.g. from some browsers).

## Test plan
- [ ] `PUT /api/v1/users/me/profile-picture` with a JPEG/PNG under 2 MiB returns 200 and `avatar_blob_id`; preview loads via `GET /api/v1/blobs/{id}/data`.
- [ ] Same file that works as a collection cover also works as profile picture when under the avatar size limit.
- [ ] `cargo test` in `backend/` passes.