### PR TITLE
Disable wasm-opt to fix frontend CI binaryen download failure

### DIFF
--- a/frontend/crates/chordlib-wasm/Cargo.toml
+++ b/frontend/crates/chordlib-wasm/Cargo.toml
@@ -15,6 +15,9 @@ wasm-bindgen = "0.2.122"
 [dev-dependencies]
 wasm-bindgen-test = "0.3.52"
 
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
+
 [profile.release]
 lto = true
 opt-level = "s"


### PR DESCRIPTION
## Summary
- Disable `wasm-opt` in `chordlib-wasm` release wasm-pack builds after CI failed downloading binaryen from GitHub
- Release builds still use Rust LTO and `opt-level = "s"`, so WASM remains optimized without the extra binaryen pass

## Test plan
- [ ] Frontend CI `pnpm build:wasm` completes on ubuntu-latest
- [ ] Docker image build succeeds on main
- [ ] Local `pnpm build:wasm` produces a working pkg