### PR TITLE
Fix iOS PDF export print CSS specificity

### DIFF
--- a/frontend/app/src/lib/song-import-export.test.ts
+++ b/frontend/app/src/lib/song-import-export.test.ts
@@ -24,13 +24,21 @@ function mockEngine(overrides?: Partial<ChordEngine>): ChordEngine {
 }
 
 describe('buildPdfPrintCss', () => {
-  it('includes print pagination overrides for chordlib page layout', () => {
+  it('includes print pagination overrides scoped like chordlib CSS', () => {
     const css = buildPdfPrintCss()
     expect(css).toContain('@media print')
-    expect(css).toContain('.pdf-export-root .page')
+    expect(css).toContain('.pdf-export-root:nth-of-type(1) .page')
     expect(css).toContain('height: auto')
     expect(css).toContain('overflow: visible')
-    expect(css).toContain('.pdf-export-root .columns')
+    expect(css).toContain('.pdf-export-root:nth-of-type(1) .columns')
+  })
+
+  it('emits one override block per exported page', () => {
+    const css = buildPdfPrintCss(3)
+    expect(css).toContain('.pdf-export-root:nth-of-type(1) .page')
+    expect(css).toContain('.pdf-export-root:nth-of-type(2) .page')
+    expect(css).toContain('.pdf-export-root:nth-of-type(3) .page')
+    expect(css).not.toContain('.pdf-export-root:nth-of-type(4) .page')
   })
 })
 

--- a/frontend/app/src/lib/song-import-export.ts
+++ b/frontend/app/src/lib/song-import-export.ts
@@ -185,7 +185,22 @@ const PDF_PAGE_BASE_CSS = `
 `
 
 /** Print overrides for chordlib fixed-height screen layout (exported for tests). */
-export function buildPdfPrintCss(): string {
+export function buildPdfPrintCss(pageCount = 1): string {
+  const pageRules = Array.from({ length: pageCount }, (_, index) => {
+    const host = `.pdf-export-root:nth-of-type(${index + 1})`
+    return `${host} .page {
+    width: 210mm;
+    height: auto;
+    min-height: 0;
+    overflow: visible;
+    transform: none;
+  }
+  ${host} .columns {
+    height: auto;
+    overflow: visible;
+  }`
+  }).join('\n  ')
+
   return `
 @page {
   size: A4 portrait;
@@ -197,22 +212,10 @@ export function buildPdfPrintCss(): string {
     padding: 0;
     background: #fff;
   }
-  .pdf-export-root .page {
-    width: 210mm;
-    height: auto;
-    min-height: 0;
-    overflow: visible;
-    transform: none;
-  }
-  .pdf-export-root .columns {
-    height: auto;
-    overflow: visible;
-  }
+  ${pageRules}
 }
 `
 }
-
-const PDF_PRINT_CSS = buildPdfPrintCss()
 
 const PDF_SETLIST_PAGE_BREAK_CSS = `
 .pdf-export-root + .pdf-export-root {
@@ -262,7 +265,7 @@ function mountPdfExportDocument(pages: PdfExportPage[], title: string): {
   const pageBreakCss = pages.length > 1 ? PDF_SETLIST_PAGE_BREAK_CSS : ''
 
   const styleEl = doc.createElement('style')
-  styleEl.textContent = `${PDF_PAGE_BASE_CSS}\n${scopedCss}\n${PDF_PRINT_CSS}\n${pageBreakCss}\nhtml, body { margin: 0; padding: 0; background: #fff; color: #000; }`
+  styleEl.textContent = `${PDF_PAGE_BASE_CSS}\n${scopedCss}\n${buildPdfPrintCss(pages.length)}\n${pageBreakCss}\nhtml, body { margin: 0; padding: 0; background: #fff; color: #000; }`
   doc.head.appendChild(styleEl)
 
   const pageRoots: HTMLElement[] = []


### PR DESCRIPTION
## Summary
- Match print CSS selectors to scoped chordlib rules (`.pdf-export-root:nth-of-type(n)`) so WebKit no longer keeps fixed-height clipping during print
- Generate one override block per exported page for setlist/collection PDF exports
- Extend unit tests for scoped print selectors and multi-page exports

## Test plan
- [ ] Export a long song in Safari on Mac with Headers and Footers enabled — full song should continue on page 2+ instead of clipping mid-chorus
- [ ] Export the same song with headers off — should fit on one page for typical songs
- [ ] Verify Mac Chrome PDF export is unchanged
- [ ] Re-test on iPhone/iPad Safari after deploy