### PR TITLE
Fix collection cover upload deleting the collection

### DIFF
--- a/backend/db-migrations/20260601140000_remove_collection_cover_blob_cascade.surql
+++ b/backend/db-migrations/20260601140000_remove_collection_cover_blob_cascade.surql
@@ -1,0 +1,1 @@
+REMOVE EVENT collection_cover_blob_cascade ON blob;

--- a/backend/src/resources/collection/service.rs
+++ b/backend/src/resources/collection/service.rs
@@ -990,6 +990,107 @@ mod tests {
         assert!(len > 0, "cover blob file must not be empty");
     }
 
+    /// Replacing an existing real cover blob must not delete the collection (regression for
+    /// collection_cover_blob_cascade).
+    #[tokio::test]
+    async fn upload_collection_cover_replaces_existing_real_cover_blob() {
+        use shared::blob::{CreateBlob, FileType};
+
+        let (db, owner, _cm, _guest, _nm, _tid) = four_user_coll_fixture().await;
+        let blob_dir = std::env::temp_dir()
+            .join(format!(
+                "worshipviewer_coll_cover_replace_test_{}",
+                uuid::Uuid::new_v4()
+            ))
+            .to_string_lossy()
+            .into_owned();
+        let blob_svc = crate::test_helpers::blob_service(&db, blob_dir);
+        let svc = CollectionServiceHandle::build(db.clone());
+        let owner_p = auth_ctx_for_user(&db, &owner).await.expect("auth");
+        let song = create_song_with_title(&db, &owner, "Cover Keep")
+            .await
+            .expect("song");
+
+        let col = svc
+            .create_collection_for_user(
+                &owner_p,
+                CreateCollection {
+                    owner: None,
+                    title: "With Real Cover".into(),
+                    cover: String::new(),
+                    songs: vec![SongLink {
+                        id: song.id.clone(),
+                        nr: Some("1".into()),
+                        key: None,
+                        tempo: None,
+                    }],
+                },
+            )
+            .await
+            .expect("create");
+
+        let first_bytes = crate::test_helpers::sample_cover_jpeg_bytes();
+        let first_blob = blob_svc
+            .create_blob_with_data_for_user(
+                &owner_p,
+                CreateBlob {
+                    owner: None,
+                    file_type: FileType::JPEG,
+                    width: 64,
+                    height: 64,
+                    ocr: String::new(),
+                },
+                &first_bytes,
+            )
+            .await
+            .expect("first blob");
+
+        let with_cover = svc
+            .update_collection_for_user(
+                &owner_p,
+                &col.id,
+                CreateCollection {
+                    owner: None,
+                    title: col.title.clone(),
+                    cover: first_blob.id.clone(),
+                    songs: col.songs.clone(),
+                },
+                None,
+            )
+            .await
+            .expect("set cover");
+
+        assert_eq!(with_cover.cover, first_blob.id);
+
+        let second_bytes = crate::test_helpers::sample_cover_jpeg_bytes();
+        let updated = svc
+            .upload_collection_cover_for_user(
+                &blob_svc,
+                &owner_p,
+                &col.id,
+                "image/jpeg",
+                &second_bytes,
+                20 * 1024 * 1024,
+            )
+            .await
+            .expect("replace cover");
+
+        assert_ne!(updated.cover, first_blob.id);
+        assert_eq!(updated.title, col.title);
+        assert_eq!(updated.songs, col.songs);
+
+        let fetched = svc
+            .get_collection_for_user(&owner_p, &col.id)
+            .await
+            .expect("collection still exists");
+        assert_eq!(fetched.id, col.id);
+        assert_eq!(fetched.cover, updated.cover);
+        blob_svc
+            .get_blob_for_user(&owner_p, &updated.cover)
+            .await
+            .expect("new cover blob exists");
+    }
+
     /// BLC-COLL-024: PUT cannot drop an existing song id from `songs`.
     #[tokio::test]
     async fn blc_coll_024_put_cannot_remove_song() {

--- a/backend/tests/5_collections.yml
+++ b/backend/tests/5_collections.yml
@@ -1556,7 +1556,7 @@ testcases:
           - result.statuscode ShouldEqual 204
 
   # BLC: BLC-BLOB-014, BLC-COLL-017
-  - name: get-collection-after-cover-delete
+  - name: get-collection-after-cover-blob-delete
     steps:
       - type: http
         method: GET
@@ -1564,7 +1564,8 @@ testcases:
         headers:
           Authorization: "Bearer {{.create-collection-owner-session.sessionid}}"
         assertions:
-          - result.statuscode ShouldEqual 404
+          - result.statuscode ShouldEqual 200
+          - result.bodyjson.cover ShouldEqual "{{.post-collection-cover-blob.blobid}}"
 
   # Cleanup users
   # BLC: BLC-USER-011

--- a/docs/business-logic-constraints/blob.md
+++ b/docs/business-logic-constraints/blob.md
@@ -27,7 +27,7 @@
 
 ## Cascading deletes and dependents
 
-- **BLC-BLOB-014:** WHEN a blob used as a collection **`cover`** IS **DELETE**d THEN **GET** that collection MAY return **404** for the collection or expose inconsistent metadata until the collection is updated or removed; clients SHOULD refresh references after deletes.
+- **BLC-BLOB-014:** WHEN a blob used as a collection **`cover`** IS **DELETE**d THEN the collection is **not** removed; **`GET /collections/{id}`** still returns the collection, but **`cover`** MAY reference a deleted blob id until the collection is updated (e.g. **`PUT /collections/{id}/cover`** or **`PATCH`** with a new **`cover`**). **`GET /blobs/{id}/data`** for the deleted blob id responds **404**; clients SHOULD refresh cover references after blob deletes.
 - **BLC-BLOB-015:** WHEN a **user** account IS deleted THEN blobs owned by their **personal** team disappear with that team (see [user.md](./user.md)).
 
 ## Move (`POST /blobs/{id}/move`)

--- a/docs/business-logic-constraints/collection.md
+++ b/docs/business-logic-constraints/collection.md
@@ -31,7 +31,7 @@
 
 ## Cascading deletes
 
-- **BLC-COLL-017:** WHEN the **cover** blob IS **DELETE**d THEN **GET /collections/{id}** for that collection MAY return **404** until the collection is fixed or removed.
+- **BLC-COLL-017:** WHEN the **cover** blob IS **DELETE**d THEN the collection is **not** removed; **`GET /collections/{id}`** still returns **200**, but **`cover`** MAY reference a deleted blob id until updated. Cover image bytes for that id are unavailable until **`cover`** is set to a valid blob.
 - **BLC-COLL-018:** WHEN a **user** account IS deleted THEN collections owned by their **personal** team are removed with that team ([user.md](./user.md)).
 - **BLC-COLL-019:** WHEN a referenced **song** IS deleted THEN collection endpoints MAY error or show stale slots until **PUT** updates **songs** ([song.md](./song.md)).
 


### PR DESCRIPTION
## Summary
- Remove the SurrealDB `collection_cover_blob_cascade` event that deleted collections when their cover blob was deleted
- Fixes `PUT /collections/{id}/cover` failing and wiping the collection when replacing an existing cover
- Update BLC-BLOB-014 and BLC-COLL-017 to document that collections survive cover blob deletion (with a possibly stale `cover` id)
- Add regression unit test and update Venom integration test

## Test plan
- [ ] Run migrations on a dev DB and replace a collection cover that already has a real cover image
- [ ] Confirm collection still exists in hub and editor after upload
- [ ] `cargo test upload_collection_cover` and `cargo venom` pass