### PR TITLE
Add atomic transfer endpoint for moving songs between collections

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2341,6 +2341,61 @@
         ],
         "type": "object"
       },
+      "TransferCollectionSong": {
+        "additionalProperties": false,
+        "description": "Move a song link from this collection into another (`POST …/collections/{id}/songs/{song_id}/transfer`).",
+        "example": {
+          "key": {
+            "level": 3
+          },
+          "nr": "3",
+          "target": "col_target"
+        },
+        "properties": {
+          "key": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleChord",
+                "description": "Optional slot key override from the editor row."
+              }
+            ]
+          },
+          "nr": {
+            "description": "Optional slot number override from the editor row.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "target": {
+            "description": "Destination collection id.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "target"
+        ],
+        "type": "object"
+      },
+      "TransferCollectionSongResult": {
+        "description": "Updated source and target collections after a successful transfer.",
+        "properties": {
+          "source": {
+            "$ref": "#/components/schemas/Collection"
+          },
+          "target": {
+            "$ref": "#/components/schemas/Collection"
+          }
+        },
+        "required": [
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
       "UpdateBlob": {
         "additionalProperties": false,
         "description": "Full replacement body for `PUT /api/v1/blobs/{id}` metadata (same shape as [`CreateBlob`]; does not upload bytes).",
@@ -4551,6 +4606,124 @@
               }
             },
             "description": "Failed to fetch collection songs"
+          }
+        },
+        "security": [
+          {
+            "SessionCookie": []
+          },
+          {
+            "SessionToken": []
+          }
+        ],
+        "tags": [
+          "Collections"
+        ]
+      }
+    },
+    "/api/v1/collections/{id}/songs/{song_id}/transfer": {
+      "post": {
+        "operationId": "transfer_collection_song",
+        "parameters": [
+          {
+            "description": "Source collection identifier",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Song identifier to move",
+            "in": "path",
+            "name": "song_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransferCollectionSong"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransferCollectionSongResult"
+                }
+              }
+            },
+            "description": "Song link moved from source to target collection atomically."
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Invalid identifiers or source equals target"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Collection or song slot not found, or caller lacks library write access"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Song already in target collection"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "API rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Failed to transfer song between collections"
           }
         },
         "security": [

--- a/backend/src/docs.rs
+++ b/backend/src/docs.rs
@@ -26,6 +26,7 @@ use shared::MoveOwner;
 use shared::api::SongListQuery;
 use shared::auth::otp::{OtpRequest, OtpVerify};
 use shared::blob::{BlobLink, FileType};
+use shared::collection::{TransferCollectionSong, TransferCollectionSongResult};
 pub use shared::error::{ErrorResponse, Problem, ProblemDetails};
 use shared::like::LikeStatus;
 use shared::player::{
@@ -162,6 +163,7 @@ fn apply_openapi_runtime_metadata(doc: &mut utoipa::openapi::OpenApi, settings: 
         crate::resources::collection::rest::put_collection_cover,
         crate::resources::collection::rest::patch_collection,
         crate::resources::collection::rest::move_collection,
+        crate::resources::collection::rest::transfer_collection_song,
         crate::resources::collection::rest::delete_collection,
         crate::resources::blob::rest::get_blobs,
         crate::resources::blob::rest::get_blob,
@@ -230,6 +232,8 @@ fn apply_openapi_runtime_metadata(doc: &mut utoipa::openapi::OpenApi, settings: 
             CreateCollection,
             UpdateCollection,
             PatchCollection,
+            TransferCollectionSong,
+            TransferCollectionSongResult,
             Setlist,
             CreateSetlist,
             UpdateSetlist,

--- a/backend/src/resources/collection/mod.rs
+++ b/backend/src/resources/collection/mod.rs
@@ -1,4 +1,7 @@
-pub use shared::collection::{Collection, CreateCollection, PatchCollection, UpdateCollection};
+pub use shared::collection::{
+    Collection, CreateCollection, PatchCollection, TransferCollectionSong,
+    TransferCollectionSongResult, UpdateCollection,
+};
 
 mod model;
 mod repository;

--- a/backend/src/resources/collection/repository.rs
+++ b/backend/src/resources/collection/repository.rs
@@ -69,4 +69,22 @@ pub trait CollectionRepository: Send + Sync {
         id: &str,
         song_link: SongLink,
     ) -> Result<(), AppError>;
+
+    /// Atomically remove `song_id` from `source_id` and append `link` to `target_id`.
+    async fn transfer_song_link_between_collections(
+        &self,
+        write_teams: &[RecordId],
+        source_id: &str,
+        target_id: &str,
+        song_id: &str,
+        link: SongLink,
+    ) -> Result<(Collection, Collection), AppError>;
+
+    /// Remove `song_id` from `source_id` only (repair / unlink without deleting the song).
+    async fn remove_song_link_from_collection(
+        &self,
+        write_teams: &[RecordId],
+        source_id: &str,
+        song_id: &str,
+    ) -> Result<Collection, AppError>;
 }

--- a/backend/src/resources/collection/rest.rs
+++ b/backend/src/resources/collection/rest.rs
@@ -13,9 +13,11 @@ use crate::http_cache::{check_if_match, if_none_match_matches, weak_etag_json};
 use crate::resources::blob::service::BlobServiceHandle;
 #[allow(unused_imports)]
 use crate::resources::collection::Collection;
-use crate::resources::collection::PatchCollection;
 use crate::resources::collection::service::CollectionServiceHandle;
 use crate::resources::collection::{CreateCollection, UpdateCollection};
+use crate::resources::collection::{
+    PatchCollection, TransferCollectionSong, TransferCollectionSongResult,
+};
 #[allow(unused_imports)]
 use crate::resources::song::Song;
 use crate::settings::CoverUploadLimits;
@@ -35,6 +37,7 @@ pub fn scope(cover_upload_max_bytes: usize) -> Scope {
         .service(update_collection)
         .service(patch_collection)
         .service(move_collection)
+        .service(transfer_collection_song)
         .service(delete_collection)
         .service(put_collection_cover)
 }
@@ -439,6 +442,48 @@ async fn move_collection(
     Ok(HttpResponse::Ok().json(
         svc.move_collection_for_user(&ctx, &id.into_inner(), payload.into_inner())
             .await?,
+    ))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/collections/{id}/songs/{song_id}/transfer",
+    params(
+        ("id" = String, Path, description = "Source collection identifier"),
+        ("song_id" = String, Path, description = "Song identifier to move")
+    ),
+    request_body = TransferCollectionSong,
+    responses(
+        (status = 200, description = "Song link moved from source to target collection atomically.", body = TransferCollectionSongResult),
+        (status = 400, description = "Invalid identifiers or source equals target", body = Problem, content_type = "application/problem+json"),
+        (status = 401, description = "Authentication required", body = Problem, content_type = "application/problem+json"),
+        (status = 404, description = "Collection or song slot not found, or caller lacks library write access", body = Problem, content_type = "application/problem+json"),
+        (status = 409, description = "Song already in target collection", body = Problem, content_type = "application/problem+json"),
+        (status = 429, description = "API rate limit exceeded", body = Problem, content_type = "application/problem+json"),
+        (status = 500, description = "Failed to transfer song between collections", body = Problem, content_type = "application/problem+json")
+    ),
+    tag = "Collections",
+    security(
+        ("SessionCookie" = []),
+        ("SessionToken" = [])
+    )
+)]
+#[post("/{id}/songs/{song_id}/transfer")]
+async fn transfer_collection_song(
+    svc: Data<CollectionServiceHandle>,
+    ctx: ReqData<AuthorizationContext>,
+    path: Path<(String, String)>,
+    payload: Json<TransferCollectionSong>,
+) -> Result<HttpResponse, AppError> {
+    let (source_id, song_id) = path.into_inner();
+    Ok(HttpResponse::Ok().json(
+        svc.transfer_song_between_collections_for_user(
+            &ctx,
+            &source_id,
+            &song_id,
+            payload.into_inner(),
+        )
+        .await?,
     ))
 }
 

--- a/backend/src/resources/collection/service.rs
+++ b/backend/src/resources/collection/service.rs
@@ -4,7 +4,10 @@ use std::sync::Arc;
 use shared::MoveOwner;
 use shared::api::ListQuery;
 use shared::blob::CreateBlob;
-use shared::collection::{Collection, CreateCollection, PatchCollection};
+use shared::collection::{
+    Collection, CreateCollection, PatchCollection, TransferCollectionSong,
+    TransferCollectionSongResult,
+};
 use shared::player::Player;
 use shared::song::{Link as SongLink, Song};
 use tracing::instrument;
@@ -185,6 +188,66 @@ impl<R: CollectionRepository, L: LikedSongIds> CollectionService<R, L> {
     }
 
     #[instrument(level = "debug", err, skip(self, ctx, payload))]
+    pub async fn transfer_song_between_collections_for_user(
+        &self,
+        ctx: &AuthorizationContext,
+        source_id: &str,
+        song_id: &str,
+        payload: TransferCollectionSong,
+    ) -> Result<TransferCollectionSongResult, AppError> {
+        if source_id == payload.target {
+            return Err(AppError::invalid_request(
+                "source and target collection must differ",
+            ));
+        }
+        let write_teams = ctx.write_teams();
+        let source = self.repo.get_collection(&write_teams, source_id).await?;
+        let target = self
+            .repo
+            .get_collection(&write_teams, &payload.target)
+            .await?;
+
+        let song_key = song_link_id_key(song_id);
+        let from_source = source
+            .songs
+            .iter()
+            .find(|l| song_link_id_key(&l.id) == song_key)
+            .ok_or_else(|| AppError::NotFound("song not in source collection".into()))?;
+
+        let already_in_target = target
+            .songs
+            .iter()
+            .any(|l| song_link_id_key(&l.id) == song_key);
+
+        if already_in_target {
+            let source = self
+                .repo
+                .remove_song_link_from_collection(&write_teams, source_id, song_id)
+                .await?;
+            return Ok(TransferCollectionSongResult { source, target });
+        }
+
+        let link = SongLink {
+            id: from_source.id.clone(),
+            key: payload.key.or_else(|| from_source.key.clone()),
+            nr: payload.nr.or_else(|| from_source.nr.clone()),
+        };
+
+        let (source, target) = self
+            .repo
+            .transfer_song_link_between_collections(
+                &write_teams,
+                source_id,
+                &payload.target,
+                song_id,
+                link,
+            )
+            .await?;
+
+        Ok(TransferCollectionSongResult { source, target })
+    }
+
+    #[instrument(level = "debug", err, skip(self, ctx, payload))]
     pub async fn move_collection_for_user(
         &self,
         ctx: &AuthorizationContext,
@@ -285,6 +348,7 @@ impl CollectionServiceHandle {
 
 #[cfg(test)]
 mod tests {
+    use chordlib::types::SimpleChord;
     use shared::song::Link as SongLink;
 
     use crate::error::AppError;
@@ -979,6 +1043,155 @@ mod tests {
             .await
             .expect("unchanged");
         assert_eq!(still.songs.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn transfer_song_between_collections_moves_link_atomically() {
+        use shared::collection::TransferCollectionSong;
+
+        let (db, owner, _cm, _guest, _nm, _tid) = four_user_coll_fixture().await;
+        let svc = CollectionServiceHandle::build(db.clone());
+        let owner_p = auth_ctx_for_user(&db, &owner).await.expect("auth");
+        let s1 = create_song_with_title(&db, &owner, "Transfer Me")
+            .await
+            .expect("s1");
+        let source = svc
+            .create_collection_for_user(
+                &owner_p,
+                CreateCollection {
+                    owner: None,
+                    title: "Source".into(),
+                    cover: "".into(),
+                    songs: vec![shared::song::Link {
+                        id: s1.id.clone(),
+                        nr: Some("1".into()),
+                        key: Some(SimpleChord::new(3)),
+                    }],
+                },
+            )
+            .await
+            .expect("source");
+        let target = svc
+            .create_collection_for_user(
+                &owner_p,
+                CreateCollection {
+                    owner: None,
+                    title: "Target".into(),
+                    cover: "".into(),
+                    songs: vec![],
+                },
+            )
+            .await
+            .expect("target");
+
+        let result = svc
+            .transfer_song_between_collections_for_user(
+                &owner_p,
+                &source.id,
+                &s1.id,
+                TransferCollectionSong {
+                    target: target.id.clone(),
+                    key: Some(SimpleChord::new(7)),
+                    nr: Some("2".into()),
+                },
+            )
+            .await
+            .expect("transfer");
+
+        assert!(result.source.songs.is_empty());
+        assert_eq!(result.source.id, source.id);
+        assert_eq!(result.target.songs.len(), 1);
+        assert_eq!(result.target.songs[0].id, s1.id);
+        assert_eq!(result.target.songs[0].key, Some(SimpleChord::new(7)));
+        assert_eq!(result.target.songs[0].nr.as_deref(), Some("2"));
+
+        let r = svc
+            .transfer_song_between_collections_for_user(
+                &owner_p,
+                &source.id,
+                &s1.id,
+                TransferCollectionSong {
+                    target: target.id,
+                    key: None,
+                    nr: None,
+                },
+            )
+            .await;
+        assert!(matches!(r, Err(AppError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn transfer_unlinks_source_when_song_already_in_target() {
+        use shared::collection::{PatchCollection, TransferCollectionSong};
+
+        let (db, owner, _cm, _guest, _nm, _tid) = four_user_coll_fixture().await;
+        let svc = CollectionServiceHandle::build(db.clone());
+        let owner_p = auth_ctx_for_user(&db, &owner).await.expect("auth");
+        let s1 = create_song_with_title(&db, &owner, "Duplicate slot")
+            .await
+            .expect("s1");
+        let source = svc
+            .create_collection_for_user(
+                &owner_p,
+                CreateCollection {
+                    owner: None,
+                    title: "Dup Source".into(),
+                    cover: "".into(),
+                    songs: vec![shared::song::Link {
+                        id: s1.id.clone(),
+                        nr: Some("1".into()),
+                        key: None,
+                    }],
+                },
+            )
+            .await
+            .expect("source");
+        let target = svc
+            .create_collection_for_user(
+                &owner_p,
+                CreateCollection {
+                    owner: None,
+                    title: "Dup Target".into(),
+                    cover: "".into(),
+                    songs: vec![],
+                },
+            )
+            .await
+            .expect("target");
+        svc.patch_collection_for_user(
+            &owner_p,
+            &target.id,
+            PatchCollection {
+                title: None,
+                cover: None,
+                songs: Some(vec![shared::song::Link {
+                    id: s1.id.clone(),
+                    nr: Some("9".into()),
+                    key: None,
+                }]),
+                owner: None,
+            },
+        )
+        .await
+        .expect("seed target");
+
+        let result = svc
+            .transfer_song_between_collections_for_user(
+                &owner_p,
+                &source.id,
+                &s1.id,
+                TransferCollectionSong {
+                    target: target.id.clone(),
+                    key: None,
+                    nr: None,
+                },
+            )
+            .await
+            .expect("repair");
+
+        assert!(result.source.songs.is_empty());
+        assert_eq!(result.target.songs.len(), 1);
+        assert_eq!(result.target.songs[0].nr.as_deref(), Some("9"));
     }
 
     /// BLC-COLL-024: PATCH cannot drop an existing song id from `songs`.

--- a/backend/src/resources/collection/surreal_repo.rs
+++ b/backend/src/resources/collection/surreal_repo.rs
@@ -14,6 +14,7 @@ use crate::database::{Database, surreal_take_errors};
 use crate::error::AppError;
 use crate::resources::common::{
     SongLinkListRow, SongLinkRecord, belongs_to, blob_thing, resource_id, song_links_to_owned,
+    song_thing,
 };
 
 use super::model::CollectionRecord;
@@ -286,5 +287,101 @@ impl CollectionRepository for SurrealCollectionRepo {
         })?;
 
         Ok(())
+    }
+
+    async fn transfer_song_link_between_collections(
+        &self,
+        write_teams: &[RecordId],
+        source_id: &str,
+        target_id: &str,
+        song_id: &str,
+        link: SongLink,
+    ) -> Result<(Collection, Collection), AppError> {
+        let db = self.inner();
+        let song_rid = song_thing(song_id);
+        let link_record = SongLinkRecord::from(link);
+        let teams = write_teams.to_vec();
+
+        let mut response = db
+            .db
+            .query(
+                r#"UPDATE type::record("collection", $source_id)
+  SET songs = fn::song_link_array_without_song(songs, $song_rid)
+  WHERE owner IN $teams AND $song_rid INSIDE array::map(songs, |$e| $e.id)
+  RETURN AFTER;
+UPDATE type::record("collection", $target_id)
+  SET songs = array::append(songs, $link)
+  WHERE owner IN $teams AND NOT ($song_rid INSIDE array::map(songs, |$e| $e.id))
+  RETURN AFTER;"#,
+            )
+            .bind(("source_id", source_id.to_owned()))
+            .bind(("target_id", target_id.to_owned()))
+            .bind(("song_rid", song_rid))
+            .bind(("link", link_record))
+            .bind(("teams", teams))
+            .await?;
+
+        surreal_take_errors(
+            "collection.transfer_song_link_between_collections",
+            &mut response,
+        )?;
+
+        let source_rows: Vec<CollectionRecord> = response.take(0)?;
+        let target_rows: Vec<CollectionRecord> = response.take(1)?;
+
+        let source = source_rows
+            .into_iter()
+            .next()
+            .map(CollectionRecord::into_collection)
+            .ok_or_else(|| {
+                AppError::NotFound(
+                    "song not found in source collection or collection not writable".into(),
+                )
+            })?;
+        let target = target_rows
+            .into_iter()
+            .next()
+            .map(CollectionRecord::into_collection)
+            .ok_or_else(|| {
+                AppError::NotFound(
+                    "target collection not found, not writable, or song already present".into(),
+                )
+            })?;
+
+        Ok((source, target))
+    }
+
+    async fn remove_song_link_from_collection(
+        &self,
+        write_teams: &[RecordId],
+        source_id: &str,
+        song_id: &str,
+    ) -> Result<Collection, AppError> {
+        let db = self.inner();
+        let song_rid = song_thing(song_id);
+        let mut response = db
+            .db
+            .query(
+                r#"UPDATE type::record("collection", $source_id)
+  SET songs = fn::song_link_array_without_song(songs, $song_rid)
+  WHERE owner IN $teams AND $song_rid INSIDE array::map(songs, |$e| $e.id)
+  RETURN AFTER;"#,
+            )
+            .bind(("source_id", source_id.to_owned()))
+            .bind(("song_rid", song_rid))
+            .bind(("teams", write_teams.to_vec()))
+            .await?;
+
+        surreal_take_errors("collection.remove_song_link_from_collection", &mut response)?;
+
+        let rows: Vec<CollectionRecord> = response.take(0)?;
+        rows.into_iter()
+            .next()
+            .map(CollectionRecord::into_collection)
+            .ok_or_else(|| {
+                AppError::NotFound(
+                    "song not found in source collection or collection not writable".into(),
+                )
+            })
     }
 }

--- a/backend/tests/5_collections.yml
+++ b/backend/tests/5_collections.yml
@@ -1112,6 +1112,214 @@ testcases:
           - result.statuscode ShouldEqual 200
           - result.bodyjson.songs ShouldHaveLength 3
 
+  # POST /api/v1/collections/{id}/songs/{song_id}/transfer
+  - name: post-collection-transfer-source
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/collections"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+          Content-Type: application/json
+        body: |
+          {
+            "title": "Transfer Source",
+            "cover": "cover-transfer-src",
+            "songs": [
+              { "id": "{{.create-collection-song-two.songid}}", "nr": "src" }
+            ]
+          }
+        assertions:
+          - result.statuscode ShouldEqual 201
+          - result.bodyjson.songs ShouldHaveLength 1
+        vars:
+          collectionid:
+            from: result.bodyjson.id
+
+  - name: post-collection-transfer-target
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/collections"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+          Content-Type: application/json
+        body: |
+          {
+            "title": "Transfer Target",
+            "cover": "cover-transfer-tgt",
+            "songs": []
+          }
+        assertions:
+          - result.statuscode ShouldEqual 201
+          - result.bodyjson.songs ShouldHaveLength 0
+        vars:
+          collectionid:
+            from: result.bodyjson.id
+
+  - name: post-transfer-collection-song-success
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/collections/{{.post-collection-transfer-source.collectionid}}/songs/{{.create-collection-song-two.songid}}/transfer"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+          Content-Type: application/json
+        body: |
+          {
+            "target": "{{.post-collection-transfer-target.collectionid}}",
+            "nr": "moved"
+          }
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson.source.id ShouldEqual "{{.post-collection-transfer-source.collectionid}}"
+          - result.bodyjson.source.songs ShouldHaveLength 0
+          - result.bodyjson.target.id ShouldEqual "{{.post-collection-transfer-target.collectionid}}"
+          - result.bodyjson.target.songs ShouldHaveLength 1
+          - result.bodyjson.target.songs.songs0.id ShouldEqual "{{.create-collection-song-two.songid}}"
+          - result.bodyjson.target.songs.songs0.nr ShouldEqual "moved"
+
+  - name: get-collection-transfer-source-after-move
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/collections/{{.post-collection-transfer-source.collectionid}}"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson.songs ShouldHaveLength 0
+
+  - name: get-collection-transfer-target-after-move
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/collections/{{.post-collection-transfer-target.collectionid}}"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson.songs ShouldHaveLength 1
+          - result.bodyjson.songs.songs0.id ShouldEqual "{{.create-collection-song-two.songid}}"
+
+  - name: post-transfer-collection-song-not-in-source
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/collections/{{.post-collection-transfer-source.collectionid}}/songs/{{.create-collection-song-two.songid}}/transfer"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+          Content-Type: application/json
+        body: |
+          {
+            "target": "{{.post-collection-transfer-target.collectionid}}"
+          }
+        assertions:
+          - result.statuscode ShouldEqual 404
+
+  - name: post-transfer-collection-song-target-not-found
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/collections/{{.post-collection-transfer-source.collectionid}}/songs/{{.create-collection-song-one.songid}}/transfer"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+          Content-Type: application/json
+        body: |
+          {
+            "target": "never-existed-collection"
+          }
+        assertions:
+          - result.statuscode ShouldEqual 404
+
+  - name: post-transfer-collection-song-same-source-and-target
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/collections/{{.post-collection-transfer-target.collectionid}}/songs/{{.create-collection-song-two.songid}}/transfer"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+          Content-Type: application/json
+        body: |
+          {
+            "target": "{{.post-collection-transfer-target.collectionid}}"
+          }
+        assertions:
+          - result.statuscode ShouldEqual 400
+
+  # BLC: BLC-COLL-007, BLC-COLL-006
+  - name: post-transfer-collection-song-read-user
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/collections/{{.post-collection-transfer-source.collectionid}}/songs/{{.create-collection-song-one.songid}}/transfer"
+        headers:
+          Authorization: "Bearer {{.create-collection-read-session.sessionid}}"
+          Content-Type: application/json
+        body: |
+          {
+            "target": "{{.post-collection-transfer-target.collectionid}}"
+          }
+        assertions:
+          - result.statuscode ShouldEqual 404
+
+  # BLC: BLC-AUTH-001
+  - name: post-transfer-collection-song-missing-token
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/collections/{{.post-collection-transfer-source.collectionid}}/songs/{{.create-collection-song-one.songid}}/transfer"
+        headers:
+          Content-Type: application/json
+        body: |
+          {
+            "target": "{{.post-collection-transfer-target.collectionid}}"
+          }
+        assertions:
+          - result.statuscode ShouldEqual 401
+
+  # Repair path: song already in target — unlink from source only
+  - name: post-collection-transfer-repair-source
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/collections"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+          Content-Type: application/json
+        body: |
+          {
+            "title": "Transfer Repair Source",
+            "cover": "cover-transfer-repair-src",
+            "songs": [
+              { "id": "{{.create-collection-song-two.songid}}", "nr": "dup-src" }
+            ]
+          }
+        assertions:
+          - result.statuscode ShouldEqual 201
+          - result.bodyjson.songs ShouldHaveLength 1
+        vars:
+          collectionid:
+            from: result.bodyjson.id
+
+  - name: post-transfer-collection-song-repair-already-in-target
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/collections/{{.post-collection-transfer-repair-source.collectionid}}/songs/{{.create-collection-song-two.songid}}/transfer"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+          Content-Type: application/json
+        body: |
+          {
+            "target": "{{.post-collection-transfer-target.collectionid}}"
+          }
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson.source.songs ShouldHaveLength 0
+          - result.bodyjson.target.songs ShouldHaveLength 1
+          - result.bodyjson.target.songs.songs0.nr ShouldEqual "moved"
+
   # Additional collections for delete scenarios
   - name: post-collection-for-delete
     steps:

--- a/shared/src/collection/collection.rs
+++ b/shared/src/collection/collection.rs
@@ -1,5 +1,9 @@
 use crate::song::Link as SongLink;
+use chordlib::types::SimpleChord;
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "backend")]
+use crate::song::SimpleChordSchema;
 
 #[cfg(feature = "backend")]
 #[allow(unused_imports)]
@@ -94,4 +98,36 @@ impl From<Collection> for CreateCollection {
             songs: value.songs,
         }
     }
+}
+
+/// Move a song link from this collection into another (`POST …/collections/{id}/songs/{song_id}/transfer`).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "backend", derive(ToSchema))]
+#[cfg_attr(
+    feature = "backend",
+    schema(example = json!({
+        "target": "col_target",
+        "key": { "level": 3 },
+        "nr": "3"
+    }))
+)]
+pub struct TransferCollectionSong {
+    /// Destination collection id.
+    pub target: String,
+    /// Optional slot key override from the editor row.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "backend", schema(value_type = Option<SimpleChordSchema>))]
+    pub key: Option<SimpleChord>,
+    /// Optional slot number override from the editor row.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nr: Option<String>,
+}
+
+/// Updated source and target collections after a successful transfer.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "backend", derive(ToSchema))]
+pub struct TransferCollectionSongResult {
+    pub source: Collection,
+    pub target: Collection,
 }

--- a/shared/src/collection/mod.rs
+++ b/shared/src/collection/mod.rs
@@ -1,4 +1,7 @@
 #[allow(clippy::module_inception)]
 mod collection;
 
-pub use collection::{Collection, CreateCollection, PatchCollection, UpdateCollection};
+pub use collection::{
+    Collection, CreateCollection, PatchCollection, TransferCollectionSong,
+    TransferCollectionSongResult, UpdateCollection,
+};


### PR DESCRIPTION
## Summary
- Adds `POST /api/v1/collections/{id}/songs/{song_id}/transfer` to move a song link between collections atomically.
- Introduces shared `TransferCollectionSong` / `TransferCollectionSongResult` types.
- Covers success, auth, 404, 400, and repair-when-already-in-target paths with Venom API tests.

## Why
BLC-COLL-024 rejects PATCH/PUT that remove songs from a collection, so the frontend move flow could add a song to the target and then fail with 409 when removing it from the source.

## Test plan
- [x] `cd backend && cargo fmt && cargo test && cargo clippy -- -D warnings && cargo venom`
- [x] `cd shared && cargo fmt && cargo test && cargo clippy -- -D warnings`