### PR TITLE
Fix song editor meta tag removal not persisting on autosave

### DIFF
--- a/frontend/app/src/components/songs/SongEditorScreen.tsx
+++ b/frontend/app/src/components/songs/SongEditorScreen.tsx
@@ -237,7 +237,9 @@ export function SongEditorScreen({ songId }: { songId: string }) {
   useEffect(() => {
     if (!engine || !detail || saveRevision === 0) return
     queueMicrotask(() => {
-      setSourceText(formatSourceFromSongData(engine, detail.data as Record<string, unknown>, chordFormat))
+      const data = detail.data as Record<string, unknown>
+      setSourceText(formatSourceFromSongData(engine, data, chordFormat))
+      setMetadataStrip(metadataStripFromSongData(data))
       setParseError(null)
     })
   }, [saveRevision, engine, detail, chordFormat])

--- a/frontend/app/src/lib/song-editor-state.test.ts
+++ b/frontend/app/src/lib/song-editor-state.test.ts
@@ -195,9 +195,9 @@ describe('songMetaTagsToWireRecord', () => {
     ).toEqual({ theme: 'Grace', author: 'John' })
   })
 
-  it('returns null when no valid entries remain', () => {
-    expect(songMetaTagsToWireRecord([])).toBeNull()
-    expect(songMetaTagsToWireRecord([{ id: '1', key: ' ', value: 'x' }])).toBeNull()
+  it('returns an empty record when no valid entries remain', () => {
+    expect(songMetaTagsToWireRecord([])).toEqual({})
+    expect(songMetaTagsToWireRecord([{ id: '1', key: ' ', value: 'x' }])).toEqual({})
   })
 })
 
@@ -303,5 +303,56 @@ describe('patchSongDataFromParsed tags', () => {
       },
     )
     expect(patch.tags).toEqual({ theme: 'Grace' })
+  })
+
+  it('sends an empty tags object when all meta tags are removed', () => {
+    const patch = patchSongDataFromParsed(
+      { sections: [], tags: { year: '2014' } },
+      {
+        title: '',
+        subtitle: '',
+        artists: '',
+        copyright: '',
+        languages: '',
+        tempo: '',
+        timeSignature: '',
+        key: '',
+        tags: [],
+      },
+    )
+    expect(patch.tags).toEqual({})
+  })
+})
+
+describe('songDataSnapshotsEqual tags', () => {
+  it('treats missing and empty tags as equivalent', () => {
+    const base = patchSongDataFromParsed({ sections: [] }, metadataStripFromSongData({ sections: [] }))
+    const withEmptyTags = { ...base, tags: {} }
+    const withNullTags = { ...base, tags: null }
+    expect(songDataSnapshotsEqual(base, withEmptyTags)).toBe(true)
+    expect(songDataSnapshotsEqual(base, withNullTags)).toBe(true)
+  })
+
+  it('detects tag removals', () => {
+    const base = patchSongDataFromParsed(
+      { sections: [], tags: { year: '2014' } },
+      metadataStripFromSongData({ sections: [], tags: { year: '2014' } }),
+    )
+    const cleared = patchSongDataFromParsed(
+      { sections: [], tags: { year: '2014' } },
+      {
+        title: '',
+        subtitle: '',
+        artists: '',
+        copyright: '',
+        languages: '',
+        tempo: '',
+        timeSignature: '',
+        key: '',
+        tags: [],
+      },
+    )
+    expect(songDataSnapshotsEqual(base, cleared)).toBe(false)
+    expect(buildSongPatchBody(base, cleared)?.data.tags).toEqual({})
   })
 })

--- a/frontend/app/src/lib/song-editor-state.ts
+++ b/frontend/app/src/lib/song-editor-state.ts
@@ -89,15 +89,15 @@ export function songMetaTagsFromSongData(
 
 export function songMetaTagsToWireRecord(
   entries: SongMetaTagEntry[] | undefined,
-): Record<string, string> | null {
-  if (!entries?.length) return null
+): Record<string, string> {
   const record: Record<string, string> = {}
+  if (!entries?.length) return record
   for (const { key, value } of entries) {
     const trimmedKey = key.trim()
     if (!trimmedKey) continue
     record[trimmedKey] = value.trim()
   }
-  return Object.keys(record).length ? record : null
+  return record
 }
 
 export type ParseSourceResult =
@@ -369,6 +369,13 @@ export function songDataSnapshotsEqual(a: PatchSongData, b: PatchSongData): bool
   return stableSnapshotJson(a) === stableSnapshotJson(b)
 }
 
+function normalizeTagsSnapshot(tags: PatchSongData['tags']): Record<string, string> | null {
+  if (!tags || typeof tags !== 'object' || Array.isArray(tags)) return null
+  const entries = Object.entries(tags as Record<string, string>).filter(([key]) => key.trim())
+  if (!entries.length) return null
+  return Object.fromEntries(entries)
+}
+
 function stableSnapshotJson(data: PatchSongData): string {
   return JSON.stringify({
     titles: data.titles ?? null,
@@ -380,7 +387,7 @@ function stableSnapshotJson(data: PatchSongData): string {
     time: data.time ?? null,
     key: data.key ?? null,
     sections: data.sections ?? null,
-    tags: data.tags ?? null,
+    tags: normalizeTagsSnapshot(data.tags),
   })
 }
 


### PR DESCRIPTION
## Summary
- Send `tags: {}` instead of `tags: null` when all ChordPro `{meta: …}` tags are removed, so the backend actually clears them on PATCH
- Normalize empty/missing tags in autosave snapshot comparison to avoid spurious dirty state
- Sync the Meta tab metadata strip after a successful save, matching the reformatted Source view

## Test plan
- [x] `npm test -- --run src/lib/song-editor-state.test.ts src/hooks/useSongAutosave.test.tsx`
- [ ] Open a song with `{meta: year 2014}` tags in Source, delete both meta lines, wait for autosave — tags should stay removed in Source and Meta
- [ ] Reload the editor — tags should remain absent
- [ ] Remove a meta tag from the Meta tab instead of Source — source should update on blur and persist after save/reload