### PR TITLE
Player inbox fixes: URL sync, overlay, AV projection, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,16 +98,10 @@ VITE_DEV_PROXY_TARGET=http://127.0.0.1:8080
 
 ### Start the frontend against the production backend
 
-Useful for UI work against live data. Create `frontend/app/.env.development.local`:
+Useful for UI work against live data:
 
 ```bash
-VITE_DEV_PROXY_TARGET=https://app.worshipviewer.com
-```
-
-Then:
-
-```bash
-pnpm -C frontend dev
+VITE_DEV_PROXY_TARGET=https://app.worshipviewer.com pnpm -C frontend dev
 ```
 
 **Caveats:**

--- a/frontend/app/src/components/hub/EntityListView.tsx
+++ b/frontend/app/src/components/hub/EntityListView.tsx
@@ -440,7 +440,11 @@ function useHubListItemPlayerTap(entity: HubEntity, itemId: string) {
     (mode?: 'normal' | 'av') => {
       void navigate({
         to: '/player',
-        search: buildPlayerSearch(playType, itemId, undefined, mode ?? readPlayerDefaultMode()),
+        search: buildPlayerSearch({
+          type: playType,
+          id: itemId,
+          mode: mode ?? readPlayerDefaultMode(),
+        }),
       })
     },
     [navigate, playType, itemId],
@@ -640,7 +644,7 @@ function HubItemContextMenu({
             onSelect={() => {
               void navigate({
                 to: '/player',
-                search: buildPlayerSearch(playType, itemId, undefined, 'normal'),
+                search: buildPlayerSearch({ type: playType, id: itemId, mode: 'normal' }),
               })
             }}
             onMouseEnter={() => setPlayHot(true)}
@@ -656,7 +660,7 @@ function HubItemContextMenu({
             onSelect={() => {
               void navigate({
                 to: '/player',
-                search: buildPlayerSearch(playType, itemId, undefined, 'av'),
+                search: buildPlayerSearch({ type: playType, id: itemId, mode: 'av' }),
               })
             }}
           >

--- a/frontend/app/src/components/player/ChordsThreeColumnSlide.tsx
+++ b/frontend/app/src/components/player/ChordsThreeColumnSlide.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button'
 import { scopeChordlibPageCss } from '@/lib/chord-page-css'
 import {
   columnWidthInMultiColumnLayout,
-  fontScaleForColumnWidth,
+  fontScaleForMultiColumnPlayer,
   scaledColumnTypography,
 } from '@/lib/chord-a4-scale'
 import { getChordEngine } from '@/lib/chord-engine'
@@ -331,8 +331,7 @@ export function ChordsThreeColumnSlide({
         COLUMN_GAP_PX,
         0,
       )
-      const scale =
-        columnCount === 3 ? fontScaleForColumnWidth(columnWidth) : 1
+      const scale = fontScaleForMultiColumnPlayer(columnWidth)
       if (scale == null) return
 
       const typography = scaledColumnTypography(scale)

--- a/frontend/app/src/components/player/EditorPlayButton.tsx
+++ b/frontend/app/src/components/player/EditorPlayButton.tsx
@@ -47,12 +47,11 @@ export function EditorPlayButton({
           navigate: () => {
             void navigate({
               to: '/player',
-              search: buildPlayerSearch(
-                entityType,
-                entityId,
-                undefined,
-                readPlayerDefaultMode(),
-              ),
+              search: buildPlayerSearch({
+                type: entityType,
+                id: entityId,
+                mode: readPlayerDefaultMode(),
+              }),
             })
           },
         })

--- a/frontend/app/src/components/player/PlayerBook.tsx
+++ b/frontend/app/src/components/player/PlayerBook.tsx
@@ -24,6 +24,7 @@ import { useChordFormatPreference } from '@/hooks/useChordFormatPreference'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { usePlayerScrollPreference } from '@/hooks/usePlayerScrollPreference'
 import { useOnline } from '@/hooks/use-online'
+import { usePlayerIndexSearchSync } from '@/hooks/usePlayerIndexSearchSync'
 import { useSetlistEvictionWatch } from '@/hooks/useSetlistEvictionWatch'
 import { getChordEngine } from '@/lib/chord-engine'
 import { chordFormatToRepresentation, writeChordFormatPreference } from '@/lib/chord-format'
@@ -62,11 +63,18 @@ import {
   writePlayerViewState,
   type PlayerViewState,
 } from '@/lib/player/player-view-state'
+import {
+  PLAYER_HEADER_ICON_SIZE,
+  playerHeaderIconButtonClass,
+  playerHeaderIconClass,
+} from '@/lib/player/player-chrome'
+import type { PlayerMode } from '@/lib/player/player-mode'
 import type { PlayerEntityType } from '@/lib/player-route'
 import { buildSongEditorReturnSearch } from '@/lib/player/player-editor-return'
 import { buildSettingsSearch } from '@/lib/settings-route'
 import { MUSICAL_KEYS } from '@/lib/setlist-editor-constants'
 import { resolveSongDataKey } from '@/lib/setlist-song-links'
+import { cn } from '@/lib/utils'
 
 type Player = components['schemas']['Player']
 type PlayerItem = Player['items'][number]
@@ -141,6 +149,7 @@ type PlayerBookProps = {
   id: string
   player: Player
   initialIndex?: number
+  mode?: PlayerMode
   allowNetworkFetch: boolean
   resourceTitle?: string
   deletedReconciled?: boolean
@@ -151,6 +160,7 @@ export function PlayerBook({
   id,
   player,
   initialIndex,
+  mode = 'normal',
   allowNetworkFetch,
   resourceTitle,
   deletedReconciled,
@@ -252,6 +262,8 @@ export function PlayerBook({
   )
 
   const navBlocked = evicted
+
+  usePlayerIndexSearchSync(type, id, nav.index, mode)
 
   const triggerLikeBurst = useCallback(() => {
     setLikeBurstKey((key) => key + 1)
@@ -380,7 +392,7 @@ export function PlayerBook({
 
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
-      const action = playerKeyboardAction(e.key, e.target, { popoverOpen })
+      const action = playerKeyboardAction(e.key, e.target, { popoverOpen, chromeVisible })
       if (!action) return
 
       if (action === 'prev') {
@@ -487,6 +499,7 @@ export function PlayerBook({
     navBlocked,
     navigate,
     popoverOpen,
+    chromeVisible,
     scrollPreferences,
     sheetOrientation,
     toggleCurrentSongLike,
@@ -563,6 +576,18 @@ export function PlayerBook({
       lastViewportTapTimeRef.current = now
 
       const zone = viewportPointerZone(clientX, rect)
+
+      if (chromeVisible) {
+        setPopoverOpen(false)
+        if (zone !== 'middle') {
+          setChromeVisible(false)
+          return true
+        }
+        setChromeVisible(false)
+        if (doubleTap) toggleCurrentSongLike()
+        return true
+      }
+
       if (zone === 'left') {
         if (!navBlocked) dispatch({ type: 'prev' })
         return true
@@ -572,11 +597,11 @@ export function PlayerBook({
         return true
       }
       setPopoverOpen(false)
-      setChromeVisible((visible) => !visible)
+      setChromeVisible(true)
       if (doubleTap) toggleCurrentSongLike()
       return true
     },
-    [dispatch, navBlocked, toggleCurrentSongLike],
+    [chromeVisible, dispatch, navBlocked, toggleCurrentSongLike],
   )
 
   function onTouchEnd(e: React.TouchEvent) {
@@ -590,7 +615,7 @@ export function PlayerBook({
     const isSwipe = Math.abs(dx) >= 48 && Math.abs(dx) >= Math.abs(dy) * 1.2
 
     if (isSwipe) {
-      if (navBlocked) return
+      if (navBlocked || chromeVisible) return
       if (dx > 0) dispatch({ type: 'prev' })
       else dispatch({ type: 'next' })
       return
@@ -647,9 +672,15 @@ export function PlayerBook({
               exit={reduceMotion ? undefined : { height: 0, opacity: 0 }}
               transition={chromeTransition}
             >
-              <Button type="button" variant="outline" size="icon" asChild className="shrink-0">
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                asChild
+                className={playerHeaderIconButtonClass}
+              >
                 <Link to={backTo} aria-label={t(backAriaKeyForPlayerType(type))}>
-                  <ChevronLeftIcon className="text-[var(--color-foreground)]" size={20} />
+                  <ChevronLeftIcon className={playerHeaderIconClass} size={PLAYER_HEADER_ICON_SIZE} />
                 </Link>
               </Button>
 
@@ -661,55 +692,21 @@ export function PlayerBook({
               </div>
 
               <div className="flex shrink-0 items-center gap-1">
-                {type === 'setlist' ? (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    className="shrink-0"
-                    aria-label={t('player.editSetlist')}
-                    onClick={navigateToResourceEditor}
-                  >
-                    <ListMusicIcon size={18} className="text-[var(--color-foreground)]" />
-                  </Button>
-                ) : null}
-                {type === 'collection' ? (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    className="shrink-0"
-                    aria-label={t('player.editCollection')}
-                    onClick={navigateToResourceEditor}
-                  >
-                    <LayersIcon size={18} className="text-[var(--color-foreground)]" />
-                  </Button>
-                ) : null}
-                {currentItem.type === 'chords' ? (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    className="shrink-0"
-                    aria-label={t('player.editSong')}
-                    onClick={navigateToSongEditor}
-                  >
-                    <PencilIcon size={18} className="text-[var(--color-foreground)]" />
-                  </Button>
-                ) : null}
                 {showChordsControls && currentItem.type === 'chords' ? (
                   <PopoverRoot open={popoverOpen} onOpenChange={setPopoverOpen}>
                     <PopoverTrigger asChild>
                       <Button
                         type="button"
                         variant="outline"
-                        size="sm"
-                        className="h-8 px-2 text-xs"
+                        size="icon"
+                        className={playerHeaderIconButtonClass}
                         aria-label={t('player.transpose.current', {
                           key: displayKey ?? t('player.transpose.default'),
                         })}
                       >
-                        {displayKey ?? t('player.transpose.default')}
+                        <span className={cn(playerHeaderIconClass, 'text-sm font-semibold leading-none')}>
+                          {displayKey ?? '♮'}
+                        </span>
                       </Button>
                     </PopoverTrigger>
                     <PopoverContent align="end" className="w-56 p-2">
@@ -744,7 +741,49 @@ export function PlayerBook({
                     </PopoverContent>
                   </PopoverRoot>
                 ) : null}
-                <Button type="button" variant="outline" size="icon" asChild className="shrink-0">
+                {currentItem.type === 'chords' ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    className={playerHeaderIconButtonClass}
+                    aria-label={t('player.editSong')}
+                    onClick={navigateToSongEditor}
+                  >
+                    <PencilIcon size={PLAYER_HEADER_ICON_SIZE} className={playerHeaderIconClass} />
+                  </Button>
+                ) : null}
+                {type === 'setlist' ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    className={playerHeaderIconButtonClass}
+                    aria-label={t('player.editSetlist')}
+                    onClick={navigateToResourceEditor}
+                  >
+                    <ListMusicIcon size={PLAYER_HEADER_ICON_SIZE} className={playerHeaderIconClass} />
+                  </Button>
+                ) : null}
+                {type === 'collection' ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    className={playerHeaderIconButtonClass}
+                    aria-label={t('player.editCollection')}
+                    onClick={navigateToResourceEditor}
+                  >
+                    <LayersIcon size={PLAYER_HEADER_ICON_SIZE} className={playerHeaderIconClass} />
+                  </Button>
+                ) : null}
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  asChild
+                  className={playerHeaderIconButtonClass}
+                >
                   <Link
                     to="/settings"
                     search={buildSettingsSearch('player', {
@@ -754,7 +793,7 @@ export function PlayerBook({
                     })}
                     aria-label={t('player.openSettings')}
                   >
-                    <SettingsIcon size={18} className="text-[var(--color-foreground)]" />
+                    <SettingsIcon size={PLAYER_HEADER_ICON_SIZE} className={playerHeaderIconClass} />
                   </Link>
                 </Button>
               </div>

--- a/frontend/app/src/components/player/PlayerRoute.tsx
+++ b/frontend/app/src/components/player/PlayerRoute.tsx
@@ -155,5 +155,5 @@ export function PlayerRouteInner({ type, id, initialIndex, mode }: PlayerRouteIn
     return <PlayerAv key={`${type}-${id}-av`} {...sharedProps} />
   }
 
-  return <PlayerBook key={`${type}-${id}`} {...sharedProps} />
+  return <PlayerBook key={`${type}-${id}`} {...sharedProps} mode={mode} />
 }

--- a/frontend/app/src/components/player/PlayerTocSidebar.tsx
+++ b/frontend/app/src/components/player/PlayerTocSidebar.tsx
@@ -7,6 +7,7 @@ import {
   TocSortLikedIcon,
   TocSortOrderIcon,
 } from '@/components/icons/toc-sort-icons'
+import { usePlayerTocSearchSync } from '@/hooks/usePlayerIndexSearchSync'
 import { displayTocEntries, tocDisplayNr, type TocDisplayMode } from '@/lib/player/toc-display'
 import {
   buildTocMetadataBySongId,
@@ -35,19 +36,17 @@ const MODE_ICONS = {
   liked: TocSortLikedIcon,
 } as const
 
-function toggleSetValue<T>(set: Set<T>, value: T): Set<T> {
-  const next = new Set(set)
-  if (next.has(value)) next.delete(value)
-  else next.add(value)
-  return next
-}
-
 export function PlayerTocSidebar({ toc, items, currentIndex, onSelect }: PlayerTocSidebarProps) {
   const { t } = useTranslation()
-  const [mode, setMode] = useState<TocDisplayMode>('order')
+  const {
+    mode,
+    setMode,
+    activeLanguageIds,
+    toggleLanguageId,
+    activeTagIds,
+    toggleTagId,
+  } = usePlayerTocSearchSync()
   const [hoveredMode, setHoveredMode] = useState<TocDisplayMode | null>(null)
-  const [activeLanguageIds, setActiveLanguageIds] = useState<Set<string>>(() => new Set())
-  const [activeTagIds, setActiveTagIds] = useState<Set<string>>(() => new Set())
 
   const metadataBySongId = useMemo(() => buildTocMetadataBySongId(items), [items])
   const languageFilters = useMemo(
@@ -155,7 +154,7 @@ export function PlayerTocSidebar({ toc, items, currentIndex, onSelect }: PlayerT
                           ? 'bg-[var(--color-primary)] text-[var(--color-primary-foreground)]'
                           : 'bg-[var(--color-muted)] text-[var(--color-foreground)] hover:bg-[var(--color-muted)]/80',
                       )}
-                      onClick={() => setActiveLanguageIds((current) => toggleSetValue(current, filter.id))}
+                      onClick={() => toggleLanguageId(filter.id)}
                     >
                       {filter.label}
                     </button>
@@ -184,7 +183,7 @@ export function PlayerTocSidebar({ toc, items, currentIndex, onSelect }: PlayerT
                           ? 'bg-[var(--color-primary)] text-[var(--color-primary-foreground)]'
                           : 'bg-[var(--color-muted)] text-[var(--color-foreground)] hover:bg-[var(--color-muted)]/80',
                       )}
-                      onClick={() => setActiveTagIds((current) => toggleSetValue(current, filter.id))}
+                      onClick={() => toggleTagId(filter.id)}
                     >
                       {filter.label}
                     </button>

--- a/frontend/app/src/components/player/av/PlayerAv.tsx
+++ b/frontend/app/src/components/player/av/PlayerAv.tsx
@@ -13,6 +13,7 @@ import { OutputIcon } from '@/components/icons/lucide-animated/output-icon'
 import { SettingsIcon } from '@/components/icons/lucide-animated/settings-icon'
 import { Button } from '@/components/ui/button'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
+import { usePlayerIndexSearchSync } from '@/hooks/usePlayerIndexSearchSync'
 import { useSetlistEvictionWatch } from '@/hooks/useSetlistEvictionWatch'
 import {
   avItemTitle,
@@ -52,6 +53,11 @@ import {
   writeAvSessionState,
   type AvSessionState,
 } from '@/lib/player/av-session-state'
+import {
+  PLAYER_HEADER_ICON_SIZE,
+  playerHeaderIconButtonClass,
+  playerHeaderIconClass,
+} from '@/lib/player/player-chrome'
 import { tocEntryForIndex } from '@/lib/player/player-helpers'
 import type { PlayerEntityType } from '@/lib/player-route'
 import { buildSettingsSearch } from '@/lib/settings-route'
@@ -119,6 +125,13 @@ export function PlayerAv({
     const startSlide = initialIndex != null ? 0 : saved.slideIndex
     return { ...saved, itemIndex: startItem, slideIndex: startSlide }
   })
+  /** What the output window shows — lags behind `session` until the user navigates slides. */
+  const [projected, setProjected] = useState<AvSessionState>(() => {
+    const saved = readAvSessionState(type, id)
+    const startItem = initialIndex ?? saved.itemIndex ?? player.index
+    const startSlide = initialIndex != null ? 0 : saved.slideIndex
+    return { ...saved, itemIndex: startItem, slideIndex: startSlide }
+  })
   const [tocVisible] = useState(true)
 
   const sessionIdRef = useRef(createAvProjectionSessionId())
@@ -132,6 +145,8 @@ export function PlayerAv({
   const evicted = useSetlistEvictionWatch(type === 'setlist' ? id : undefined, type === 'setlist')
   const navBlocked = evicted
   const backTo = hubPathForPlayerType(type)
+
+  usePlayerIndexSearchSync(type, id, session.itemIndex, 'av')
 
   const collapseLyricWhitespace = readLyricCollapseWhitespacePreference()
 
@@ -150,6 +165,28 @@ export function PlayerAv({
       session.itemIndex,
     ],
   )
+
+  const projectedItem = useMemo(
+    () =>
+      avSlidesForPlayerItem(player.items, projected.itemIndex, {
+        maxLinesPerSlide: prefs.contentLayer.maxLinesPerSlide,
+        balanceSlideLines: prefs.contentLayer.balanceSlideLines,
+        collapseLyricWhitespace,
+      }),
+    [
+      player.items,
+      prefs.contentLayer.maxLinesPerSlide,
+      prefs.contentLayer.balanceSlideLines,
+      collapseLyricWhitespace,
+      projected.itemIndex,
+    ],
+  )
+
+  const projectedTocRow = tocEntryForIndex(player.toc, projected.itemIndex)
+  const projectedTitle =
+    resourceTitle ||
+    projectedTocRow?.title ||
+    avItemTitle(player.items, projected.itemIndex, projectedTocRow?.title)
 
   const slideCount = currentItem.slides.length
   const announcement = useMemo(() => {
@@ -179,11 +216,19 @@ export function PlayerAv({
     return currentItem.slides[session.slideIndex] ?? currentItem.slides[0] ?? ''
   }, [currentItem.slides, session.screenState, session.slideIndex])
 
-  const nextText = useMemo(() => {
-    const nextIndex = avNextSlideInItem(slideCount, session.slideIndex)
+  const projectedSlideCount = projectedItem.slides.length
+  const projectedText = useMemo(() => {
+    if (projected.screenState !== 'live') return ''
+    return (
+      projectedItem.slides[projected.slideIndex] ?? projectedItem.slides[0] ?? ''
+    )
+  }, [projected.screenState, projected.slideIndex, projectedItem.slides])
+
+  const projectedNextText = useMemo(() => {
+    const nextIndex = avNextSlideInItem(projectedSlideCount, projected.slideIndex)
     if (nextIndex == null) return null
-    return currentItem.slides[nextIndex] ?? null
-  }, [currentItem.slides, session.slideIndex, slideCount])
+    return projectedItem.slides[nextIndex] ?? null
+  }, [projected.slideIndex, projectedItem.slides, projectedSlideCount])
 
   const playerReturnContext = useMemo(
     () => ({
@@ -224,17 +269,25 @@ export function PlayerAv({
 
   useEffect(() => {
     const payload = buildAvProjectionPayload({
-      contentText: currentText,
+      contentText: projectedText,
       contentLayer: prefs.contentLayer,
       backgroundLayer: prefs.backgroundLayer,
       transition: prefs.transition,
-      screenState: session.screenState,
-      itemTitle: title || t('player.untitled'),
-      nextPreview: nextText,
+      screenState: projected.screenState,
+      itemTitle: projectedTitle || t('player.untitled'),
+      nextPreview: projectedNextText,
       prefersReducedMotion: reduceMotion ?? false,
     })
     syncRef.current?.broadcast(payload)
-  }, [currentText, nextText, prefs, reduceMotion, session.screenState, t, title])
+  }, [
+    projectedText,
+    projectedNextText,
+    projected.screenState,
+    projectedTitle,
+    prefs,
+    reduceMotion,
+    t,
+  ])
 
   const setBackgroundPreset = useCallback((preset: AvBackgroundPreset) => {
     setPrefs((prev) => {
@@ -246,36 +299,42 @@ export function PlayerAv({
 
   const goToSlide = useCallback(
     (slideIndex: number, clearScreenState = true) => {
-      const clamped = Math.max(0, Math.min(slideIndex, Math.max(slideCount - 1, 0)))
-      setSession((state) => ({
-        ...state,
-        slideIndex: clamped,
-        screenState: clearScreenState ? 'live' : state.screenState,
-      }))
+      setSession((state) => {
+        const clamped = Math.max(0, Math.min(slideIndex, Math.max(slideCount - 1, 0)))
+        const next: AvSessionState = {
+          ...state,
+          slideIndex: clamped,
+          screenState: clearScreenState ? 'live' : state.screenState,
+        }
+        setProjected(next)
+        return next
+      })
     },
     [slideCount],
   )
 
   const goToItem = useCallback((itemIndex: number) => {
-    setSession(() => ({
+    setSession((state) => ({
+      ...state,
       itemIndex,
       slideIndex: 0,
-      screenState: 'live',
     }))
   }, [])
 
   const toggleBlank = useCallback(() => {
-    setSession((state) => ({
-      ...state,
-      screenState: toggleBlankScreenState(state.screenState),
-    }))
+    setSession((state) => {
+      const screenState = toggleBlankScreenState(state.screenState)
+      setProjected((projectedState) => ({ ...projectedState, screenState }))
+      return { ...state, screenState }
+    })
   }, [])
 
   const toggleBlackout = useCallback(() => {
-    setSession((state) => ({
-      ...state,
-      screenState: toggleBlackoutScreenState(state.screenState),
-    }))
+    setSession((state) => {
+      const screenState = toggleBlackoutScreenState(state.screenState)
+      setProjected((projectedState) => ({ ...projectedState, screenState }))
+      return { ...state, screenState }
+    })
   }, [])
 
   const goPrev = useCallback(() => {
@@ -421,9 +480,15 @@ export function PlayerAv({
       </p>
 
       <header className="player-av__header flex shrink-0 items-center gap-2 border-b border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-2 sm:px-3">
-        <Button type="button" variant="outline" size="icon" asChild className="shrink-0">
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          asChild
+          className={playerHeaderIconButtonClass}
+        >
           <Link to={backTo} aria-label={t(backAriaKeyForPlayerType(type))}>
-            <ChevronLeftIcon className="text-[var(--color-foreground)]" size={20} />
+            <ChevronLeftIcon className={playerHeaderIconClass} size={PLAYER_HEADER_ICON_SIZE} />
           </Link>
         </Button>
         <div className="min-w-0 flex-1 text-center">
@@ -442,20 +507,26 @@ export function PlayerAv({
             type="button"
             variant="outline"
             size="icon"
-            className="min-h-11 min-w-11 shrink-0"
+            className={playerHeaderIconButtonClass}
             aria-label={t('player.av.openOutput')}
             aria-keyshortcuts={AV_OPEN_OUTPUT_SHORTCUT_KEY}
             onClick={() => openOutputWindow()}
           >
-            <OutputIcon size={18} className="text-[var(--color-foreground)]" />
+            <OutputIcon size={PLAYER_HEADER_ICON_SIZE} className={playerHeaderIconClass} />
           </Button>
-          <Button type="button" variant="outline" size="icon" asChild className="min-h-11 min-w-11">
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            asChild
+            className={playerHeaderIconButtonClass}
+          >
             <Link
               to="/settings"
               search={buildSettingsSearch('playerRoles', playerReturnContext)}
               aria-label={t('player.av.openSettings')}
             >
-              <SettingsIcon size={18} className="text-[var(--color-foreground)]" />
+              <SettingsIcon size={PLAYER_HEADER_ICON_SIZE} className={playerHeaderIconClass} />
             </Link>
           </Button>
         </div>
@@ -499,11 +570,11 @@ export function PlayerAv({
         <aside className="player-av__right w-44 shrink-0 sm:w-56">
           <div className="player-av__preview">
             <AvSlideView
-              contentText={currentText}
+              contentText={projectedText}
               contentLayer={prefs.contentLayer}
               backgroundLayer={prefs.backgroundLayer}
               transition={prefs.transition}
-              screenState={session.screenState}
+              screenState={projected.screenState}
             />
           </div>
 

--- a/frontend/app/src/components/teams/TeamDetailView.tsx
+++ b/frontend/app/src/components/teams/TeamDetailView.tsx
@@ -212,7 +212,7 @@ export function TeamDetailView({ teamId, onRequestClose }: TeamDetailViewProps) 
       const { response } = await api.DELETE('/api/v1/teams/{id}', {
         params: { path: { id: teamId } },
       })
-      if (!response.ok) {
+      if (!response.ok && response.status !== 204) {
         const problem = await parseProblemResponse(response.clone())
         throw new Error(problem?.title ?? t('teams.deleteFailed'))
       }

--- a/frontend/app/src/hooks/usePlayerIndexSearchSync.ts
+++ b/frontend/app/src/hooks/usePlayerIndexSearchSync.ts
@@ -1,0 +1,150 @@
+import { getRouteApi, useNavigate } from '@tanstack/react-router'
+import { useCallback, useEffect, useMemo } from 'react'
+
+import type { PlayerMode } from '@/lib/player/player-mode'
+import {
+  parseTocLangSearch,
+  parseTocTagsSearch,
+  resolveTocDisplayMode,
+} from '@/lib/player/player-toc-search'
+import type { TocDisplayMode } from '@/lib/player/toc-display'
+import { buildPlayerSearch, type PlayerEntityType } from '@/lib/player-route'
+
+const playerRoute = getRouteApi('/player/')
+
+function playerSearchSnapshot(
+  search: ReturnType<typeof playerRoute.useSearch>,
+  type: PlayerEntityType,
+  id: string,
+  mode: PlayerMode,
+) {
+  return {
+    type,
+    id,
+    index: search.index,
+    mode: search.mode ?? mode,
+    toc: search.toc,
+    tocLang: parseTocLangSearch(search.tocLang),
+    tocTags: parseTocTagsSearch(search.tocTags),
+  }
+}
+
+export function usePlayerIndexSearchSync(
+  type: PlayerEntityType,
+  id: string,
+  index: number,
+  mode: PlayerMode,
+) {
+  const navigate = useNavigate()
+  const search = playerRoute.useSearch({
+    select: (state) => ({
+      index: state.index,
+      mode: state.mode,
+      toc: state.toc,
+      tocLang: state.tocLang,
+      tocTags: state.tocTags,
+    }),
+  })
+
+  useEffect(() => {
+    if (search.index === index) return
+    void navigate({
+      to: '/player',
+      search: buildPlayerSearch({ ...playerSearchSnapshot(search, type, id, mode), index }),
+      replace: true,
+    })
+  }, [
+    id,
+    index,
+    mode,
+    navigate,
+    search.index,
+    search.mode,
+    search.toc,
+    search.tocLang,
+    search.tocTags,
+    type,
+  ])
+}
+
+export function usePlayerTocSearchSync() {
+  const navigate = useNavigate()
+  const search = playerRoute.useSearch({
+    select: (state) => ({
+      type: state.type,
+      id: state.id,
+      index: state.index,
+      mode: state.mode,
+      toc: state.toc,
+      tocLang: state.tocLang,
+      tocTags: state.tocTags,
+    }),
+  })
+
+  const mode = resolveTocDisplayMode(search.toc)
+  const activeLanguageIds = useMemo(
+    () => new Set(parseTocLangSearch(search.tocLang)),
+    [search.tocLang],
+  )
+  const activeTagIds = useMemo(() => new Set(parseTocTagsSearch(search.tocTags)), [search.tocTags])
+
+  const updateToc = useCallback(
+    (partial: {
+      toc?: TocDisplayMode
+      tocLang?: readonly string[]
+      tocTags?: readonly string[]
+    }) => {
+      if (!search.type || !search.id) return
+      void navigate({
+        to: '/player',
+        search: buildPlayerSearch({
+          type: search.type,
+          id: search.id,
+          index: search.index,
+          mode: search.mode,
+          toc: partial.toc ?? resolveTocDisplayMode(search.toc),
+          tocLang: partial.tocLang ?? parseTocLangSearch(search.tocLang),
+          tocTags: partial.tocTags ?? parseTocTagsSearch(search.tocTags),
+        }),
+        replace: true,
+      })
+    },
+    [navigate, search.id, search.index, search.mode, search.toc, search.tocLang, search.tocTags, search.type],
+  )
+
+  const setMode = useCallback(
+    (next: TocDisplayMode) => {
+      updateToc({ toc: next })
+    },
+    [updateToc],
+  )
+
+  const toggleLanguageId = useCallback(
+    (languageId: string) => {
+      const next = new Set(activeLanguageIds)
+      if (next.has(languageId)) next.delete(languageId)
+      else next.add(languageId)
+      updateToc({ tocLang: [...next] })
+    },
+    [activeLanguageIds, updateToc],
+  )
+
+  const toggleTagId = useCallback(
+    (tagId: string) => {
+      const next = new Set(activeTagIds)
+      if (next.has(tagId)) next.delete(tagId)
+      else next.add(tagId)
+      updateToc({ tocTags: [...next] })
+    },
+    [activeTagIds, updateToc],
+  )
+
+  return {
+    mode,
+    setMode,
+    activeLanguageIds,
+    toggleLanguageId,
+    activeTagIds,
+    toggleTagId,
+  }
+}

--- a/frontend/app/src/lib/chord-a4-scale.test.ts
+++ b/frontend/app/src/lib/chord-a4-scale.test.ts
@@ -12,6 +12,8 @@ import {
   cssScaleToViewportWidth,
   cappedColumnFontScale,
   fontScaleForColumnWidth,
+  fontScaleForMultiColumnPlayer,
+  MULTI_COLUMN_PLAYER_FONT_SCALE_FACTOR,
   scaledColumnTypography,
   viewportScaleForA4,
 } from '@/lib/chord-a4-scale'
@@ -109,5 +111,15 @@ describe('column typography scaling', () => {
         A4_REFERENCE_WIDTH_PX,
       ),
     ).toBe(a4Cap)
+  })
+
+  it('applies player multi-column font reduction', () => {
+    expect(fontScaleForMultiColumnPlayer(A4_REFERENCE_COLUMN_WIDTH_PX)).toBe(
+      MULTI_COLUMN_PLAYER_FONT_SCALE_FACTOR,
+    )
+    expect(scaledColumnTypography(MULTI_COLUMN_PLAYER_FONT_SCALE_FACTOR)).toEqual({
+      fontSizePx: A4_COLUMN_FONT_SIZE_PX * MULTI_COLUMN_PLAYER_FONT_SCALE_FACTOR,
+      lineHeightPx: A4_COLUMN_LINE_HEIGHT_PX * MULTI_COLUMN_PLAYER_FONT_SCALE_FACTOR,
+    })
   })
 })

--- a/frontend/app/src/lib/chord-a4-scale.ts
+++ b/frontend/app/src/lib/chord-a4-scale.ts
@@ -35,6 +35,16 @@ export function fontScaleForColumnWidth(columnWidthPx: number): number | undefin
   return columnWidthPx / A4_REFERENCE_COLUMN_WIDTH_PX
 }
 
+/** Player 2/3-column layouts render ~24% smaller than the raw A4 column scale. */
+export const MULTI_COLUMN_PLAYER_FONT_SCALE_FACTOR = 0.76
+
+/** Typography scale for player multi-column chord layouts. */
+export function fontScaleForMultiColumnPlayer(columnWidthPx: number): number | undefined {
+  const base = fontScaleForColumnWidth(columnWidthPx)
+  if (base == null) return undefined
+  return base * MULTI_COLUMN_PLAYER_FONT_SCALE_FACTOR
+}
+
 /** Column typography scale capped like A4 pages (min of width- and height-derived scale). */
 export function cappedColumnFontScale(
   columnWidthPx: number,

--- a/frontend/app/src/lib/player-route.test.ts
+++ b/frontend/app/src/lib/player-route.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest'
 
 import { buildPlayerSearch, buildPlayerSearchParams, type PlayerEntityType } from '@/lib/player-route'
+import { tocTagFilterId } from '@/lib/player/toc-filters'
+import {
+  parseTocDisplayMode,
+  parseTocLangSearch,
+  parseTocTagsSearch,
+  serializeTocLangSearch,
+  serializeTocTagsSearch,
+} from '@/lib/player/player-toc-search'
 
 describe('buildPlayerSearchParams', () => {
   it('returns type and id for each entity', () => {
@@ -13,11 +21,79 @@ describe('buildPlayerSearchParams', () => {
 
 describe('buildPlayerSearch', () => {
   it('includes optional mode and index', () => {
-    expect(buildPlayerSearch('song', 'id-1', 2, 'av')).toEqual({
+    expect(buildPlayerSearch({ type: 'song', id: 'id-1', index: 2, mode: 'av' })).toEqual({
       type: 'song',
       id: 'id-1',
       index: 2,
       mode: 'av',
+      toc: undefined,
+      tocLang: undefined,
+      tocTags: undefined,
     })
+  })
+
+  it('includes index zero for first item', () => {
+    expect(buildPlayerSearch({ type: 'setlist', id: 'set-1', index: 0, mode: 'normal' })).toEqual({
+      type: 'setlist',
+      id: 'set-1',
+      index: 0,
+      mode: 'normal',
+      toc: undefined,
+      tocLang: undefined,
+      tocTags: undefined,
+    })
+  })
+
+  it('serializes toc mode and filters', () => {
+    expect(
+      buildPlayerSearch({
+        type: 'setlist',
+        id: 'set-1',
+        toc: 'alphabetical',
+        tocLang: ['de', 'en'],
+        tocTags: [tocTagFilterId('Explorer', 'true'), tocTagFilterId('Ocean', 'true')],
+      }),
+    ).toEqual({
+      type: 'setlist',
+      id: 'set-1',
+      index: undefined,
+      mode: undefined,
+      toc: 'alphabetical',
+      tocLang: serializeTocLangSearch(['de', 'en']),
+      tocTags: serializeTocTagsSearch([
+        tocTagFilterId('Explorer', 'true'),
+        tocTagFilterId('Ocean', 'true'),
+      ]),
+    })
+  })
+
+  it('omits default toc mode and empty filters', () => {
+    expect(buildPlayerSearch({ type: 'song', id: 'id-1', toc: 'order', tocLang: [], tocTags: [] })).toEqual({
+      type: 'song',
+      id: 'id-1',
+      index: undefined,
+      mode: undefined,
+      toc: undefined,
+      tocLang: undefined,
+      tocTags: undefined,
+    })
+  })
+})
+
+describe('player toc search parsing', () => {
+  it('parses toc display mode', () => {
+    expect(parseTocDisplayMode('liked')).toBe('liked')
+    expect(parseTocDisplayMode('invalid')).toBeUndefined()
+  })
+
+  it('round-trips language filters', () => {
+    const serialized = serializeTocLangSearch(['English', 'de'])
+    expect(parseTocLangSearch(serialized)).toEqual(['English', 'de'])
+  })
+
+  it('round-trips tag filters', () => {
+    const ids = [tocTagFilterId('Explorer', 'true'), tocTagFilterId('Ocean', 'true')]
+    const serialized = serializeTocTagsSearch(ids)
+    expect(parseTocTagsSearch(serialized)).toEqual(ids)
   })
 })

--- a/frontend/app/src/lib/player-route.ts
+++ b/frontend/app/src/lib/player-route.ts
@@ -1,7 +1,37 @@
+import type { TocDisplayMode } from '@/lib/player/toc-display'
+import {
+  parseTocDisplayMode,
+  parseTocLangSearch,
+  parseTocTagsSearch,
+  serializeTocLangSearch,
+  serializeTocTagsSearch,
+} from '@/lib/player/player-toc-search'
+import { parseOptionalPlayerIndex } from '@/lib/player/player-editor-return'
+import { parsePlayerMode } from '@/lib/player/player-mode'
 import type { HubEntity } from '@/lib/hub-entity'
 import type { PlayerMode } from '@/lib/player/player-mode'
 
 export type PlayerEntityType = 'collection' | 'song' | 'setlist'
+
+export type PlayerRouteSearchState = {
+  type: PlayerEntityType
+  id: string
+  index?: number
+  mode?: PlayerMode
+  toc?: TocDisplayMode
+  tocLang?: readonly string[]
+  tocTags?: readonly string[]
+}
+
+export type PlayerRouteSearchParams = {
+  type: PlayerEntityType
+  id: string
+  index: number | undefined
+  mode: PlayerMode | undefined
+  toc: TocDisplayMode | undefined
+  tocLang: string | undefined
+  tocTags: string | undefined
+}
 
 export function hubEntityToPlayerType(entity: HubEntity): PlayerEntityType {
   if (entity === 'collections') return 'collection'
@@ -9,19 +39,42 @@ export function hubEntityToPlayerType(entity: HubEntity): PlayerEntityType {
   return 'setlist'
 }
 
-/** Search params for `/player` route. */
-export function buildPlayerSearch(
-  type: PlayerEntityType,
-  id: string,
-  index?: number,
-  mode?: PlayerMode,
-): {
-  type: PlayerEntityType
+/** Build `/player` search params for navigation. */
+export function buildPlayerSearch(state: PlayerRouteSearchState): PlayerRouteSearchParams {
+  return {
+    type: state.type,
+    id: state.id,
+    index: state.index,
+    mode: state.mode,
+    toc: state.toc && state.toc !== 'order' ? state.toc : undefined,
+    tocLang: serializeTocLangSearch(state.tocLang ?? []),
+    tocTags: serializeTocTagsSearch(state.tocTags ?? []),
+  }
+}
+
+export function parsePlayerRouteSearch(search: Record<string, unknown>): {
+  type: PlayerEntityType | undefined
   id: string
   index: number | undefined
   mode: PlayerMode | undefined
+  toc: TocDisplayMode | undefined
+  tocLang: string[]
+  tocTags: string[]
 } {
-  return { type, id, index, mode }
+  const typeRaw = search.type
+  const type =
+    typeRaw === 'song' || typeRaw === 'setlist' || typeRaw === 'collection' ? typeRaw : undefined
+  const id = typeof search.id === 'string' ? search.id : ''
+
+  return {
+    type,
+    id,
+    index: parseOptionalPlayerIndex(search.index),
+    mode: parsePlayerMode(search.mode),
+    toc: parseTocDisplayMode(search.toc),
+    tocLang: parseTocLangSearch(search.tocLang),
+    tocTags: parseTocTagsSearch(search.tocTags),
+  }
 }
 
 /** @deprecated Prefer {@link buildPlayerSearch} for typed TanStack Router search. */

--- a/frontend/app/src/lib/player/player-chrome.ts
+++ b/frontend/app/src/lib/player/player-chrome.ts
@@ -1,0 +1,7 @@
+/** Matches hub detail chrome (`HubShell` back button). */
+export const playerHeaderIconButtonClass =
+  'size-[3.6rem] shrink-0 rounded-full shadow-[var(--shadow-elevated)]'
+
+export const playerHeaderIconClass = 'text-[var(--color-foreground)]'
+
+export const PLAYER_HEADER_ICON_SIZE = 22

--- a/frontend/app/src/lib/player/player-editor-return.ts
+++ b/frontend/app/src/lib/player/player-editor-return.ts
@@ -1,4 +1,5 @@
 import type { PlayerEntityType } from '@/lib/player-route'
+import { buildPlayerSearch } from '@/lib/player-route'
 import type { PlayerMode } from '@/lib/player/player-mode'
 import { parsePlayerMode } from '@/lib/player/player-mode'
 
@@ -70,18 +71,11 @@ export function emptyEditorReturnSearch(): {
   }
 }
 
-export function buildPlayerReturnSearch(
-  context: PlayerEditorReturnContext,
-): {
-  type: PlayerEntityType
-  id: string
-  index: number
-  mode: PlayerMode | undefined
-} {
-  return {
+export function buildPlayerReturnSearch(context: PlayerEditorReturnContext) {
+  return buildPlayerSearch({
     type: context.playerType,
     id: context.playerId,
     index: context.playerIndex,
     mode: context.playerMode,
-  }
+  })
 }

--- a/frontend/app/src/lib/player/player-keyboard.test.ts
+++ b/frontend/app/src/lib/player/player-keyboard.test.ts
@@ -70,6 +70,12 @@ describe('playerKeyboardAction', () => {
     expect(playerKeyboardAction('m', body, { popoverOpen: true })).toBeNull()
   })
 
+  it('blocks navigation when chrome overlay is open but keeps chrome toggle', () => {
+    expect(playerKeyboardAction('ArrowRight', body, { chromeVisible: true })).toBeNull()
+    expect(playerKeyboardAction('Home', body, { chromeVisible: true })).toBeNull()
+    expect(playerKeyboardAction('m', body, { chromeVisible: true })).toBe('toggleChrome')
+  })
+
   it('returns null for unmapped keys', () => {
     expect(playerKeyboardAction('t', body)).toBeNull()
     expect(playerKeyboardAction('q', body)).toBeNull()

--- a/frontend/app/src/lib/player/player-keyboard.ts
+++ b/frontend/app/src/lib/player/player-keyboard.ts
@@ -46,11 +46,13 @@ function transposeAction(key: string): PlayerKeyboardAction {
 export function playerKeyboardAction(
   key: string,
   target: EventTarget | null,
-  options?: { popoverOpen?: boolean },
+  options?: { popoverOpen?: boolean; chromeVisible?: boolean },
 ): PlayerKeyboardAction {
   if (isEditableTarget(target)) return null
 
   const popoverOpen = options?.popoverOpen ?? false
+  const chromeVisible = options?.chromeVisible ?? false
+  const blockNavigation = popoverOpen || chromeVisible
 
   if (key === 'Escape') return 'escape'
 
@@ -65,6 +67,7 @@ export function playerKeyboardAction(
     case 'ArrowLeft':
     case 'Backspace':
     case 'k':
+      if (blockNavigation) return null
       return 'prev'
     case 'ArrowDown':
     case 'PageDown':
@@ -72,10 +75,13 @@ export function playerKeyboardAction(
     case ' ':
     case 'Enter':
     case 'j':
+      if (blockNavigation) return null
       return 'next'
     case 'Home':
+      if (blockNavigation) return null
       return 'home'
     case 'End':
+      if (blockNavigation) return null
       return 'end'
     case 'm':
       return 'toggleChrome'

--- a/frontend/app/src/lib/player/player-toc-search.ts
+++ b/frontend/app/src/lib/player/player-toc-search.ts
@@ -1,0 +1,79 @@
+import type { TocDisplayMode } from '@/lib/player/toc-display'
+import { tocTagFilterId } from '@/lib/player/toc-filters'
+
+const TOC_MODES: readonly TocDisplayMode[] = ['order', 'alphabetical', 'liked']
+const TAG_URL_SEP = '~'
+
+export function parseTocDisplayMode(raw: unknown): TocDisplayMode | undefined {
+  if (typeof raw !== 'string') return undefined
+  return TOC_MODES.includes(raw as TocDisplayMode) ? (raw as TocDisplayMode) : undefined
+}
+
+export function resolveTocDisplayMode(raw: unknown): TocDisplayMode {
+  return parseTocDisplayMode(raw) ?? 'order'
+}
+
+export function parseTocLangSearch(raw: unknown): string[] {
+  if (Array.isArray(raw)) {
+    return raw
+      .flatMap((part) => (typeof part === 'string' ? parseTocLangSearch(part) : []))
+      .filter(Boolean)
+  }
+  if (typeof raw !== 'string' || !raw.trim()) return []
+  return raw
+    .split(',')
+    .map((part) => decodeURIComponent(part.trim()))
+    .filter(Boolean)
+}
+
+export function serializeTocLangSearch(ids: readonly string[]): string | undefined {
+  if (ids.length === 0) return undefined
+  return ids.map((id) => encodeURIComponent(id)).join(',')
+}
+
+function parseTocTagSearchPart(part: string): string | undefined {
+  const trimmed = part.trim()
+  if (!trimmed) return undefined
+
+  const urlSep = trimmed.indexOf(TAG_URL_SEP)
+  if (urlSep >= 0) {
+    const key = decodeURIComponent(trimmed.slice(0, urlSep))
+    const value = decodeURIComponent(trimmed.slice(urlSep + 1))
+    return key && value ? tocTagFilterId(key, value) : undefined
+  }
+
+  const internalSep = trimmed.indexOf('\u0000')
+  if (internalSep >= 0) {
+    const key = trimmed.slice(0, internalSep)
+    const value = trimmed.slice(internalSep + 1)
+    return key && value ? tocTagFilterId(key, value) : undefined
+  }
+
+  return undefined
+}
+
+export function parseTocTagsSearch(raw: unknown): string[] {
+  if (Array.isArray(raw)) {
+    return raw.flatMap((part) => (typeof part === 'string' ? parseTocTagsSearch(part) : []))
+  }
+  if (typeof raw !== 'string' || !raw.trim()) return []
+  const ids: string[] = []
+  for (const part of raw.split(',')) {
+    const id = parseTocTagSearchPart(part)
+    if (id) ids.push(id)
+  }
+  return ids
+}
+
+export function serializeTocTagsSearch(ids: readonly string[]): string | undefined {
+  if (ids.length === 0) return undefined
+  return ids
+    .map((id) => {
+      const sep = id.indexOf('\u0000')
+      if (sep < 0) return encodeURIComponent(id)
+      const key = id.slice(0, sep)
+      const value = id.slice(sep + 1)
+      return `${encodeURIComponent(key)}${TAG_URL_SEP}${encodeURIComponent(value)}`
+    })
+    .join(',')
+}

--- a/frontend/app/src/routes/player/index.tsx
+++ b/frontend/app/src/routes/player/index.tsx
@@ -2,23 +2,26 @@ import { createFileRoute } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 
 import { PlayerRouteInner } from '@/components/player/PlayerRoute'
-import { parsePlayerMode, resolvePlayerMode } from '@/lib/player/player-mode'
+import { resolvePlayerMode } from '@/lib/player/player-mode'
 import { readPlayerDefaultMode } from '@/lib/player/player-mode-preference'
-import { parseOptionalPlayerIndex } from '@/lib/player/player-editor-return'
-import type { PlayerEntityType } from '@/lib/player-route'
-
-function parsePlayerType(raw: unknown): PlayerEntityType | undefined {
-  if (raw === 'song' || raw === 'setlist' || raw === 'collection') return raw
-  return undefined
-}
+import { parsePlayerRouteSearch } from '@/lib/player-route'
+import {
+  serializeTocLangSearch,
+  serializeTocTagsSearch,
+} from '@/lib/player/player-toc-search'
 
 export const Route = createFileRoute('/player/')({
   validateSearch: (search: Record<string, unknown>) => {
-    const id = typeof search.id === 'string' ? search.id : ''
-    const type = parsePlayerType(search.type)
-    const index = parseOptionalPlayerIndex(search.index)
-    const mode = parsePlayerMode(search.mode)
-    return { type, id, index, mode }
+    const parsed = parsePlayerRouteSearch(search)
+    return {
+      type: parsed.type,
+      id: parsed.id,
+      index: parsed.index,
+      mode: parsed.mode,
+      toc: parsed.toc,
+      tocLang: serializeTocLangSearch(parsed.tocLang),
+      tocTags: serializeTocTagsSearch(parsed.tocTags),
+    }
   },
   component: PlayerPageComponent,
 })


### PR DESCRIPTION
## Summary

- Simplify the README command for running the frontend against production
- Sync player song index and TOC sidebar filters to URL query params
- Align player header icon buttons with hub styling and refine overlay tap/keyboard behavior
- Keep AV projection output stable when switching songs in the outline
- Fix false error on team delete (HTTP 204)
- Reduce two- and three-column chord font size in the player

## Commits

1. fix(teams): accept HTTP 204 as successful team delete
2. fix(player): reduce multi-column chord font size
3. docs(readme): simplify production frontend dev command
4. feat(player): add typed route search params for player URL
5. feat(player): sync song index and TOC filters to URL
6. feat(player): align header icons and refine overlay interaction
7. fix(player/av): preserve projection output when switching songs

## Test plan

- [ ] Run `VITE_DEV_PROXY_TARGET=https://app.worshipviewer.com pnpm -C frontend dev` and confirm the app loads
- [ ] Open a setlist in the player; confirm `index` updates in the URL when navigating songs
- [ ] Toggle TOC sort mode and tag filters; confirm `toc`, `tocTags` appear in the URL and restore on reload
- [ ] Open player chrome overlay; confirm edge taps close it, middle tap toggles it, and prev/next/swipe are blocked while open
- [ ] In AV mode, switch songs via TOC; confirm the output/preview slide is not cleared until slides are navigated
- [ ] Delete a team; confirm no error toast when delete succeeds
- [ ] View a dense 2/3-column chord sheet; confirm text is slightly smaller than before