### PR TITLE
Fix song editor multiple titles

### DIFF
--- a/frontend/app/src/lib/song-editor-state.test.ts
+++ b/frontend/app/src/lib/song-editor-state.test.ts
@@ -92,6 +92,20 @@ describe('buildSongPatchBody', () => {
   })
 })
 
+describe('metadataStripFromSongData', () => {
+  it('joins multiple titles like artists and languages', () => {
+    const strip = metadataStripFromSongData({
+      titles: ['Anker', 'Anchor'],
+      artists: ['Urban Life Worship', 'Hillsong Worship'],
+      languages: ['de', 'en'],
+      sections: [],
+    })
+    expect(strip.title).toBe('Anker, Anchor')
+    expect(strip.artists).toBe('Urban Life Worship, Hillsong Worship')
+    expect(strip.languages).toBe('de, en')
+  })
+})
+
 describe('patchSongDataFromParsed', () => {
   it('tolerates partial strip objects', () => {
     const patch = patchSongDataFromParsed(
@@ -99,6 +113,33 @@ describe('patchSongDataFromParsed', () => {
       { title: 'B' } as SongMetadataStrip,
     )
     expect(patch.titles).toEqual(['B'])
+  })
+
+  it('splits comma-separated titles like artists and languages', () => {
+    const patch = patchSongDataFromParsed(
+      { sections: [] },
+      {
+        title: 'Anker, Anchor',
+        subtitle: '',
+        artists: 'Urban Life Worship, Hillsong Worship',
+        copyright: '',
+        languages: 'de, en',
+        tempo: '',
+        timeSignature: '',
+        key: '',
+        tags: [],
+      },
+    )
+    expect(patch.titles).toEqual(['Anker', 'Anchor'])
+    expect(patch.artists).toEqual(['Urban Life Worship', 'Hillsong Worship'])
+    expect(patch.languages).toEqual(['de', 'en'])
+  })
+
+  it('round-trips multiple titles through the metadata strip', () => {
+    const data = { titles: ['Anker', 'Anchor'], sections: [] }
+    const strip = metadataStripFromSongData(data)
+    const patch = patchSongDataFromParsed(data, strip)
+    expect(patch.titles).toEqual(['Anker', 'Anchor'])
   })
 
   it('maps 4/4 and 6/8 time signatures only', () => {

--- a/frontend/app/src/lib/song-editor-state.ts
+++ b/frontend/app/src/lib/song-editor-state.ts
@@ -147,14 +147,14 @@ function parseTimeSignature(value: string): number[] | null {
 }
 
 export function metadataStripFromSongData(data: ChordSongData): SongMetadataStrip {
-  const titles = Array.isArray(data.titles) ? data.titles : []
+  const titles = Array.isArray(data.titles) ? data.titles.filter(Boolean).map(String) : []
   const artists = Array.isArray(data.artists) ? data.artists.filter(Boolean) : []
   const languages = Array.isArray(data.languages) ? data.languages.filter(Boolean) : []
   const tempo =
     typeof data.tempo === 'number' && Number.isFinite(data.tempo) ? String(Math.round(data.tempo)) : ''
 
   return {
-    title: typeof titles[0] === 'string' ? titles[0] : '',
+    title: titles.join(', '),
     subtitle: typeof data.subtitle === 'string' ? data.subtitle : '',
     artists: artists.join(', '),
     copyright: typeof data.copyright === 'string' ? data.copyright : '',
@@ -186,9 +186,9 @@ export function patchSongDataFromParsed(
 ): PatchSongData {
   const strip = normalizeMetadataStrip(stripInput)
   const sections = Array.isArray(parsed.sections) ? parsed.sections : []
-  const title = strip.title.trim()
-  const titles = title
-    ? [title]
+  const titlesFromStrip = splitCsv(strip.title)
+  const titles = titlesFromStrip.length
+    ? titlesFromStrip
     : Array.isArray(parsed.titles) && parsed.titles.length
       ? parsed.titles.map(String)
       : ['']


### PR DESCRIPTION
## Summary
- Join all song titles in the Meta tab Title field with comma separation, matching artists and languages.
- Split comma-separated Title input into multiple `titles[]` entries on save so alternate titles round-trip correctly.
- Add unit tests for load, save, and round-trip behavior.

## Test plan
- [x] `npx vitest run src/lib/song-editor-state.test.ts`
- [ ] Open a song with multiple titles in the editor Meta tab and confirm all titles appear comma-separated
- [ ] Edit Title to `Anker, Anchor`, save, reload, and confirm both titles persist
- [ ] Confirm artists and languages behavior is unchanged