### PR TITLE
feat(search): case-insensitive title substring matching for list q

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3602,7 +3602,7 @@
             }
           },
           {
-            "description": "Full-text search query (title); uses text_search analyzer (stemming)",
+            "description": "Search query (title): full-text via text_search analyzer (stemming) plus case-insensitive substring match",
             "in": "query",
             "name": "q",
             "required": false,
@@ -5071,7 +5071,7 @@
             }
           },
           {
-            "description": "Full-text search query (title); uses text_search analyzer (stemming)",
+            "description": "Search query (title): full-text via text_search analyzer (stemming) plus case-insensitive substring match",
             "in": "query",
             "name": "q",
             "required": false,
@@ -5985,7 +5985,7 @@
             }
           },
           {
-            "description": "Full-text search query (titles, artists, line lyrics); uses text_search analyzer (stemming)",
+            "description": "Search query: full-text on titles (plus case-insensitive title substring), artists, and line lyrics via text_search analyzer (stemming)",
             "in": "query",
             "name": "q",
             "required": false,

--- a/backend/src/resources/collection/rest.rs
+++ b/backend/src/resources/collection/rest.rs
@@ -48,7 +48,7 @@ pub fn scope(cover_upload_max_bytes: usize) -> Scope {
     params(
         ("page" = Option<u32>, Query, description = "Zero-based page (default 0). `X-Total-Count` = filtered total before pagination; last page when `items.len() < page_size` or empty (`list-pagination.md`).", minimum = 0, nullable = true),
         ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50.", minimum = 1, maximum = 500, example = 50, nullable = true),
-        ("q" = Option<String>, Query, description = "Full-text search query (title); uses text_search analyzer (stemming)")
+        ("q" = Option<String>, Query, description = "Search query (title): full-text via text_search analyzer (stemming) plus case-insensitive substring match")
     ),
     responses(
         (status = 200, description = "Return all collections. `X-Total-Count` header contains the total number of matching collections.", body = [Collection]),

--- a/backend/src/resources/collection/surreal_repo.rs
+++ b/backend/src/resources/collection/surreal_repo.rs
@@ -52,7 +52,9 @@ impl CollectionRepository for SurrealCollectionRepo {
             String::from("SELECT * FROM collection WHERE owner IN $teams")
         };
         if q_nonempty {
-            query.push_str(" AND title @0@ $q ORDER BY score DESC");
+            query.push_str(
+                " AND (title @0@ $q OR string::contains(string::lowercase(title), string::lowercase($q))) ORDER BY score DESC",
+            );
         }
         let (offset, limit) = pagination.effective_offset_limit();
         query.push_str(" LIMIT $limit START $start");
@@ -86,7 +88,9 @@ impl CollectionRepository for SurrealCollectionRepo {
         let q_nonempty = q.is_some_and(|s| !s.trim().is_empty());
         let mut query = String::from("SELECT count() FROM collection WHERE owner IN $teams");
         if q_nonempty {
-            query.push_str(" AND title @0@ $q");
+            query.push_str(
+                " AND (title @0@ $q OR string::contains(string::lowercase(title), string::lowercase($q)))",
+            );
         }
         query.push_str(" GROUP ALL");
 

--- a/backend/src/resources/setlist/rest.rs
+++ b/backend/src/resources/setlist/rest.rs
@@ -41,7 +41,7 @@ pub fn scope() -> Scope {
     params(
         ("page" = Option<u32>, Query, description = "Zero-based page (default 0). `X-Total-Count` = filtered total before pagination; last page when `items.len() < page_size` or empty (`list-pagination.md`).", minimum = 0, nullable = true),
         ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50.", minimum = 1, maximum = 500, example = 50, nullable = true),
-        ("q" = Option<String>, Query, description = "Full-text search query (title); uses text_search analyzer (stemming)")
+        ("q" = Option<String>, Query, description = "Search query (title): full-text via text_search analyzer (stemming) plus case-insensitive substring match")
     ),
     responses(
         (status = 200, description = "Return all setlists. `X-Total-Count` header contains the total number of matching setlists.", body = [Setlist]),

--- a/backend/src/resources/setlist/surreal_repo.rs
+++ b/backend/src/resources/setlist/surreal_repo.rs
@@ -52,7 +52,9 @@ impl SetlistRepository for SurrealSetlistRepo {
             String::from("SELECT * FROM setlist WHERE owner IN $teams")
         };
         if q_nonempty {
-            query.push_str(" AND title @0@ $q ORDER BY score DESC");
+            query.push_str(
+                " AND (title @0@ $q OR string::contains(string::lowercase(title), string::lowercase($q))) ORDER BY score DESC",
+            );
         }
         let (offset, limit) = pagination.effective_offset_limit();
         query.push_str(" LIMIT $limit START $start");
@@ -85,7 +87,9 @@ impl SetlistRepository for SurrealSetlistRepo {
         let q_nonempty = q.is_some_and(|s| !s.trim().is_empty());
         let mut query = String::from("SELECT count() FROM setlist WHERE owner IN $teams");
         if q_nonempty {
-            query.push_str(" AND title @0@ $q");
+            query.push_str(
+                " AND (title @0@ $q OR string::contains(string::lowercase(title), string::lowercase($q)))",
+            );
         }
         query.push_str(" GROUP ALL");
 

--- a/backend/src/resources/song/rest.rs
+++ b/backend/src/resources/song/rest.rs
@@ -43,7 +43,7 @@ pub fn scope() -> Scope {
     params(
         ("page" = Option<u32>, Query, description = "Zero-based page index (default 0). `X-Total-Count` is the total before pagination; the last page is when `items.len() < page_size` or the list is empty (see `docs/business-logic-constraints/list-pagination.md`).", minimum = 0, nullable = true),
         ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50.", minimum = 1, maximum = 500, example = 50, nullable = true),
-        ("q" = Option<String>, Query, description = "Full-text search query (titles, artists, line lyrics); uses text_search analyzer (stemming)"),
+        ("q" = Option<String>, Query, description = "Search query: full-text on titles (plus case-insensitive title substring), artists, and line lyrics via text_search analyzer (stemming)"),
         ("sort" = Option<String>, Query, description = "Sort: JSON:API-style comma-separated keys (`-` = descending), e.g. `-id`, `title`, `relevance` (with `q`). Legacy `id_desc` / … still accepted."),
         ("lang" = Option<String>, Query, description = "Filter: song must list this language in `data.languages`."),
         ("tag" = Option<String>, Query, description = "Filter: case-insensitive substring match on stringified `data.tags`.")

--- a/backend/src/resources/song/surreal_repo.rs
+++ b/backend/src/resources/song/surreal_repo.rs
@@ -71,6 +71,9 @@ const FULLTEXT_FRAGMENTS: &[&str] = &[
 
 const FULLTEXT_WEIGHTS: &[f64] = &[100.0, 10.0, 1.0];
 
+/// Case-insensitive title substring (no `search::score` — not a full-text predicate).
+const TITLE_SUBSTRING_PREDICATE: &str = "array::len(data.titles[WHERE string::contains(string::lowercase($this), string::lowercase($q))]) > 0";
+
 async fn song_fulltext_combined_scores(
     db: &Database,
     read_teams: &[RecordId],
@@ -104,6 +107,31 @@ async fn song_fulltext_combined_scores(
             *scores.entry(id).or_insert(0.0) += row.rel_score * weight;
         }
     }
+
+    let sql = format!(
+        "SELECT id, 0.0 AS rel_score FROM song WHERE owner IN $teams{extra_where} AND {TITLE_SUBSTRING_PREDICATE}",
+    );
+    let mut request = db
+        .db
+        .query(sql)
+        .bind(("teams", read_teams.to_vec()))
+        .bind(("q", q_trimmed.to_string()));
+    for &(k, ref v) in extra_binds {
+        request = request.bind((k, v.clone()));
+    }
+    let mut response = request.await?;
+    let rows: Vec<SongIdScoreRow> = response.take(0)?;
+    for row in rows {
+        let Some(ref rid) = row.id else {
+            continue;
+        };
+        let id = record_id_string(rid);
+        if id.is_empty() {
+            continue;
+        }
+        scores.entry(id).or_insert(0.0);
+    }
+
     Ok(scores)
 }
 

--- a/backend/tests/4_songs.yml
+++ b/backend/tests/4_songs.yml
@@ -538,6 +538,19 @@ testcases:
           - result.bodyjson ShouldHaveLength 1
           - result.bodyjson.bodyjson0.id ShouldEqual "{{.post-search-fixture-by-title.songid}}"
 
+  # BLC: BLC-SONG-011, BLC-LP-003 — title substring (mid-word; full-text alone would not match)
+  - name: get-songs-q-title-substring
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/songs?q=titletokenx9"
+        headers:
+          Authorization: "Bearer {{.create-song-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 1
+          - result.bodyjson.bodyjson0.id ShouldEqual "{{.post-search-fixture-by-title.songid}}"
+
   # BLC: BLC-SONG-011, BLC-LP-003
   - name: get-songs-q-matches-artist
     steps:

--- a/backend/tests/5_collections.yml
+++ b/backend/tests/5_collections.yml
@@ -617,6 +617,19 @@ testcases:
           - result.bodyjson ShouldHaveLength 1
           - result.bodyjson.bodyjson0.id ShouldEqual "{{.post-collection-success.collectionid}}"
 
+  # BLC: BLC-LP-003 — title substring (mid-word; full-text alone would not match)
+  - name: get-collections-q-title-substring
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/collections?q=vorite"
+        headers:
+          Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 1
+          - result.bodyjson.bodyjson0.id ShouldEqual "{{.post-collection-success.collectionid}}"
+
   # BLC: BLC-LP-009, BLC-LP-003
   - name: get-collections-q-with-pagination
     steps:

--- a/backend/tests/6_setlists.yml
+++ b/backend/tests/6_setlists.yml
@@ -541,6 +541,19 @@ testcases:
           - result.bodyjson ShouldHaveLength 1
           - result.bodyjson.bodyjson0.id ShouldEqual "{{.post-setlist-success.setlistid}}"
 
+  # BLC: BLC-LP-003 — title substring (mid-word; full-text alone would not match)
+  - name: get-setlists-q-title-substring
+    steps:
+      - type: http
+        method: GET
+        url: "{{.base_url}}/api/v1/setlists?q=ornin"
+        headers:
+          Authorization: "Bearer {{.create-setlist-owner-session.sessionid}}"
+        assertions:
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson ShouldHaveLength 1
+          - result.bodyjson.bodyjson0.id ShouldEqual "{{.post-setlist-success.setlistid}}"
+
   # BLC: BLC-LP-009, BLC-LP-003
   - name: get-setlists-q-with-pagination
     steps:

--- a/docs/business-logic-constraints/collection.md
+++ b/docs/business-logic-constraints/collection.md
@@ -18,7 +18,7 @@
 - **BLC-COLL-007:** WHEN the caller is **guest** on the owning team and attempts **POST**/**PUT**/**DELETE** THEN the API responds **404**.
 - **BLC-COLL-008:** WHEN the caller is the personal-team **owner**, or **admin** / **content_maintainer** on the owning team, THEN mutations are allowed (subject to validation).
 - **BLC-COLL-009:** WHEN **POST** omits **`owner`** THEN the new collection’s **`owner`** IS the caller’s **personal** team. WHEN **POST** includes **`owner`** THEN it MUST name a team id the caller may **edit** (library content); **guest** on that team THEN **404**; unknown team or no edit access THEN **404** (malformed id THEN **400**).
-- **BLC-COLL-010:** WHEN **GET /collections** runs THEN only collections whose **`owner`** team the caller may read are returned; optional **`q`** filters by **title**.
+- **BLC-COLL-010:** WHEN **GET /collections** runs THEN only collections whose **`owner`** team the caller may read are returned; optional **`q`** filters by **title** (full-text plus case-insensitive substring).
 - **BLC-COLL-011:** WHEN **GET /collections/{id}**, **…/songs**, or **…/player** runs THEN visibility matches **GET /collections/{id}**.
 - **BLC-COLL-012:** WHEN **GET …/songs** runs AND a stored song id does not resolve THEN behavior is defined by the implementation (partial list, omission, or error); **500** is reserved for genuine server/infrastructure failures, not as an optional substitute for **200**.
 - **BLC-COLL-013:** WHEN **PUT** includes a **song** id that does not exist THEN the API MAY still return **200** and persist the slot; clients SHOULD validate ids.

--- a/docs/business-logic-constraints/list-pagination.md
+++ b/docs/business-logic-constraints/list-pagination.md
@@ -6,7 +6,7 @@ Applies to **GET** list routes that support paging, including **`/users`** (admi
 
 - **BLC-LP-001:** **`page`** — 0-based index of the page.
 - **BLC-LP-002:** **`page_size`** — maximum number of items per page.
-- **BLC-LP-003:** **`q`** — optional search filter: **`/songs`** (full-text: titles, artists, lyrics per analyzer rules), **`/collections`** and **`/setlists`** (**title**), **`/users`** (admin list: **email** or **user id** substring, case-insensitive), **`/teams`** (full-text **name**; case-insensitive substring on **team id**, personal **owner** email, and **member** emails), **`/users/me/sessions`** and **`/users/{id}/sessions`** (substring on **session id**, **user id**, or **user email**), **`/blobs`** (**OCR** substring, case-insensitive). Whitespace-only **`q`** is treated as absent everywhere.
+- **BLC-LP-003:** **`q`** — optional search filter: **`/songs`** (full-text on titles, artists, and line lyrics per analyzer rules; titles also match case-insensitive substring), **`/collections`** and **`/setlists`** (full-text on **title** plus case-insensitive title substring), **`/users`** (admin list: **email** or **user id** substring, case-insensitive), **`/teams`** (full-text **name**; case-insensitive substring on **team id**, personal **owner** email, and **member** emails), **`/users/me/sessions`** and **`/users/{id}/sessions`** (substring on **session id**, **user id**, or **user email**), **`/blobs`** (**OCR** substring, case-insensitive). Whitespace-only **`q`** is treated as absent everywhere.
 
 ## Validation
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3602,7 +3602,7 @@
             }
           },
           {
-            "description": "Full-text search query (title); uses text_search analyzer (stemming)",
+            "description": "Search query (title): full-text via text_search analyzer (stemming) plus case-insensitive substring match",
             "in": "query",
             "name": "q",
             "required": false,
@@ -5071,7 +5071,7 @@
             }
           },
           {
-            "description": "Full-text search query (title); uses text_search analyzer (stemming)",
+            "description": "Search query (title): full-text via text_search analyzer (stemming) plus case-insensitive substring match",
             "in": "query",
             "name": "q",
             "required": false,
@@ -5985,7 +5985,7 @@
             }
           },
           {
-            "description": "Full-text search query (titles, artists, line lyrics); uses text_search analyzer (stemming)",
+            "description": "Search query: full-text on titles (plus case-insensitive title substring), artists, and line lyrics via text_search analyzer (stemming)",
             "in": "query",
             "name": "q",
             "required": false,

--- a/frontend/app/src/api/openapi.json
+++ b/frontend/app/src/api/openapi.json
@@ -3602,7 +3602,7 @@
             }
           },
           {
-            "description": "Full-text search query (title); uses text_search analyzer (stemming)",
+            "description": "Search query (title): full-text via text_search analyzer (stemming) plus case-insensitive substring match",
             "in": "query",
             "name": "q",
             "required": false,
@@ -5071,7 +5071,7 @@
             }
           },
           {
-            "description": "Full-text search query (title); uses text_search analyzer (stemming)",
+            "description": "Search query (title): full-text via text_search analyzer (stemming) plus case-insensitive substring match",
             "in": "query",
             "name": "q",
             "required": false,
@@ -5985,7 +5985,7 @@
             }
           },
           {
-            "description": "Full-text search query (titles, artists, line lyrics); uses text_search analyzer (stemming)",
+            "description": "Search query: full-text on titles (plus case-insensitive title substring), artists, and line lyrics via text_search analyzer (stemming)",
             "in": "query",
             "name": "q",
             "required": false,

--- a/frontend/app/src/api/schema.d.ts
+++ b/frontend/app/src/api/schema.d.ts
@@ -2515,7 +2515,7 @@ export interface operations {
                  * @example 50
                  */
                 page_size?: number | null;
-                /** @description Full-text search query (title); uses text_search analyzer (stemming) */
+                /** @description Search query (title): full-text via text_search analyzer (stemming) plus case-insensitive substring match */
                 q?: string;
             };
             header?: never;
@@ -3581,7 +3581,7 @@ export interface operations {
                  * @example 50
                  */
                 page_size?: number | null;
-                /** @description Full-text search query (title); uses text_search analyzer (stemming) */
+                /** @description Search query (title): full-text via text_search analyzer (stemming) plus case-insensitive substring match */
                 q?: string;
             };
             header?: never;
@@ -4253,7 +4253,7 @@ export interface operations {
                  * @example 50
                  */
                 page_size?: number | null;
-                /** @description Full-text search query (titles, artists, line lyrics); uses text_search analyzer (stemming) */
+                /** @description Search query: full-text on titles (plus case-insensitive title substring), artists, and line lyrics via text_search analyzer (stemming) */
                 q?: string;
                 /** @description Sort: JSON:API-style comma-separated keys (`-` = descending), e.g. `-id`, `title`, `relevance` (with `q`). Legacy `id_desc` / … still accepted. */
                 sort?: string;


### PR DESCRIPTION
## Summary

- Extend `q` search on **collections**, **setlists**, and **songs** (titles only) with case-insensitive substring matching alongside existing full-text (BM25) search, so partial words like `vorite` match "Favorite Collection".
- Songs use a dedicated Surreal query for title substring (no `search::score`); artist and lyric full-text behavior is unchanged.
- Update OpenAPI descriptions, BLC docs, and Venom integration tests.

## Test plan

- [x] `cd backend && cargo fmt && cargo test && cargo clippy -- -D warnings && cargo venom`
- [ ] Manual: hub search on collections/setlists/songs with a mid-word fragment