### PR TITLE
chore: bump Rust to 1.96.0 to fix Docker CI build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.94.1-slim AS builder
+FROM rust:1.96.0-slim AS builder
 
 RUN export CARGO_BUILD_JOBS=$(nproc) && \
     rustup target add wasm32-unknown-unknown && \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "1.96.0"


### PR DESCRIPTION
## Summary
- The recent dependency update pulled in `ferntree 0.7.0`, which calls `std::hint::cold_path()` — a feature stabilized in **Rust 1.95.0**.
- The Docker builder was pinned to `rust:1.94.1-slim`, so the build failed with `error[E0658]: use of unstable library feature 'cold_path'`.
- Bump the builder image to `rust:1.96.0-slim` and pin `rust-toolchain.toml` to `1.96.0` so local and CI toolchains stay in lockstep.

## Test plan
- [ ] Backend CI `docker-publish` job builds successfully.