### PR TITLE
Fix iPhone PDF export, search zoom, and Safari print hints

### DIFF
--- a/frontend/app/src/components/hub/EntityListView.tsx
+++ b/frontend/app/src/components/hub/EntityListView.tsx
@@ -49,6 +49,7 @@ import { useLongPress } from '@/hooks/useLongPress'
 import { useOnline } from '@/hooks/use-online'
 import { useSession } from '@/hooks/useSession'
 import { useTeamDetail } from '@/hooks/useTeamDetail'
+import { exportPdfHintTitle } from '@/lib/export-pdf-hint'
 import { runCollectionExport } from '@/lib/run-collection-export'
 import { runSetlistExport } from '@/lib/run-setlist-export'
 import { runSongExport, type SongExportKind } from '@/lib/run-song-export'
@@ -521,6 +522,14 @@ function HubItemContextMenu({
   const showOrderedExport = entity === 'setlists' || entity === 'collections'
   const showDuplicate = showOrderedExport
   const titleSuffix = t('collections.hub.duplicateTitleSuffix')
+  const hubExportPdfHint = useMemo(
+    () =>
+      exportPdfHintTitle(
+        t('hub.actions.exportPdfHint'),
+        t('hub.actions.exportPdfHintSafariHeaders'),
+      ),
+    [t],
+  )
 
   const onDuplicate = useCallback(async () => {
     const toastId = toast.loading(t('hub.actions.duplicate'))
@@ -723,7 +732,7 @@ function HubItemContextMenu({
               </ContextMenuItem>
               <ContextMenuItem
                 className="gap-2"
-                title={t('hub.actions.exportPdfHint')}
+                title={hubExportPdfHint}
                 onSelect={() => void onSongExport('pdf')}
               >
                 {t('hub.actions.export')} — {t('hub.actions.exportPdf')}
@@ -747,7 +756,7 @@ function HubItemContextMenu({
               </ContextMenuItem>
               <ContextMenuItem
                 className="gap-2"
-                title={t('hub.actions.exportPdfHint')}
+                title={hubExportPdfHint}
                 onSelect={() => void onOrderedExport('pdf')}
               >
                 {t('hub.actions.export')} — {t('hub.actions.exportPdf')}

--- a/frontend/app/src/components/songs/SongEditorActionsMenu.tsx
+++ b/frontend/app/src/components/songs/SongEditorActionsMenu.tsx
@@ -21,6 +21,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import type { ChordFormatPreference } from '@/lib/chord-format'
+import { exportPdfHintTitle } from '@/lib/export-pdf-hint'
 import { runSongExport, type SongExportKind } from '@/lib/run-song-export'
 import {
   formatImportedSource,
@@ -106,13 +107,13 @@ export function SongEditorActionsMenu({
       if (!exportData) return
       onExportError?.(null)
       try {
-        await runSongExport(exportData, kind, chordFormat)
+        await runSongExport(exportData, kind, chordFormat, engine ?? undefined)
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e)
         onExportError?.(message || t('songs.editor.exportFailed'))
       }
     },
-    [chordFormat, exportData, onExportError, t],
+    [chordFormat, engine, exportData, onExportError, t],
   )
 
   return (
@@ -166,7 +167,10 @@ export function SongEditorActionsMenu({
             {t('songs.editor.exportWorshipPro')}
           </DropdownMenuItem>
           <DropdownMenuItem
-            title={t('songs.editor.exportPdfHint')}
+            title={exportPdfHintTitle(
+              t('songs.editor.exportPdfHint'),
+              t('songs.editor.exportPdfHintSafariHeaders'),
+            )}
             onSelect={() => void onExport('pdf')}
           >
             {t('songs.editor.exportPdf')}

--- a/frontend/app/src/components/ui/input.tsx
+++ b/frontend/app/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className
     <input
       ref={ref}
       className={cn(
-        'flex h-9 w-full rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1 text-base shadow-sm transition-colors placeholder:text-[var(--color-muted-foreground)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary)] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'flex h-9 w-full rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1 text-base shadow-sm transition-colors placeholder:text-[var(--color-muted-foreground)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary)] disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
       {...props}

--- a/frontend/app/src/i18n/de.json
+++ b/frontend/app/src/i18n/de.json
@@ -136,6 +136,7 @@
       "exportWorshipPro": "Worship Pro",
       "exportPdf": "PDF (Drucken)",
       "exportPdfHint": "Öffnet den Druckdialog — „Als PDF sichern“ wählen.",
+      "exportPdfHintSafariHeaders": "In Safari: Kopf- und Fußzeilen im Druckdialog deaktivieren für beste Ergebnisse.",
       "exportPreparing": "Export wird vorbereitet…",
       "exportFailed": "Song konnte nicht exportiert werden.",
       "exportSetlistFailed": "Setliste konnte nicht exportiert werden.",
@@ -700,6 +701,7 @@
       "exportWorshipPro": "Als Worship Pro exportieren",
       "exportPdf": "Drucken / Als PDF",
       "exportPdfHint": "Öffnet den Druckdialog — „Als PDF sichern“ wählen.",
+      "exportPdfHintSafariHeaders": "In Safari: Kopf- und Fußzeilen im Druckdialog deaktivieren für beste Ergebnisse.",
       "exportFailed": "Song konnte nicht exportiert werden."
     },
     "import": {

--- a/frontend/app/src/i18n/en.json
+++ b/frontend/app/src/i18n/en.json
@@ -136,6 +136,7 @@
       "exportWorshipPro": "Worship Pro",
       "exportPdf": "PDF (print)",
       "exportPdfHint": "Opens the print dialog — choose Save as PDF.",
+      "exportPdfHintSafariHeaders": "On Safari, turn off Headers and Footers in print options for best results.",
       "exportPreparing": "Preparing export…",
       "exportFailed": "Could not export this song.",
       "exportSetlistFailed": "Could not export this setlist.",
@@ -700,6 +701,7 @@
       "exportWorshipPro": "Export as Worship Pro",
       "exportPdf": "Print / Save as PDF",
       "exportPdfHint": "Opens the print dialog — choose Save as PDF.",
+      "exportPdfHintSafariHeaders": "On Safari, turn off Headers and Footers in print options for best results.",
       "exportFailed": "Could not export this song."
     },
     "import": {

--- a/frontend/app/src/lib/export-pdf-hint.test.ts
+++ b/frontend/app/src/lib/export-pdf-hint.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { exportPdfHintTitle } from '@/lib/export-pdf-hint'
+
+describe('exportPdfHintTitle', () => {
+  it('returns base hint only on non-Safari platforms', () => {
+    vi.stubGlobal('navigator', {
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+    })
+    expect(exportPdfHintTitle('Base.', 'Safari extra.')).toBe('Base.')
+    vi.unstubAllGlobals()
+  })
+
+  it('appends Safari headers hint on iPhone', () => {
+    vi.stubGlobal('navigator', {
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)',
+      platform: 'iPhone',
+      maxTouchPoints: 5,
+    })
+    expect(exportPdfHintTitle('Base.', 'Safari extra.')).toBe('Base. Safari extra.')
+    vi.unstubAllGlobals()
+  })
+})

--- a/frontend/app/src/lib/export-pdf-hint.ts
+++ b/frontend/app/src/lib/export-pdf-hint.ts
@@ -1,0 +1,9 @@
+import { needsSafariPdfPrintHint } from '@/lib/platform'
+
+/** Tooltip for PDF export menu items (base hint + Safari headers note when relevant). */
+export function exportPdfHintTitle(baseHint: string, safariHeadersHint: string): string {
+  if (!needsSafariPdfPrintHint()) {
+    return baseHint
+  }
+  return `${baseHint} ${safariHeadersHint}`
+}

--- a/frontend/app/src/lib/platform.test.ts
+++ b/frontend/app/src/lib/platform.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { isIosOrIpadosDevice, isMacDesktopSafari, needsSafariPdfPrintHint } from '@/lib/platform'
+
+describe('platform detection', () => {
+  it('needsSafariPdfPrintHint is true when iOS or Mac Safari', () => {
+    vi.stubGlobal('navigator', {
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)',
+      platform: 'iPhone',
+      maxTouchPoints: 5,
+    })
+    expect(isIosOrIpadosDevice()).toBe(true)
+    expect(needsSafariPdfPrintHint()).toBe(true)
+    vi.unstubAllGlobals()
+  })
+
+  it('needsSafariPdfPrintHint is false for Chrome on Mac', () => {
+    vi.stubGlobal('navigator', {
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+    })
+    expect(isIosOrIpadosDevice()).toBe(false)
+    expect(isMacDesktopSafari()).toBe(false)
+    expect(needsSafariPdfPrintHint()).toBe(false)
+    vi.unstubAllGlobals()
+  })
+})

--- a/frontend/app/src/lib/platform.ts
+++ b/frontend/app/src/lib/platform.ts
@@ -1,0 +1,46 @@
+/**
+ * iPhone / iPod / iPad (incl. iPadOS 13+ “desktop” UA) / iOS WebKit (`standalone` exists).
+ * Safari on macOS does not expose `navigator.standalone`.
+ */
+export function isIosOrIpadosDevice(): boolean {
+  if (typeof globalThis.navigator === 'undefined') {
+    return false
+  }
+  const nav = globalThis.navigator
+  const ua = nav.userAgent
+  if (/(iPad|iPhone|iPod)/.test(ua)) {
+    return true
+  }
+  // iPad (incl. “Request desktop website”) often reports as Mac with touch
+  if (nav.platform === 'MacIntel' && nav.maxTouchPoints > 1) {
+    return true
+  }
+  if ('standalone' in nav) {
+    return true
+  }
+  return false
+}
+
+/** Safari on desktop macOS (not iOS, not Chrome/Edge engine disguised as Safari). */
+export function isMacDesktopSafari(): boolean {
+  if (typeof globalThis.navigator === 'undefined') {
+    return false
+  }
+  if (isIosOrIpadosDevice()) {
+    return false
+  }
+  const ua = globalThis.navigator.userAgent
+  if (!/Macintosh|Mac OS X/.test(ua) || !/Safari\//.test(ua)) {
+    return false
+  }
+  // Real Safari has “Version/… Safari/…”; Chrome/Edge/Brave/Firefox on Mac include a different engine token
+  if (/(?:Chrome|Chromium|Edg|OPR|Brave|Firefox|FxiOS|CriOS)\//.test(ua)) {
+    return false
+  }
+  return true
+}
+
+/** iOS/iPadOS or Safari on Mac — browsers that show print header/footer chrome. */
+export function needsSafariPdfPrintHint(): boolean {
+  return isIosOrIpadosDevice() || isMacDesktopSafari()
+}

--- a/frontend/app/src/lib/run-song-export.ts
+++ b/frontend/app/src/lib/run-song-export.ts
@@ -5,7 +5,7 @@ import {
   exportSongText,
   type TextExportFormat,
 } from '@/lib/song-import-export'
-import type { ChordSongData } from '@/ports/chord-engine'
+import type { ChordEngine, ChordSongData } from '@/ports/chord-engine'
 
 export type SongExportKind = TextExportFormat | 'pdf'
 
@@ -13,11 +13,12 @@ export async function runSongExport(
   data: ChordSongData,
   kind: SongExportKind,
   chordFormat: ChordFormatPreference,
+  engine?: ChordEngine,
 ): Promise<void> {
-  const engine = await getChordEngine()
+  const resolved = engine ?? (await getChordEngine())
   if (kind === 'pdf') {
-    await exportSongPdf(engine, data, chordFormat)
+    await exportSongPdf(resolved, data, chordFormat)
     return
   }
-  exportSongText(engine, data, kind, chordFormat)
+  exportSongText(resolved, data, kind, chordFormat)
 }

--- a/frontend/app/src/lib/song-import-export.test.ts
+++ b/frontend/app/src/lib/song-import-export.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import {
+  buildPdfPrintCss,
   createSongBodyFromParsed,
   importSongsBatch,
   orderedSongZipEntryNames,
@@ -21,6 +22,17 @@ function mockEngine(overrides?: Partial<ChordEngine>): ChordEngine {
     ...overrides,
   }
 }
+
+describe('buildPdfPrintCss', () => {
+  it('includes print pagination overrides for chordlib page layout', () => {
+    const css = buildPdfPrintCss()
+    expect(css).toContain('@media print')
+    expect(css).toContain('.pdf-export-root .page')
+    expect(css).toContain('height: auto')
+    expect(css).toContain('overflow: visible')
+    expect(css).toContain('.pdf-export-root .columns')
+  })
+})
 
 describe('sanitizeDownloadBasename', () => {
   it('strips unsafe characters', () => {

--- a/frontend/app/src/lib/song-import-export.ts
+++ b/frontend/app/src/lib/song-import-export.ts
@@ -184,7 +184,9 @@ const PDF_PAGE_BASE_CSS = `
 }
 `
 
-const PDF_PRINT_CSS = `
+/** Print overrides for chordlib fixed-height screen layout (exported for tests). */
+export function buildPdfPrintCss(): string {
+  return `
 @page {
   size: A4 portrait;
   margin: 0;
@@ -195,8 +197,22 @@ const PDF_PRINT_CSS = `
     padding: 0;
     background: #fff;
   }
+  .pdf-export-root .page {
+    width: 210mm;
+    height: auto;
+    min-height: 0;
+    overflow: visible;
+    transform: none;
+  }
+  .pdf-export-root .columns {
+    height: auto;
+    overflow: visible;
+  }
 }
 `
+}
+
+const PDF_PRINT_CSS = buildPdfPrintCss()
 
 const PDF_SETLIST_PAGE_BREAK_CSS = `
 .pdf-export-root + .pdf-export-root {
@@ -219,7 +235,7 @@ function mountPdfExportDocument(pages: PdfExportPage[], title: string): {
 
   const frame = document.createElement('iframe')
   frame.setAttribute('aria-hidden', 'true')
-  frame.style.cssText = `position:fixed;left:-10000px;top:0;width:${A4_WIDTH_PX}px;height:${A4_HEIGHT_PX}px;border:0;visibility:hidden;`
+  frame.style.cssText = `position:fixed;left:0;top:0;width:${A4_WIDTH_PX}px;height:${A4_HEIGHT_PX}px;border:0;opacity:0;pointer-events:none;z-index:-1;`
   document.body.appendChild(frame)
 
   const doc = frame.contentDocument
@@ -261,8 +277,10 @@ function mountPdfExportDocument(pages: PdfExportPage[], title: string): {
   return { frame, pageRoots, contentWindow }
 }
 
-async function waitForPdfLayout(pageRoots: HTMLElement[]): Promise<void> {
-  await document.fonts.ready
+async function waitForPdfLayout(doc: Document, pageRoots: HTMLElement[]): Promise<void> {
+  if (doc.fonts?.ready) {
+    await doc.fonts.ready
+  }
   await new Promise<void>((resolve) => {
     requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
   })
@@ -295,7 +313,7 @@ async function printPdfDocument(pages: PdfExportPage[], title: string): Promise<
   window.setTimeout(restoreAppTitle, 300_000)
 
   try {
-    await waitForPdfLayout(pageRoots)
+    await waitForPdfLayout(contentWindow.document, pageRoots)
     await new Promise<void>((resolve) => {
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {

--- a/frontend/app/src/pwa/PwaInstallProvider.tsx
+++ b/frontend/app/src/pwa/PwaInstallProvider.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
+import { isIosOrIpadosDevice, isMacDesktopSafari } from '@/lib/platform'
 import { PwaInstallContext } from '@/pwa/pwa-install-context'
 import { cn } from '@/lib/utils'
 
@@ -59,48 +60,6 @@ async function probeIndexedDbDurable(): Promise<boolean> {
       resolve(false)
     }
   })
-}
-
-/**
- * iPhone / iPod / iPad (incl. iPadOS 13+ “desktop” UA) / iOS WebKit (`standalone` exists).
- * Safari on macOS does not expose `navigator.standalone`.
- */
-function isIosOrIpadosDevice(): boolean {
-  if (typeof globalThis.navigator === 'undefined') {
-    return false
-  }
-  const nav = globalThis.navigator
-  const ua = nav.userAgent
-  if (/(iPad|iPhone|iPod)/.test(ua)) {
-    return true
-  }
-  // iPad (incl. “Request desktop website”) often reports as Mac with touch
-  if (nav.platform === 'MacIntel' && nav.maxTouchPoints > 1) {
-    return true
-  }
-  if ('standalone' in nav) {
-    return true
-  }
-  return false
-}
-
-/** Safari on desktop macOS (not iOS, not Chrome/Edge engine disguised as Safari). */
-function isMacDesktopSafari(): boolean {
-  if (typeof globalThis.navigator === 'undefined') {
-    return false
-  }
-  if (isIosOrIpadosDevice()) {
-    return false
-  }
-  const ua = globalThis.navigator.userAgent
-  if (!/Macintosh|Mac OS X/.test(ua) || !/Safari\//.test(ua)) {
-    return false
-  }
-  // Real Safari has “Version/… Safari/…”; Chrome/Edge/Brave/Firefox on Mac include a different engine token
-  if (/(?:Chrome|Chromium|Edg|OPR|Brave|Firefox|FxiOS|CriOS)\//.test(ua)) {
-    return false
-  }
-  return true
 }
 
 export function PwaInstallProvider({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Summary

- **PDF export on iPhone/iPad/Safari:** Add `@media print` overrides so chordlib A4 pages paginate instead of clipping with `overflow: hidden`; use a WebKit-safe in-viewport print iframe and await fonts on the iframe document.
- **Hub search zoom:** Keep all `Input` fields at `text-base` (16px) by removing `md:text-sm`, complementing the existing viewport and hub search styling.
- **Safari print UX:** Extract iOS/Safari detection to `platform.ts` and append a tooltip on PDF export menu items to turn off Headers and Footers in the print dialog.
- **Song editor PDF:** Pass a preloaded `ChordEngine` into export to keep print closer to the user tap on iOS.

Player rotation React error #185 was already fixed in #148; no additional code in this PR.

## Test plan

- [ ] Export a long song as PDF in Safari on Mac with headers on/off — full lyrics, no empty second page when content fits one page
- [ ] iPhone: tap hub search — no page zoom; pinch/double-tap do not zoom the app
- [ ] iPhone: player with portrait 2+ / landscape 3+ columns — rotate without React error #185
- [ ] Mac Chrome PDF export unchanged
- [x] Unit tests: `song-import-export`, `platform`, `export-pdf-hint`