### PR TITLE
Speed up CI: reuse frontend dist and debug backend for e2e

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -37,7 +37,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: backend
+          workspaces: |
+            backend
+            shared
 
       - name: Build
         working-directory: backend
@@ -45,7 +47,7 @@ jobs:
 
       - name: Test
         working-directory: backend
-        run: cargo test
+        run: cargo test -- --test-threads=4
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -37,13 +37,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: |
-            backend
-            shared
-
-      - name: Build
-        working-directory: backend
-        run: cargo build
+          workspaces: backend
+          shared-key: wv-backend
 
       - name: Test
         working-directory: backend

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -68,8 +68,35 @@ jobs:
           path: frontend/app/dist/
           retention-days: 1
 
+  backend-e2e:
+    runs-on: ubuntu-latest
+    env:
+      GIT_COMMIT_SHA: ${{ github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.96.0
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: backend
+          shared-key: wv-backend
+
+      - name: Build backend (e2e server)
+        working-directory: backend
+        run: cargo build -p backend
+
+      - name: Upload backend binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-e2e-bin
+          path: backend/target/debug/backend
+          retention-days: 1
+
   frontend-e2e:
-    needs: frontend
+    needs: [frontend, backend-e2e]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -84,6 +111,14 @@ jobs:
           name: frontend-dist
           path: frontend/app/dist
 
+      - uses: actions/download-artifact@v4
+        with:
+          name: backend-e2e-bin
+          path: backend/target/debug
+
+      - name: Make backend binary executable
+        run: chmod +x backend/target/debug/backend
+
       - uses: pnpm/action-setup@v4
         with:
           version: 10.33.0
@@ -96,20 +131,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: 1.96.0
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            backend
-            shared
-
-      - name: Build backend (e2e server)
-        working-directory: backend
-        run: cargo build -p backend
 
       - name: Get Playwright version
         id: playwright-version

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -114,10 +114,13 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: backend-e2e-bin
-          path: backend/target/debug
+          path: backend-e2e-staging
 
-      - name: Make backend binary executable
-        run: chmod +x backend/target/debug/backend
+      - name: Install backend binary
+        working-directory: ${{ github.workspace }}
+        run: |
+          mkdir -p backend/target/debug
+          install -m 755 backend-e2e-staging/backend backend/target/debug/backend
 
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -61,13 +61,28 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Upload frontend dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/app/dist/
+          retention-days: 1
+
   frontend-e2e:
+    needs: frontend
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: frontend
+    env:
+      GIT_COMMIT_SHA: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/app/dist
 
       - uses: pnpm/action-setup@v4
         with:
@@ -82,27 +97,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-
-      - name: Build WASM
-        run: pnpm build:wasm
-
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: 1.96.0
 
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: backend
+          workspaces: |
+            backend
+            shared
 
       - name: Build backend (e2e server)
         working-directory: backend
-        run: cargo build --release -p backend
+        run: cargo build -p backend
 
       - name: Get Playwright version
         id: playwright-version
@@ -116,10 +123,8 @@ jobs:
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm --filter app exec playwright install --with-deps chromium
-
-      - name: Build
-        run: pnpm build
 
       - name: Run e2e tests
         run: pnpm --filter app test:e2e

--- a/frontend/app/e2e/auth.spec.ts
+++ b/frontend/app/e2e/auth.spec.ts
@@ -137,7 +137,7 @@ test('A4: log out clears local data', async ({ seed, browser, baseURL }) => {
     const { context, page } = await authedPage()
     await goto(page, '/collections')
     await context.setOffline(true)
-    await page.getByRole('button', { name: 'Open profile menu' }).click()
+    await page.getByRole('button', { name: /Open profile menu/ }).click()
     await page.getByRole('menuitem', { name: 'Log out' }).click()
     await expect(page).toHaveURL(/\/login/)
     await context.close()

--- a/frontend/app/e2e/serve-backend.mjs
+++ b/frontend/app/e2e/serve-backend.mjs
@@ -1,6 +1,6 @@
 /**
  * Playwright webServer entry: boots the real backend with in-memory DB and admin test session.
- * Requires `pnpm build` (frontend/app/dist) and a release backend binary (or cargo run).
+ * Requires `pnpm build` (frontend/app/dist) and a backend binary (debug preferred, or cargo run).
  */
 import { spawn } from 'node:child_process'
 import { existsSync, mkdtempSync } from 'node:fs'
@@ -13,6 +13,7 @@ const appDir = path.resolve(__dirname, '..')
 const repoRoot = path.resolve(appDir, '../..')
 const distDir = path.join(appDir, 'dist')
 const backendDir = path.join(repoRoot, 'backend')
+const debugBin = path.join(backendDir, 'target/debug/backend')
 const releaseBin = path.join(backendDir, 'target/release/backend')
 
 const PORT = Number(process.env.E2E_PORT ?? 8788)
@@ -41,11 +42,17 @@ const env = {
   DB_ADDRESS: 'mem://',
 }
 
-const useRelease = existsSync(releaseBin)
-const cmd = useRelease ? releaseBin : 'cargo'
-const args = useRelease ? [] : ['run', '--release', '--bin', 'backend']
+const prebuiltBin = existsSync(debugBin)
+  ? debugBin
+  : existsSync(releaseBin)
+    ? releaseBin
+    : null
+const cmd = prebuiltBin ?? 'cargo'
+const args = prebuiltBin ? [] : ['run', '--bin', 'backend']
 
-console.log(`[e2e] starting backend (${useRelease ? 'release binary' : 'cargo run'}) on ${HOST}:${PORT}`)
+console.log(
+  `[e2e] starting backend (${prebuiltBin ? 'prebuilt binary' : 'cargo run'}) on ${HOST}:${PORT}`,
+)
 
 const child = spawn(cmd, args, {
   cwd: backendDir,


### PR DESCRIPTION
## Summary
- Upload `frontend/app/dist` from the `frontend` job and have `frontend-e2e` download it, skipping duplicate WASM and frontend builds (~60s saved).
- Build a debug backend for e2e (`cargo build -p backend`) so it shares the rust-cache profile with `backend-validate` instead of cold-compiling release (~10 min on cache miss).
- Prefer the debug binary in `serve-backend.mjs`; parallelize backend tests with `--test-threads=4`.

## Test plan
- [ ] Verify `frontend` job uploads dist artifact successfully
- [ ] Verify `frontend-e2e` completes in under ~2 minutes with warm rust cache
- [ ] Confirm e2e tests pass against debug backend binary