### PR TITLE
Update device settings defaults

### DIFF
--- a/frontend/app/src/components/player/ChordsThreeColumnSlide.tsx
+++ b/frontend/app/src/components/player/ChordsThreeColumnSlide.tsx
@@ -265,7 +265,7 @@ export function ChordsThreeColumnSlide({
   nextDisplayKey,
   chordFormat,
   columnCount = 3,
-  overflowStyle = 'cut',
+  overflowStyle = 'scroll',
   expandSections = false,
   fillParent = false,
 }: ChordsThreeColumnSlideProps) {

--- a/frontend/app/src/components/settings/SettingsView.tsx
+++ b/frontend/app/src/components/settings/SettingsView.tsx
@@ -61,10 +61,10 @@ import type { HubViewMode } from '@/lib/hub-view-mode'
 import { clearAllLocalData } from '@/lib/clear-local'
 import { formatApproxBytes } from '@/lib/format-bytes'
 import {
-  BROWSER_LOCALE_FLAG_KEY,
-  LOCALE_STORAGE_KEY,
   mapLanguagesToLocale,
-  resolveLocalePreference,
+  readLocalePreference,
+  writeBrowserLocalePreference,
+  writeExplicitLocalePreference,
   type AppLocale,
   type LocalePreference,
 } from '@/lib/locale'
@@ -89,10 +89,7 @@ type SettingsOption<T extends string | number> = {
 const settingsTabs: SettingsTab[] = ['general', 'player', 'playerRoles']
 
 function getLocalePreference(): LocalePreference {
-  return resolveLocalePreference(
-    globalThis.localStorage.getItem(LOCALE_STORAGE_KEY),
-    globalThis.localStorage.getItem(BROWSER_LOCALE_FLAG_KEY),
-  )
+  return readLocalePreference()
 }
 
 function OptionButton<T extends string | number>({
@@ -525,15 +522,13 @@ export function SettingsView({
   async function setLocalePreference(next: LocalePreference) {
     setLocalePreferenceState(next)
     if (next === 'browser') {
-      globalThis.localStorage.setItem(BROWSER_LOCALE_FLAG_KEY, '1')
-      globalThis.localStorage.removeItem(LOCALE_STORAGE_KEY)
+      writeBrowserLocalePreference()
       await i18n.changeLanguage(mapLanguagesToLocale(globalThis.navigator.languages))
       return
     }
 
     const locale: AppLocale = next
-    globalThis.localStorage.removeItem(BROWSER_LOCALE_FLAG_KEY)
-    globalThis.localStorage.setItem(LOCALE_STORAGE_KEY, locale)
+    writeExplicitLocalePreference(locale)
     await i18n.changeLanguage(locale)
   }
 

--- a/frontend/app/src/i18n/index.ts
+++ b/frontend/app/src/i18n/index.ts
@@ -7,11 +7,14 @@ import {
   BROWSER_LOCALE_FLAG_KEY,
   LOCALE_STORAGE_KEY,
   type AppLocale,
+  ensureBrowserLocaleStorage,
   resolveInitialLocale,
 } from '@/lib/locale'
 
 export function initI18n(): void {
   if (typeof globalThis.window === 'undefined') return
+
+  ensureBrowserLocaleStorage()
 
   const params = new URLSearchParams(globalThis.window.location.search)
   const stored = globalThis.localStorage.getItem(LOCALE_STORAGE_KEY)
@@ -31,15 +34,6 @@ export function initI18n(): void {
     lng,
     fallbackLng: 'en',
     interpolation: { escapeValue: false },
-  })
-
-  i18n.on('languageChanged', (l) => {
-    if (globalThis.localStorage.getItem(BROWSER_LOCALE_FLAG_KEY) === '1') {
-      return
-    }
-    if (l === 'en' || l === 'de') {
-      globalThis.localStorage.setItem(LOCALE_STORAGE_KEY, l)
-    }
   })
 }
 

--- a/frontend/app/src/lib/locale.test.ts
+++ b/frontend/app/src/lib/locale.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  BROWSER_LOCALE_FLAG_KEY,
+  LOCALE_STORAGE_KEY,
+  ensureBrowserLocaleStorage,
   mapLanguagesToLocale,
+  readLocalePreference,
   resolveInitialLocale,
   resolveLocalePreference,
+  writeBrowserLocalePreference,
+  writeExplicitLocalePreference,
 } from '@/lib/locale'
 
 describe('mapLanguagesToLocale', () => {
@@ -42,5 +48,61 @@ describe('resolveLocalePreference', () => {
   })
   it('falls back to browser mode for invalid stored values', () => {
     expect(resolveLocalePreference('fr', null)).toBe('browser')
+  })
+})
+
+describe('locale preference storage', () => {
+  it('defaults to browser without an explicit locale key', () => {
+    const storage = new Map<string, string>()
+    const mockStorage = {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        storage.set(key, value)
+      },
+      removeItem: (key: string) => {
+        storage.delete(key)
+      },
+    }
+
+    expect(readLocalePreference(mockStorage)).toBe('browser')
+    ensureBrowserLocaleStorage(mockStorage)
+    expect(storage.get(BROWSER_LOCALE_FLAG_KEY)).toBe('1')
+    expect(storage.has(LOCALE_STORAGE_KEY)).toBe(false)
+  })
+
+  it('stores explicit locales without the browser flag', () => {
+    const storage = new Map<string, string>([[BROWSER_LOCALE_FLAG_KEY, '1']])
+    const mockStorage = {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        storage.set(key, value)
+      },
+      removeItem: (key: string) => {
+        storage.delete(key)
+      },
+    }
+
+    writeExplicitLocalePreference('de', mockStorage)
+    expect(storage.get(LOCALE_STORAGE_KEY)).toBe('de')
+    expect(storage.has(BROWSER_LOCALE_FLAG_KEY)).toBe(false)
+    expect(readLocalePreference(mockStorage)).toBe('de')
+  })
+
+  it('clears explicit locale when switching back to browser', () => {
+    const storage = new Map<string, string>([[LOCALE_STORAGE_KEY, 'en']])
+    const mockStorage = {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        storage.set(key, value)
+      },
+      removeItem: (key: string) => {
+        storage.delete(key)
+      },
+    }
+
+    writeBrowserLocalePreference(mockStorage)
+    expect(storage.get(BROWSER_LOCALE_FLAG_KEY)).toBe('1')
+    expect(storage.has(LOCALE_STORAGE_KEY)).toBe(false)
+    expect(readLocalePreference(mockStorage)).toBe('browser')
   })
 })

--- a/frontend/app/src/lib/locale.ts
+++ b/frontend/app/src/lib/locale.ts
@@ -29,6 +29,39 @@ export function resolveLocalePreference(
   return 'browser'
 }
 
+export function readLocalePreference(
+  storage: Pick<Storage, 'getItem'> = globalThis.localStorage,
+): LocalePreference {
+  return resolveLocalePreference(
+    storage.getItem(LOCALE_STORAGE_KEY),
+    storage.getItem(BROWSER_LOCALE_FLAG_KEY),
+  )
+}
+
+/** Browser default: follow navigator languages; do not persist an explicit locale. */
+export function writeBrowserLocalePreference(
+  storage: Pick<Storage, 'setItem' | 'removeItem'> = globalThis.localStorage,
+): void {
+  storage.setItem(BROWSER_LOCALE_FLAG_KEY, '1')
+  storage.removeItem(LOCALE_STORAGE_KEY)
+}
+
+export function writeExplicitLocalePreference(
+  locale: AppLocale,
+  storage: Pick<Storage, 'setItem' | 'removeItem'> = globalThis.localStorage,
+): void {
+  storage.removeItem(BROWSER_LOCALE_FLAG_KEY)
+  storage.setItem(LOCALE_STORAGE_KEY, locale)
+}
+
+export function ensureBrowserLocaleStorage(
+  storage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> = globalThis.localStorage,
+): void {
+  if (readLocalePreference(storage) === 'browser') {
+    writeBrowserLocalePreference(storage)
+  }
+}
+
 /**
  * Resolve initial UI locale: `?lang=` QA override > persisted > browser languages.
  */

--- a/frontend/app/src/lib/player-layout-preference.test.ts
+++ b/frontend/app/src/lib/player-layout-preference.test.ts
@@ -23,7 +23,7 @@ describe('readPlayerLayoutPreferences', () => {
       pageCount: 1 as const,
       columnCount: 'adaptive' as const,
       nextSongPreview: false,
-      overflowStyle: 'cut' as const,
+      overflowStyle: 'scroll' as const,
       expandSections: false,
     }
     const mockStorage = {
@@ -148,7 +148,7 @@ describe('readPlayerLayoutPreferences', () => {
       pageCount: 1,
       columnCount: 2,
       nextSongPreview: true,
-      overflowStyle: 'cut',
+      overflowStyle: 'scroll',
       expandSections: false,
     })
     expect(prefs.landscape).toEqual(prefs.portrait)
@@ -225,7 +225,7 @@ describe('scrollTypeToLayoutPreference', () => {
       pageCount: 1,
       columnCount: 3,
       nextSongPreview: true,
-      overflowStyle: 'cut',
+      overflowStyle: 'scroll',
       expandSections: false,
     })
     expect(

--- a/frontend/app/src/lib/player-scroll-preference.ts
+++ b/frontend/app/src/lib/player-scroll-preference.ts
@@ -49,7 +49,7 @@ function normalizeLayoutPreference(raw: unknown): PlayerLayoutPreference {
     ? value.columnCount
     : DEFAULT_PLAYER_LAYOUT_PREFERENCE.columnCount
   const nextSongPreview = value.nextSongPreview === true
-  const overflowStyle = value.overflowStyle === 'scroll' ? 'scroll' : 'cut'
+  const overflowStyle = value.overflowStyle === 'cut' ? 'cut' : 'scroll'
   const expandSections = value.expandSections === true
   return { mode, pageCount, columnCount, nextSongPreview, overflowStyle, expandSections }
 }

--- a/frontend/app/src/lib/player/av-preferences.ts
+++ b/frontend/app/src/lib/player/av-preferences.ts
@@ -64,8 +64,8 @@ export const DEFAULT_AV_PREFERENCES: AvPreferences = {
     preset: 2,
   },
   transition: {
-    style: 'fade',
-    durationMs: 250,
+    style: 'none',
+    durationMs: 0,
   },
   projection: {
     outputFullscreenOnDblClick: true,

--- a/frontend/app/src/lib/player/effective-scroll-type.ts
+++ b/frontend/app/src/lib/player/effective-scroll-type.ts
@@ -34,7 +34,7 @@ export const DEFAULT_PLAYER_LAYOUT_PREFERENCE: PlayerLayoutPreference = {
   pageCount: 1,
   columnCount: 'adaptive',
   nextSongPreview: false,
-  overflowStyle: 'cut',
+  overflowStyle: 'scroll',
   expandSections: false,
 }
 

--- a/frontend/app/src/lib/sheet-background.test.ts
+++ b/frontend/app/src/lib/sheet-background.test.ts
@@ -13,9 +13,9 @@ describe('resolveSheetBackgroundPreference', () => {
     expect(resolveSheetBackgroundPreference('app')).toBe('app')
   })
 
-  it('falls back to white for missing or invalid values', () => {
-    expect(resolveSheetBackgroundPreference(null)).toBe('white')
-    expect(resolveSheetBackgroundPreference('paper')).toBe('white')
+  it('falls back to app for missing or invalid values', () => {
+    expect(resolveSheetBackgroundPreference(null)).toBe('app')
+    expect(resolveSheetBackgroundPreference('paper')).toBe('app')
   })
 })
 
@@ -42,16 +42,16 @@ describe('applySheetBackgroundPreference', () => {
 })
 
 describe('writeSheetBackgroundPreference', () => {
-  it('stores app and clears white', () => {
+  it('stores white and clears app', () => {
     const storage = {
       setItem: vi.fn(),
       removeItem: vi.fn(),
     }
 
-    writeSheetBackgroundPreference('app', storage)
-    expect(storage.setItem).toHaveBeenCalledWith(SHEET_BACKGROUND_STORAGE_KEY, 'app')
-
     writeSheetBackgroundPreference('white', storage)
+    expect(storage.setItem).toHaveBeenCalledWith(SHEET_BACKGROUND_STORAGE_KEY, 'white')
+
+    writeSheetBackgroundPreference('app', storage)
     expect(storage.removeItem).toHaveBeenCalledWith(SHEET_BACKGROUND_STORAGE_KEY)
   })
 

--- a/frontend/app/src/lib/sheet-background.ts
+++ b/frontend/app/src/lib/sheet-background.ts
@@ -5,8 +5,8 @@ export const SHEET_BACKGROUND_CHANGE_EVENT = 'wv-sheet-background-change'
 export type SheetBackgroundPreference = 'white' | 'app'
 
 export function resolveSheetBackgroundPreference(value: string | null): SheetBackgroundPreference {
-  if (value === 'app') return 'app'
-  return 'white'
+  if (value === 'white') return 'white'
+  return 'app'
 }
 
 export function applySheetBackgroundPreference(
@@ -31,7 +31,7 @@ export function writeSheetBackgroundPreference(
   preference: SheetBackgroundPreference,
   storage: Pick<Storage, 'setItem' | 'removeItem'> = globalThis.localStorage,
 ): void {
-  if (preference === 'white') {
+  if (preference === 'app') {
     storage.removeItem(SHEET_BACKGROUND_STORAGE_KEY)
   } else {
     storage.setItem(SHEET_BACKGROUND_STORAGE_KEY, preference)


### PR DESCRIPTION
## Summary
- Default language follows the browser without auto-persisting `i18nextLng`; explicit en/de is only stored when chosen in Settings.
- Default sheet background is app-themed instead of white.
- Default player layout overflow is scroll instead of cut.
- Default AV slide transition is none at 0 ms instead of fade at 250 ms.

## Test plan
- [ ] Fresh profile / cleared localStorage: Settings shows browser language, app sheet background, scroll overflow, and none/0 ms AV transition.
- [ ] Explicit language, white sheet background, cut overflow, and fade transition still persist after changing them in Settings.
- [ ] `npm test -- --run src/lib/sheet-background.test.ts src/lib/locale.test.ts src/lib/player-layout-preference.test.ts src/lib/player-scroll-preference.test.ts`