### PR TITLE
Add hide-chords toggle for player and exports

### DIFF
--- a/frontend/app/e2e/settings.spec.ts
+++ b/frontend/app/e2e/settings.spec.ts
@@ -40,6 +40,11 @@ test('J2+J3: settings preferences round-trip after reload', async ({ page }) => 
   await page.reload()
   await expect(page.getByRole('radio', { name: /nashville/i })).toBeChecked()
 
+  await settings.goto('player')
+  await page.getByRole('checkbox', { name: /hide chords in player and exports/i }).click()
+  await page.reload()
+  await expect(page.getByRole('checkbox', { name: /hide chords in player and exports/i })).toBeChecked()
+
   await settings.goto('playerRoles')
   await page.getByRole('radio', { name: /fade/i }).click()
   await page.reload()

--- a/frontend/app/src/components/hub/EntityListView.tsx
+++ b/frontend/app/src/components/hub/EntityListView.tsx
@@ -51,6 +51,7 @@ import {
   ContextMenuTrigger,
 } from '@/components/ui/context-menu'
 import { useChordFormatPreference } from '@/hooks/useChordFormatPreference'
+import { useHideChordsPreference } from '@/hooks/useHideChordsPreference'
 import { useHubSearch } from '@/hooks/useHubSearch'
 import { useCoverImageSrc } from '@/hooks/useCoverImageSrc'
 import { useDeleteHubEntity, HubDeleteConflictError } from '@/hooks/useDeleteHubEntity'
@@ -560,6 +561,7 @@ function HubItemContextMenu({
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const chordFormat = useChordFormatPreference()
+  const hideChords = useHideChordsPreference()
   const [editHot, setEditHot] = useState(false)
   const [playHot, setPlayHot] = useState(false)
   const [addToSetlistHot, setAddToSetlistHot] = useState(false)
@@ -635,9 +637,9 @@ function HubItemContextMenu({
       const toastId = toast.loading(t('hub.actions.exportPreparing'))
       try {
         if (entity === 'setlists') {
-          await runSetlistExport(queryClient, itemId, kind, chordFormat)
+          await runSetlistExport(queryClient, itemId, kind, chordFormat, hideChords)
         } else if (entity === 'collections') {
-          await runCollectionExport(queryClient, itemId, kind, chordFormat)
+          await runCollectionExport(queryClient, itemId, kind, chordFormat, hideChords)
         }
         toast.dismiss(toastId)
       } catch (e) {
@@ -651,7 +653,7 @@ function HubItemContextMenu({
         console.error(`${entity} export failed`, e)
       }
     },
-    [chordFormat, entity, itemId, queryClient, t],
+    [chordFormat, entity, hideChords, itemId, queryClient, t],
   )
 
   const onSongExport = useCallback(
@@ -659,7 +661,7 @@ function HubItemContextMenu({
       if (!hubSong) return
       const toastId = toast.loading(t('hub.actions.exportPreparing'))
       try {
-        await runSongExport(hubSong.data as Record<string, unknown>, kind, chordFormat)
+        await runSongExport(hubSong.data as Record<string, unknown>, kind, chordFormat, undefined, hideChords)
         toast.dismiss(toastId)
       } catch (e) {
         toast.dismiss(toastId)
@@ -668,7 +670,7 @@ function HubItemContextMenu({
         console.error('Song export failed', e)
       }
     },
-    [chordFormat, hubSong, t],
+    [chordFormat, hideChords, hubSong, t],
   )
 
   const onSaveOffline = useCallback(async () => {

--- a/frontend/app/src/components/player/ChordsSlide.tsx
+++ b/frontend/app/src/components/player/ChordsSlide.tsx
@@ -3,10 +3,12 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
+import { useHideChordsPreference } from '@/hooks/useHideChordsPreference'
 import { scopeChordlibPageCss } from '@/lib/chord-page-css'
 import { getChordEngine } from '@/lib/chord-engine'
 import { cssScaleToFitViewport } from '@/lib/chord-a4-scale'
 import { chordFormatToRepresentation, type ChordFormatPreference } from '@/lib/chord-format'
+import { stripChordsFromChordlibHtml } from '@/lib/strip-chords-from-html'
 import type { ChordSongData } from '@/ports/chord-engine'
 import { cn } from '@/lib/utils'
 
@@ -37,6 +39,7 @@ export function ChordsSlide({
   fillParent = false,
 }: ChordsSlideProps) {
   const { t } = useTranslation()
+  const hideChords = useHideChordsPreference()
   const viewportRef = useRef<HTMLDivElement>(null)
   const pageRef = useRef<HTMLDivElement>(null)
   const [viewportSize, setViewportSize] = useState({ width: 0, height: 0 })
@@ -55,7 +58,7 @@ export function ChordsSlide({
 
   const songData = song.data as ChordSongData
   const representation = useMemo(() => chordFormatToRepresentation(chordFormat), [chordFormat])
-  const renderKey = `${song.id}:${displayKey ?? ''}:${renderPass}:${representation}`
+  const renderKey = `${song.id}:${displayKey ?? ''}:${renderPass}:${representation}:${hideChords ? 'hidden' : 'shown'}`
   const renderState = useMemo(
     (): RenderState =>
       renderCache.key === renderKey ? renderCache.state : { status: 'loading' },
@@ -103,7 +106,8 @@ export function ChordsSlide({
           representation,
         })
         if (cancelled) return
-        setRenderCache({ key: renderKey, state: { status: 'ready', html: page.html, css: page.css } })
+        const html = hideChords ? stripChordsFromChordlibHtml(page.html) : page.html
+        setRenderCache({ key: renderKey, state: { status: 'ready', html, css: page.css } })
       } catch (e) {
         if (cancelled) return
         const message = e instanceof Error ? e.message : String(e)
@@ -113,7 +117,7 @@ export function ChordsSlide({
     return () => {
       cancelled = true
     }
-  }, [renderKey, songData, displayKey, representation])
+  }, [renderKey, songData, displayKey, representation, hideChords])
 
   useLayoutEffect(() => {
     if (renderState.status !== 'ready') return

--- a/frontend/app/src/components/player/ChordsThreeColumnSlide.tsx
+++ b/frontend/app/src/components/player/ChordsThreeColumnSlide.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
+import { useHideChordsPreference } from '@/hooks/useHideChordsPreference'
 import { scopeChordlibPageCss } from '@/lib/chord-page-css'
 import {
   columnWidthInMultiColumnLayout,
@@ -11,6 +12,7 @@ import {
 } from '@/lib/chord-a4-scale'
 import { getChordEngine } from '@/lib/chord-engine'
 import { chordFormatToRepresentation, type ChordFormatPreference } from '@/lib/chord-format'
+import { stripChordsFromChordlibHtml } from '@/lib/strip-chords-from-html'
 import { songTitleFromData } from '@/lib/song-import-export'
 import type { ChordSongData } from '@/ports/chord-engine'
 import { expandSongSectionsForPlayer } from '@/lib/player/expand-song-sections'
@@ -114,6 +116,7 @@ function useMultiColumnSongRender(
   songData: ChordSongData | undefined,
   displayKey: string | null | undefined,
   chordFormat: ChordFormatPreference,
+  hideChords: boolean,
   renderPass: number,
 ): RenderState {
   const [renderCache, setRenderCache] = useState<{ key: string; state: RenderState }>({
@@ -121,7 +124,9 @@ function useMultiColumnSongRender(
     state: { status: 'loading' },
   })
   const representation = useMemo(() => chordFormatToRepresentation(chordFormat), [chordFormat])
-  const renderKey = song ? `${song.id}:${displayKey ?? ''}:${renderPass}:${representation}` : ''
+  const renderKey = song
+    ? `${song.id}:${displayKey ?? ''}:${renderPass}:${representation}:${hideChords ? 'hidden' : 'shown'}`
+    : ''
 
   useEffect(() => {
     if (!song || !songData) return
@@ -135,9 +140,12 @@ function useMultiColumnSongRender(
           representation,
         })
         if (cancelled) return
+        const sections = hideChords
+          ? page.sections.map((section) => stripChordsFromChordlibHtml(section))
+          : page.sections
         setRenderCache({
           key: renderKey,
-          state: { status: 'ready', sections: page.sections, css: page.css },
+          state: { status: 'ready', sections, css: page.css },
         })
       } catch (e) {
         if (cancelled) return
@@ -148,7 +156,7 @@ function useMultiColumnSongRender(
     return () => {
       cancelled = true
     }
-  }, [song, songData, displayKey, renderKey, representation])
+  }, [song, songData, displayKey, renderKey, representation, hideChords])
 
   if (!song || !songData || renderCache.key !== renderKey) {
     return LOADING_RENDER_STATE
@@ -270,6 +278,7 @@ export function ChordsThreeColumnSlide({
   fillParent = false,
 }: ChordsThreeColumnSlideProps) {
   const { t } = useTranslation()
+  const hideChords = useHideChordsPreference()
   const viewportRef = useRef<HTMLDivElement>(null)
   const columnAreaRef = useRef<HTMLDivElement>(null)
   const measureRef = useRef<HTMLDivElement>(null)
@@ -301,6 +310,7 @@ export function ChordsThreeColumnSlide({
     renderSongData,
     displayKey,
     chordFormat,
+    hideChords,
     renderPass,
   )
   const nextSongData = nextSong?.data as ChordSongData | undefined
@@ -314,6 +324,7 @@ export function ChordsThreeColumnSlide({
     nextRenderSongData,
     nextDisplayKey,
     chordFormat,
+    hideChords,
     0,
   )
   const nextPreviewRenderState = showNextPreview ? nextRenderState : null

--- a/frontend/app/src/components/settings/SettingsView.tsx
+++ b/frontend/app/src/components/settings/SettingsView.tsx
@@ -53,6 +53,10 @@ import {
   writeSheetBackgroundPreference,
 } from '@/lib/sheet-background'
 import {
+  readHideChordsPreference,
+  writeHideChordsPreference,
+} from '@/lib/hide-chords-preference'
+import {
   readSheetImageInvertPreference,
   writeSheetImageInvertPreference,
 } from '@/lib/sheet-image-invert-preference'
@@ -307,6 +311,7 @@ export function SettingsView({
   const [localePreference, setLocalePreferenceState] = useState(getLocalePreference)
   const [appearancePreference, setAppearancePreference] = useState(readAppearancePreference)
   const [chordFormatPreference, setChordFormatPreference] = useState(readChordFormatPreference)
+  const [hideChords, setHideChordsState] = useState(readHideChordsPreference)
   const [sheetBackgroundPreference, setSheetBackgroundPreference] = useState(readSheetBackgroundPreference)
   const [invertSheetImages, setInvertSheetImagesState] = useState(readSheetImageInvertPreference)
   const [layoutPreferences, setLayoutPreferences] = useState(readPlayerLayoutPreferences)
@@ -541,6 +546,11 @@ export function SettingsView({
   function setChordFormat(next: ChordFormatPreference) {
     setChordFormatPreference(next)
     writeChordFormatPreference(next)
+  }
+
+  function setHideChords(enabled: boolean) {
+    setHideChordsState(enabled)
+    writeHideChordsPreference(enabled)
   }
 
   function setSheetBackground(next: SheetBackgroundPreference) {
@@ -829,6 +839,26 @@ export function SettingsView({
             value={chordFormatPreference}
             onChange={setChordFormat}
           />
+
+          <Card>
+            <CardContent className="p-4">
+              <label className="flex items-start gap-3 text-sm">
+                <input
+                  type="checkbox"
+                  className="mt-0.5 size-4 shrink-0 accent-[var(--color-primary)]"
+                  aria-label={t('settings.hideChords.label')}
+                  checked={hideChords}
+                  onChange={(e) => setHideChords(e.target.checked)}
+                />
+                <span className="flex flex-col gap-0.5">
+                  <span>{t('settings.hideChords.label')}</span>
+                  <span className="text-xs text-[var(--color-muted-foreground)]">
+                    {t('settings.hideChords.description')}
+                  </span>
+                </span>
+              </label>
+            </CardContent>
+          </Card>
 
           <Card>
             <CardHeader className="p-4 pb-3">

--- a/frontend/app/src/components/settings/player-default.test.tsx
+++ b/frontend/app/src/components/settings/player-default.test.tsx
@@ -9,6 +9,7 @@ import {
   chordFormatToRepresentation,
   resolveChordFormatPreference,
 } from '@/lib/chord-format'
+import { readHideChordsPreference } from '@/lib/hide-chords-preference'
 
 // Flow: J2 — Player Default tab option surfaces
 describe('J2: Player Default tab options', () => {
@@ -17,6 +18,11 @@ describe('J2: Player Default tab options', () => {
     expect(resolveChordFormatPreference('nashville')).toBe('nashville')
     expect(chordFormatToRepresentation('letters')).toBeTruthy()
     expect(chordFormatToRepresentation('nashville')).toBeTruthy()
+  })
+
+  it('J2: hide chords preference defaults to off', () => {
+    expect(readHideChordsPreference({ getItem: () => null })).toBe(false)
+    expect(readHideChordsPreference({ getItem: () => 'true' })).toBe(true)
   })
 
   it('J2: scroll modes cycle through eight variants', () => {

--- a/frontend/app/src/components/songs/SongEditorActionsMenu.tsx
+++ b/frontend/app/src/components/songs/SongEditorActionsMenu.tsx
@@ -12,6 +12,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
+import { useHideChordsPreference } from '@/hooks/useHideChordsPreference'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -60,6 +61,7 @@ export function SongEditorActionsMenu({
   playDisabled,
 }: SongEditorActionsMenuProps) {
   const { t } = useTranslation()
+  const hideChords = useHideChordsPreference()
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [replaceOpen, setReplaceOpen] = useState(false)
   const [pendingFile, setPendingFile] = useState<File | null>(null)
@@ -107,13 +109,13 @@ export function SongEditorActionsMenu({
       if (!exportData) return
       onExportError?.(null)
       try {
-        await runSongExport(exportData, kind, chordFormat, engine ?? undefined)
+        await runSongExport(exportData, kind, chordFormat, engine ?? undefined, hideChords)
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e)
         onExportError?.(message || t('songs.editor.exportFailed'))
       }
     },
-    [chordFormat, engine, exportData, onExportError, t],
+    [chordFormat, engine, exportData, hideChords, onExportError, t],
   )
 
   return (

--- a/frontend/app/src/hooks/useHideChordsPreference.ts
+++ b/frontend/app/src/hooks/useHideChordsPreference.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react'
+
+import {
+  HIDE_CHORDS_CHANGE_EVENT,
+  readHideChordsPreference,
+} from '@/lib/hide-chords-preference'
+
+export function useHideChordsPreference(): boolean {
+  const [enabled, setEnabled] = useState(readHideChordsPreference)
+
+  useEffect(() => {
+    const onChange = (event: Event) => {
+      const detail = (event as CustomEvent<boolean>).detail
+      setEnabled(detail ?? readHideChordsPreference())
+    }
+
+    globalThis.window.addEventListener(HIDE_CHORDS_CHANGE_EVENT, onChange)
+    return () => globalThis.window.removeEventListener(HIDE_CHORDS_CHANGE_EVENT, onChange)
+  }, [])
+
+  return enabled
+}

--- a/frontend/app/src/i18n/de.json
+++ b/frontend/app/src/i18n/de.json
@@ -382,6 +382,10 @@
       "nashville": "Nashville",
       "nashvilleDescription": "Zeigt Nashville-Ziffern wie 1, 4 und 6m."
     },
+    "hideChords": {
+      "label": "Akkorde im Player und Export ausblenden",
+      "description": "Zeigt im Player und beim Export von PDF- oder Textdateien nur Songtext. Der Song-Editor bleibt unverändert."
+    },
     "sheetBackground": {
       "title": "Blatt-Hintergrund",
       "description": "Hintergrund hinter Akkordblättern und Anhängen im Player und in der Song-Vorschau.",

--- a/frontend/app/src/i18n/en.json
+++ b/frontend/app/src/i18n/en.json
@@ -382,6 +382,10 @@
       "nashville": "Nashville",
       "nashvilleDescription": "Show Nashville numbers such as 1, 4, and 6m."
     },
+    "hideChords": {
+      "label": "Hide chords in player and exports",
+      "description": "Show only song lyrics in the player and when exporting PDF or text files. The song editor is not affected."
+    },
     "sheetBackground": {
       "title": "Sheet background",
       "description": "Choose the background behind chord sheets and attachments in the player and song preview.",

--- a/frontend/app/src/lib/hide-chords-preference.test.ts
+++ b/frontend/app/src/lib/hide-chords-preference.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  HIDE_CHORDS_STORAGE_KEY,
+  readHideChordsPreference,
+  writeHideChordsPreference,
+} from '@/lib/hide-chords-preference'
+
+describe('readHideChordsPreference', () => {
+  it('returns false when unset', () => {
+    expect(readHideChordsPreference({ getItem: () => null })).toBe(false)
+  })
+
+  it('returns true when stored as true', () => {
+    expect(readHideChordsPreference({ getItem: () => 'true' })).toBe(true)
+  })
+})
+
+describe('writeHideChordsPreference', () => {
+  it('stores enabled preference', () => {
+    const storage = { setItem: vi.fn(), removeItem: vi.fn() }
+
+    writeHideChordsPreference(true, storage)
+    expect(storage.setItem).toHaveBeenCalledWith(HIDE_CHORDS_STORAGE_KEY, 'true')
+    expect(storage.removeItem).not.toHaveBeenCalled()
+  })
+
+  it('removes preference when disabled', () => {
+    const storage = { setItem: vi.fn(), removeItem: vi.fn() }
+
+    writeHideChordsPreference(false, storage)
+    expect(storage.removeItem).toHaveBeenCalledWith(HIDE_CHORDS_STORAGE_KEY)
+    expect(storage.setItem).not.toHaveBeenCalled()
+  })
+
+  it('notifies listeners when window is available', () => {
+    vi.stubGlobal('window', { dispatchEvent: vi.fn() })
+
+    writeHideChordsPreference(true, { setItem: vi.fn(), removeItem: vi.fn() })
+
+    expect(globalThis.window.dispatchEvent).toHaveBeenCalled()
+    vi.unstubAllGlobals()
+  })
+})

--- a/frontend/app/src/lib/hide-chords-preference.ts
+++ b/frontend/app/src/lib/hide-chords-preference.ts
@@ -1,0 +1,24 @@
+export const HIDE_CHORDS_STORAGE_KEY = 'wv_hide_chords'
+
+export const HIDE_CHORDS_CHANGE_EVENT = 'wv-hide-chords-change'
+
+export function readHideChordsPreference(
+  storage: Pick<Storage, 'getItem'> = globalThis.localStorage,
+): boolean {
+  return storage.getItem(HIDE_CHORDS_STORAGE_KEY) === 'true'
+}
+
+export function writeHideChordsPreference(
+  enabled: boolean,
+  storage: Pick<Storage, 'setItem' | 'removeItem'> = globalThis.localStorage,
+): void {
+  if (enabled) {
+    storage.setItem(HIDE_CHORDS_STORAGE_KEY, 'true')
+  } else {
+    storage.removeItem(HIDE_CHORDS_STORAGE_KEY)
+  }
+
+  if (typeof globalThis.window !== 'undefined') {
+    globalThis.window.dispatchEvent(new CustomEvent(HIDE_CHORDS_CHANGE_EVENT, { detail: enabled }))
+  }
+}

--- a/frontend/app/src/lib/hydrate-hub-song-links.ts
+++ b/frontend/app/src/lib/hydrate-hub-song-links.ts
@@ -39,10 +39,11 @@ export async function runOrderedSongsPdfExport(
   title: string,
   links: HubExportSongLink[],
   chordFormat: ChordFormatPreference,
+  hideChords?: boolean,
 ): Promise<void> {
   const songs = await hydrateSongLinksForHubExport(queryClient, links)
   const engine = await getChordEngine()
-  await exportSetlistPdf(engine, title, songs, chordFormat)
+  await exportSetlistPdf(engine, title, songs, chordFormat, hideChords)
 }
 
 export async function runOrderedSongsZipExport(
@@ -51,8 +52,9 @@ export async function runOrderedSongsZipExport(
   links: HubExportSongLink[],
   format: TextExportFormat,
   chordFormat: ChordFormatPreference,
+  hideChords?: boolean,
 ): Promise<void> {
   const songs = await hydrateSongLinksForHubExport(queryClient, links)
   const engine = await getChordEngine()
-  await exportOrderedSongsZip(engine, title, songs, format, chordFormat)
+  await exportOrderedSongsZip(engine, title, songs, format, chordFormat, hideChords)
 }

--- a/frontend/app/src/lib/run-collection-export.test.ts
+++ b/frontend/app/src/lib/run-collection-export.test.ts
@@ -35,6 +35,7 @@ describe('runCollectionExport', () => {
       'Hymns',
       expect.any(Array),
       'letters',
+      undefined,
     )
   })
 
@@ -46,6 +47,18 @@ describe('runCollectionExport', () => {
       expect.any(Array),
       'worshippro',
       'nashville',
+      undefined,
+    )
+  })
+
+  it('forwards hide chords preference', async () => {
+    await runCollectionExport(queryClient, 'coll-1', 'pdf', 'letters', true)
+    expect(runOrderedSongsPdfExport).toHaveBeenCalledWith(
+      queryClient,
+      'Hymns',
+      expect.any(Array),
+      'letters',
+      true,
     )
   })
 })

--- a/frontend/app/src/lib/run-collection-export.ts
+++ b/frontend/app/src/lib/run-collection-export.ts
@@ -16,14 +16,15 @@ export async function runCollectionExport(
   collectionId: string,
   kind: CollectionExportKind,
   chordFormat: ChordFormatPreference,
+  hideChords?: boolean,
 ): Promise<void> {
   const detail = await fetchCollectionDetail(queryClient, { id: collectionId })
   const links = normalizeSongLinksForCollectionEditor(detail.songs)
   if (kind === 'pdf') {
-    await runOrderedSongsPdfExport(queryClient, detail.title, links, chordFormat)
+    await runOrderedSongsPdfExport(queryClient, detail.title, links, chordFormat, hideChords)
     return
   }
-  await runOrderedSongsZipExport(queryClient, detail.title, links, kind, chordFormat)
+  await runOrderedSongsZipExport(queryClient, detail.title, links, kind, chordFormat, hideChords)
 }
 
 /** @deprecated Use {@link runCollectionExport}. */

--- a/frontend/app/src/lib/run-setlist-export.test.ts
+++ b/frontend/app/src/lib/run-setlist-export.test.ts
@@ -35,6 +35,7 @@ describe('runSetlistExport', () => {
       'Sunday',
       expect.any(Array),
       'letters',
+      undefined,
     )
     expect(runOrderedSongsZipExport).not.toHaveBeenCalled()
   })
@@ -47,6 +48,18 @@ describe('runSetlistExport', () => {
       expect.any(Array),
       'chordpro',
       'nashville',
+      undefined,
+    )
+  })
+
+  it('forwards hide chords preference', async () => {
+    await runSetlistExport(queryClient, 'sl-1', 'pdf', 'letters', true)
+    expect(runOrderedSongsPdfExport).toHaveBeenCalledWith(
+      queryClient,
+      'Sunday',
+      expect.any(Array),
+      'letters',
+      true,
     )
   })
 })

--- a/frontend/app/src/lib/run-setlist-export.ts
+++ b/frontend/app/src/lib/run-setlist-export.ts
@@ -16,14 +16,15 @@ export async function runSetlistExport(
   setlistId: string,
   kind: SetlistExportKind,
   chordFormat: ChordFormatPreference,
+  hideChords?: boolean,
 ): Promise<void> {
   const detail = await fetchSetlistDetail(queryClient, { id: setlistId })
   const links = normalizeSongLinksForEditor(detail.songs)
   if (kind === 'pdf') {
-    await runOrderedSongsPdfExport(queryClient, detail.title, links, chordFormat)
+    await runOrderedSongsPdfExport(queryClient, detail.title, links, chordFormat, hideChords)
     return
   }
-  await runOrderedSongsZipExport(queryClient, detail.title, links, kind, chordFormat)
+  await runOrderedSongsZipExport(queryClient, detail.title, links, kind, chordFormat, hideChords)
 }
 
 /** @deprecated Use {@link runSetlistExport}. */

--- a/frontend/app/src/lib/run-song-export.ts
+++ b/frontend/app/src/lib/run-song-export.ts
@@ -14,11 +14,12 @@ export async function runSongExport(
   kind: SongExportKind,
   chordFormat: ChordFormatPreference,
   engine?: ChordEngine,
+  hideChords?: boolean,
 ): Promise<void> {
   const resolved = engine ?? (await getChordEngine())
   if (kind === 'pdf') {
-    await exportSongPdf(resolved, data, chordFormat)
+    await exportSongPdf(resolved, data, chordFormat, hideChords)
     return
   }
-  exportSongText(resolved, data, kind, chordFormat)
+  exportSongText(resolved, data, kind, chordFormat, hideChords)
 }

--- a/frontend/app/src/lib/song-import-export.ts
+++ b/frontend/app/src/lib/song-import-export.ts
@@ -2,7 +2,10 @@ import JSZip from 'jszip'
 
 import { scopeChordlibPageCss } from '@/lib/chord-page-css'
 import { chordFormatToRepresentation, type ChordFormatPreference } from '@/lib/chord-format'
+import { readHideChordsPreference } from '@/lib/hide-chords-preference'
 import { resolveSongDataKey } from '@/lib/setlist-song-links'
+import { stripChordsFromChordlibHtml } from '@/lib/strip-chords-from-html'
+import { stripChordsFromChordpro } from '@/lib/strip-chords-from-chordpro'
 import { songEditorFormatOptions } from '@/lib/song-editor-state'
 import type { ChordEngine, ChordSongData } from '@/ports/chord-engine'
 
@@ -108,15 +111,17 @@ export function formatSongForExport(
   format: TextExportFormat,
   chordFormat: ChordFormatPreference,
   keyOverride?: string,
+  hideChords: boolean = readHideChordsPreference(),
 ): string {
   const worshipPro = format === 'worshippro'
   const key =
     keyOverride ?? resolveSongDataKey(data as Record<string, unknown>) ?? undefined
-  return engine.formatChordPro(data, {
+  const text = engine.formatChordPro(data, {
     worshipPro,
     key,
     representation: chordFormatToRepresentation(chordFormat),
   })
+  return hideChords ? stripChordsFromChordpro(text) : text
 }
 
 export function orderedSongZipEntryNames(
@@ -161,11 +166,12 @@ export function exportSongText(
   data: ChordSongData,
   format: TextExportFormat,
   chordFormat: ChordFormatPreference,
+  hideChords: boolean = readHideChordsPreference(),
 ): void {
   const worshipPro = format === 'worshippro'
   const ext = worshipPro ? 'wp' : 'cp'
   const basename = sanitizeDownloadBasename(songTitleFromData(data))
-  const text = formatSongForExport(engine, data, format, chordFormat)
+  const text = formatSongForExport(engine, data, format, chordFormat, undefined, hideChords)
   downloadTextFile(`${basename}.${ext}`, text)
 }
 
@@ -357,12 +363,15 @@ function renderA4ExportPage(
   data: ChordSongData,
   key: string | undefined,
   chordFormat: ChordFormatPreference,
+  hideChords: boolean = readHideChordsPreference(),
 ): PdfExportPage {
-  return engine.renderA4Html(data, {
+  const page = engine.renderA4Html(data, {
     key,
     representation: chordFormatToRepresentation(chordFormat),
     scale: 1,
   })
+  if (!hideChords) return page
+  return { html: stripChordsFromChordlibHtml(page.html), css: page.css }
 }
 
 export type HubExportSong = {
@@ -379,6 +388,7 @@ export async function exportOrderedSongsZip(
   songs: HubExportSong[],
   format: TextExportFormat,
   chordFormat: ChordFormatPreference,
+  hideChords: boolean = readHideChordsPreference(),
 ): Promise<void> {
   if (songs.length === 0) {
     throw new Error('No exportable songs')
@@ -386,7 +396,7 @@ export async function exportOrderedSongsZip(
   const zip = new JSZip()
   const entryNames = orderedSongZipEntryNames(songs, format)
   songs.forEach((song, index) => {
-    const text = formatSongForExport(engine, song.data, format, chordFormat, song.key)
+    const text = formatSongForExport(engine, song.data, format, chordFormat, song.key, hideChords)
     zip.file(entryNames[index]!, text)
   })
   const blob = await zip.generateAsync({ type: 'blob' })
@@ -402,9 +412,10 @@ export async function exportSongPdf(
   engine: ChordEngine,
   data: ChordSongData,
   chordFormat: ChordFormatPreference,
+  hideChords: boolean = readHideChordsPreference(),
 ): Promise<void> {
   const key = resolveSongDataKey(data as Record<string, unknown>) ?? undefined
-  const pages = [renderA4ExportPage(engine, data, key, chordFormat)]
+  const pages = [renderA4ExportPage(engine, data, key, chordFormat, hideChords)]
   const title = sanitizeDownloadBasename(songTitleFromData(data))
   await printPdfDocument(pages, title)
 }
@@ -418,12 +429,13 @@ export async function exportSetlistPdf(
   setlistTitle: string,
   songs: HubExportSong[],
   chordFormat: ChordFormatPreference,
+  hideChords: boolean = readHideChordsPreference(),
 ): Promise<void> {
   if (songs.length === 0) {
     throw new Error('No exportable songs')
   }
   const pages = songs.map((song) =>
-    renderA4ExportPage(engine, song.data, song.key, chordFormat),
+    renderA4ExportPage(engine, song.data, song.key, chordFormat, hideChords),
   )
   const title = sanitizeDownloadBasename(setlistTitle)
   await printPdfDocument(pages, title)

--- a/frontend/app/src/lib/strip-chords-from-chordpro.test.ts
+++ b/frontend/app/src/lib/strip-chords-from-chordpro.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+
+import { stripChordsFromChordpro } from '@/lib/strip-chords-from-chordpro'
+
+describe('stripChordsFromChordpro', () => {
+  it('removes inline chord brackets and keeps lyrics', () => {
+    const input = '[C]Hello [G]world'
+    expect(stripChordsFromChordpro(input)).toBe('Hello world')
+  })
+
+  it('drops chord-only lines', () => {
+    const input = '[C] [G]\n[C]Line one\n[Am] [F]'
+    expect(stripChordsFromChordpro(input)).toBe('Line one')
+  })
+
+  it('preserves directive lines', () => {
+    const input = '{title: My Song}\n{key: C}\n[C]Verse line'
+    expect(stripChordsFromChordpro(input)).toBe('{title: My Song}\n{key: C}\nVerse line')
+  })
+})

--- a/frontend/app/src/lib/strip-chords-from-chordpro.ts
+++ b/frontend/app/src/lib/strip-chords-from-chordpro.ts
@@ -1,0 +1,20 @@
+const DIRECTIVE_LINE = /^\{[^}]+\}\s*$/
+
+/** Remove chord markers from ChordPro / Worship Pro export text. */
+export function stripChordsFromChordpro(text: string): string {
+  const lines = text.split('\n')
+  const out: string[] = []
+
+  for (const line of lines) {
+    if (DIRECTIVE_LINE.test(line.trim())) {
+      out.push(line)
+      continue
+    }
+
+    const stripped = line.replace(/\[[^\]]*\]/g, '')
+    if (!stripped.trim()) continue
+    out.push(stripped)
+  }
+
+  return out.join('\n')
+}

--- a/frontend/app/src/lib/strip-chords-from-html.test.tsx
+++ b/frontend/app/src/lib/strip-chords-from-html.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { stripChordsFromChordlibHtml } from '@/lib/strip-chords-from-html'
+
+describe('stripChordsFromChordlibHtml', () => {
+  it('removes inline chord spans and keeps lyrics', () => {
+    const html =
+      '<p><span class="keyword">Verse</span><br>' +
+      '<span class="part part-has-chord"><span class="chord">C</span><span class="text">Hello </span></span>' +
+      '<span class="part"><span class="text">world</span></span><br></p>'
+
+    const result = stripChordsFromChordlibHtml(html)
+
+    expect(result).not.toContain('class="chord"')
+    expect(result).not.toContain('part-has-chord')
+    expect(result).toContain('Hello')
+    expect(result).toContain('world')
+    expect(result).toContain('Verse')
+  })
+
+  it('removes chord bar lines', () => {
+    const html =
+      '<p><span class="keyword">Intro</span><br>' +
+      '<span class="bars"><span class="bar">|</span><span class="chord">C</span>' +
+      '<span class="bar">|</span><span class="chord">G</span><span class="bar">|</span></span><br></p>'
+
+    const result = stripChordsFromChordlibHtml(html)
+
+    expect(result).not.toContain('class="bars"')
+    expect(result).not.toContain('>C<')
+    expect(result).toContain('Intro')
+  })
+
+  it('removes whitespace-only text spans used for chord alignment', () => {
+    const html =
+      '<span class="part part-has-chord"><span class="chord">Am</span><span class="text">Line</span></span>' +
+      '<span class="text">     </span>'
+
+    const result = stripChordsFromChordlibHtml(html)
+
+    expect(result).toContain('Line')
+    expect(result).not.toMatch(/<span class="text">\s+<\/span>/)
+  })
+})

--- a/frontend/app/src/lib/strip-chords-from-html.ts
+++ b/frontend/app/src/lib/strip-chords-from-html.ts
@@ -1,0 +1,18 @@
+/**
+ * Remove chord symbols from chordlib A4 HTML while keeping lyrics and section titles.
+ */
+export function stripChordsFromChordlibHtml(html: string): string {
+  if (typeof document === 'undefined') return html
+
+  const root = document.createElement('div')
+  root.innerHTML = html
+
+  root.querySelectorAll('.bars').forEach((el) => el.remove())
+  root.querySelectorAll('.chord').forEach((el) => el.remove())
+  root.querySelectorAll('.part-has-chord').forEach((el) => el.classList.remove('part-has-chord'))
+  root.querySelectorAll('.text').forEach((el) => {
+    if (!el.textContent?.trim()) el.remove()
+  })
+
+  return root.innerHTML
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
   "packageManager": "pnpm@10.33.0",
   "pnpm": {
     "overrides": {
+      "esbuild": "0.28.1",
       "serialize-javascript": ">=7.0.5"
     }
   }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  esbuild: 0.28.1
   serialize-javascript: '>=7.0.5'
 
 importers:
@@ -70,7 +71,7 @@ importers:
         version: 1.2.5(@types/react@19.2.17)(react@19.2.7)
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.0(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))
+        version: 4.3.0(vite@8.0.16(@types/node@25.9.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))
       '@tanstack/query-async-storage-persister':
         specifier: ^5.101.0
         version: 5.101.0
@@ -152,7 +153,7 @@ importers:
         version: 1.60.0
       '@tanstack/router-plugin':
         specifier: ^1.168.18
-        version: 1.168.18(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))
+        version: 1.168.18(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -173,7 +174,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))
+        version: 6.0.2(vite@8.0.16(@types/node@25.9.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))
       '@vitest/coverage-v8':
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
@@ -209,13 +210,13 @@ importers:
         version: 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       vite:
         specifier: ^8.0.16
-        version: 8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)
+        version: 8.0.16(@types/node@25.9.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)
       vite-plugin-pwa:
         specifier: ^1.3.0
-        version: 1.3.0(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))(workbox-build@7.4.0)(workbox-window@7.4.1)
+        version: 1.3.0(vite@8.0.16(@types/node@25.9.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))(workbox-build@7.4.0)(workbox-window@7.4.1)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))
+        version: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))
 
   packages/chordlib-wasm: {}
 
@@ -859,158 +860,158 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2524,8 +2525,8 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3876,7 +3877,7 @@ packages:
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.1.18
-      esbuild: ^0.27.0 || ^0.28.0
+      esbuild: 0.28.1
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -4934,82 +4935,82 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.7':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.27.7':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.27.7':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.7':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.7':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.27.7':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.7':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.7':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.7':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.7':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.7':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.7':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.7':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/win32-x64@0.27.7':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.4.1(jiti@2.7.0))':
@@ -5778,12 +5779,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
 
-  '@tailwindcss/vite@4.3.0(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))':
+  '@tailwindcss/vite@4.3.0(vite@8.0.16(@types/node@25.9.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))':
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)
+      vite: 8.0.16(@types/node@25.9.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)
 
   '@tanstack/history@1.162.0': {}
 
@@ -5845,7 +5846,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.18(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))':
+  '@tanstack/router-plugin@1.168.18(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/template': 7.29.7
@@ -5858,7 +5859,7 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       '@tanstack/react-router': 1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)
+      vite: 8.0.16(@types/node@25.9.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6069,10 +6070,10 @@ snapshots:
       - '@codemirror/lint'
       - '@codemirror/search'
 
-  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))':
+  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)
+      vite: 8.0.16(@types/node@25.9.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)
 
   '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
     dependencies:
@@ -6086,7 +6087,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))
+      vitest: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -6097,13 +6098,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)
+      vite: 8.0.16(@types/node@25.9.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -6519,34 +6520,34 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
-  esbuild@0.27.7:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
     optional: true
 
   escalade@3.2.0: {}
@@ -7763,7 +7764,7 @@ snapshots:
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       get-tsconfig: 4.14.0
     optionalDependencies:
       fsevents: 2.3.3
@@ -7892,18 +7893,18 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-plugin-pwa@1.3.0(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))(workbox-build@7.4.0)(workbox-window@7.4.1):
+  vite-plugin-pwa@1.3.0(vite@8.0.16(@types/node@25.9.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))(workbox-build@7.4.0)(workbox-window@7.4.1):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.17
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)
+      vite: 8.0.16(@types/node@25.9.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)
       workbox-build: 7.4.0
       workbox-window: 7.4.1
     transitivePeerDependencies:
       - supports-color
 
-  vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0):
+  vite@8.0.16(@types/node@25.9.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -7912,16 +7913,15 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.2
-      esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.7.0
       terser: 5.48.0
       tsx: 4.21.0
 
-  vitest@4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)):
+  vitest@4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -7938,7 +7938,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)
+      vite: 8.0.16(@types/node@25.9.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.2


### PR DESCRIPTION
## Summary
- Add a Player Default setting to hide chord symbols in the player and exports while keeping the song editor unchanged
- Post-process chordlib HTML and ChordPro text to show lyrics only when enabled
- Wire the preference through player slides, hub exports, and song editor export actions

## Test plan
- [ ] Enable "Hide chords in player and exports" in Settings → Player Default
- [ ] Verify player shows lyrics only (no chord symbols or bar lines)
- [ ] Verify song editor preview still shows chords
- [ ] Export PDF/text from player hub and song editor; confirm chords are hidden when toggle is on
- [ ] Reload settings page and confirm checkbox persists