### PR TITLE
Fix setlist player with duplicate song slots

### DIFF
--- a/backend/src/resources/common.rs
+++ b/backend/src/resources/common.rs
@@ -155,10 +155,17 @@ pub async fn song_links_to_owned(
         };
         by_id.insert(record_id_string(rid), r);
     }
+    map_song_link_records(links, &by_id)
+}
+
+fn map_song_link_records(
+    links: Vec<SongLinkRecord>,
+    by_id: &HashMap<String, SongRecord>,
+) -> Result<Vec<SongLinkOwned>, AppError> {
     let mut out = Vec::with_capacity(links.len());
     for link in links {
         let sid = record_id_string(&link.id);
-        let rec = by_id.remove(&sid).ok_or_else(|| {
+        let rec = by_id.get(&sid).cloned().ok_or_else(|| {
             AppError::database(
                 "referenced song not found (collection or setlist data may be inconsistent)",
             )
@@ -307,5 +314,42 @@ mod tests {
         assert_eq!(toc.len(), 2);
         assert_eq!(toc[0].nr, "1");
         assert_eq!(toc[1].nr, "x");
+    }
+
+    #[test]
+    fn map_song_link_records_reuses_song_for_duplicate_slots() {
+        let song_id = RecordId::new("song", "anchor");
+        let by_id = HashMap::from([(
+            record_id_string(&song_id),
+            SongRecord {
+                id: Some(song_id.clone()),
+                ..Default::default()
+            },
+        )]);
+        let links = vec![
+            SongLinkRecord::from(SongLink {
+                id: record_id_string(&song_id),
+                nr: Some("1".into()),
+                key: None,
+                tempo: None,
+            }),
+            SongLinkRecord::from(SongLink {
+                id: record_id_string(&song_id),
+                nr: Some("2".into()),
+                key: None,
+                tempo: None,
+            }),
+        ];
+
+        let owned = map_song_link_records(links, &by_id).unwrap();
+        assert_eq!(owned.len(), 2);
+        assert_eq!(owned[0].song.id, record_id_string(&song_id));
+        assert_eq!(owned[1].song.id, record_id_string(&song_id));
+        assert_eq!(owned[0].nr.as_deref(), Some("1"));
+        assert_eq!(owned[1].nr.as_deref(), Some("2"));
+
+        let player = player_from_song_links(HashSet::new(), owned).unwrap();
+        assert_eq!(player.toc().len(), 2);
+        assert_eq!(player.max_index(), 1);
     }
 }

--- a/backend/src/resources/setlist/service.rs
+++ b/backend/src/resources/setlist/service.rs
@@ -850,6 +850,35 @@ mod tests {
         assert!(matches!(pl_nf, Err(AppError::NotFound(_))));
     }
 
+    /// Same song in consecutive setlist slots must still produce a playable player.
+    #[tokio::test]
+    async fn blc_setl_player_duplicate_consecutive_song_slots() {
+        let (db, owner, _read_u, _write_u, _noperm, _team_id) = four_user_setlist_fixture().await;
+        let sl = setlist_service(&db);
+        let s1 = create_song_with_title(&db, &owner, "Song One")
+            .await
+            .expect("s1");
+        let owner_p = auth_ctx_for_user(&db, &owner).await.expect("auth");
+
+        let created = sl
+            .create_setlist_for_user(
+                &owner_p,
+                setlist_with_songs(
+                    "Encore",
+                    &[(s1.id.as_str(), Some("1")), (s1.id.as_str(), Some("2"))],
+                ),
+            )
+            .await
+            .expect("create");
+
+        let player = sl
+            .setlist_player_for_user(&owner_p, &created.id)
+            .await
+            .expect("player with duplicate song slots");
+        assert_eq!(player.toc().len(), 2);
+        assert_eq!(player.max_index(), 1);
+    }
+
     /// BLC-SETL-009i: update succeeds for owner (title changes) and for write user;
     /// writer's change is visible to owner on subsequent get; read user and noperm user
     /// are rejected; wrong-table id returns InvalidRequest; non-existent id returns

--- a/shared/src/player/player.rs
+++ b/shared/src/player/player.rs
@@ -272,17 +272,12 @@ impl Add for Player {
             return other;
         }
         let self_len = self.items.len();
-        let last_self_item = self.items.last().expect("non-empty").clone();
         Self {
             toc: self
                 .toc
                 .into_iter()
                 .chain(other.toc.iter().map(|item| TocItem {
-                    idx: if !other.items.is_empty() && self.items.last() == other.items.first() {
-                        item.idx + self_len.saturating_sub(1)
-                    } else {
-                        item.idx + self_len
-                    },
+                    idx: item.idx + self_len,
                     title: item.title.clone(),
                     id: item.id.clone(),
                     nr: item.nr.clone(),
@@ -292,12 +287,7 @@ impl Add for Player {
             items: self
                 .items
                 .into_iter()
-                .chain(
-                    other
-                        .items
-                        .into_iter()
-                        .skip_while(|item| *item == last_self_item),
-                )
+                .chain(other.items)
                 .collect(),
             scroll_type: self.scroll_type,
             scroll_type_cache_other_orientation: self.scroll_type_cache_other_orientation,
@@ -406,5 +396,67 @@ mod tests {
             PlayerItem::Chords(chords) => assert_eq!(chords.song.data.tempo, Some(120)),
             _ => panic!("expected chords player item"),
         }
+    }
+
+    #[test]
+    fn add_keeps_consecutive_duplicate_song_slots() {
+        let song = song_with_tempo(None);
+        let first = Player::from(SongLinkOwned {
+            song: song.clone(),
+            nr: Some("1".into()),
+            key: None,
+            tempo: None,
+            liked: false,
+        });
+        let second = Player::from(SongLinkOwned {
+            song,
+            nr: Some("2".into()),
+            key: None,
+            tempo: None,
+            liked: false,
+        });
+        let merged = first + second;
+
+        assert_eq!(merged.max_index(), 1);
+        let toc = merged.toc();
+        assert_eq!(toc.len(), 2);
+        assert_eq!(toc[0].idx, 0);
+        assert_eq!(toc[0].nr, "1");
+        assert_eq!(toc[1].idx, 1);
+        assert_eq!(toc[1].nr, "2");
+    }
+
+    #[test]
+    fn add_keeps_consecutive_duplicate_blob_only_song_slots() {
+        use crate::blob::BlobLink;
+
+        let song = Song {
+            id: "blob-song".into(),
+            blobs: vec![BlobLink {
+                id: "sheet-1".into(),
+            }],
+            ..Default::default()
+        };
+        let first = Player::from(SongLinkOwned {
+            song: song.clone(),
+            nr: Some("1".into()),
+            key: None,
+            tempo: None,
+            liked: false,
+        });
+        let second = Player::from(SongLinkOwned {
+            song,
+            nr: Some("2".into()),
+            key: None,
+            tempo: None,
+            liked: false,
+        });
+        let merged = first + second;
+
+        assert_eq!(merged.max_index(), 1);
+        let toc = merged.toc();
+        assert_eq!(toc.len(), 2);
+        assert_eq!(toc[0].idx, 0);
+        assert_eq!(toc[1].idx, 1);
     }
 }


### PR DESCRIPTION
## Summary
- Fix `song_links_to_owned` to reuse song records for duplicate setlist/collection slots instead of consuming each ID once from a map
- Remove legacy player merge deduplication that dropped consecutive identical items, which made back-to-back song entries unreachable
- Add unit and integration tests covering duplicate consecutive slots

## Test plan
- [x] `cargo test map_song_link_records_reuses` (backend)
- [x] `cargo test blc_setl_player_duplicate_consecutive` (backend)
- [x] `cargo test add_keeps_consecutive` (shared)
- [ ] Create a setlist with the same song in slots 1 and 2, then open `/player?type=setlist&id=…`
- [ ] Confirm both TOC entries are present and navigable