### PR TITLE
Fix Venom tests for required song collection on create

### DIFF
--- a/backend/tests/2_users.yml
+++ b/backend/tests/2_users.yml
@@ -547,6 +547,28 @@ testcases:
           blobid:
             from: result.bodyjson.id
 
+  # BLC: BLC-USER-003, BLC-SONG-009
+  - name: create-default-user-song-collection-setup
+    steps:
+      - type: http
+        method: POST
+        url: "{{.base_url}}/api/v1/collections"
+        headers:
+          Authorization: "Bearer {{.create-session-for-default-user.sessionid}}"
+          Content-Type: application/json
+        body: |
+          {
+            "title": "Cascade Song Collection",
+            "cover": "{{.create-default-user-blob.blobid}}",
+            "songs": []
+          }
+        assertions:
+          - result.statuscode ShouldEqual 201
+          - result.bodyjson.owner ShouldEqual "{{.get-default-user-personal-team.default_user_personal_team_id}}"
+        vars:
+          collectionid:
+            from: result.bodyjson.id
+
   # BLC: BLC-USER-003
   - name: create-default-user-song
     steps:
@@ -558,6 +580,7 @@ testcases:
           Content-Type: application/json
         body: |
           {
+            "collection": "{{.create-default-user-song-collection-setup.collectionid}}",
             "not_a_song": false,
             "blobs": [],
             "data": {

--- a/backend/tests/4_songs.yml
+++ b/backend/tests/4_songs.yml
@@ -1202,7 +1202,6 @@ testcases:
           Content-Type: application/json
         body: |
           {
-            "collection": "{{.setup-song-owner-test-collection.song_owner_collection_id}}",
             "not_a_song": false,
             "blobs": [],
             "data": {


### PR DESCRIPTION
## Summary
- Add a collection setup step before cascade song creation in `2_users.yml` (POST `/api/v1/songs` now requires `collection` since #150).
- Remove `collection` from the `put-song-success` body in `4_songs.yml` (`UpdateSong` rejects unknown fields).

Fixes the `docker-publish` Venom step that failed on [main run 26752331864](https://github.com/xilefmusics/worshipviewer/actions/runs/26752331864).

## Test plan
- [x] `cd backend && cargo venom` — all suites PASS locally
- [ ] Merge to `main` and confirm Backend CI `docker-publish` succeeds