### PR TITLE
docs: add AGENTS.md and tighten CONTRIBUTING quality gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,115 @@
+# AI agent instructions
+
+This file is for **AI coding agents** (Cursor, Copilot, Codex, etc.). Human contributors should follow [CONTRIBUTING.md](CONTRIBUTING.md); agents must follow **both** documents.
+
+## Non-negotiable rules
+
+1. **Do not create git commits** unless the user explicitly asks. When they do, the commit must contain only code that already passes the quality gates below.
+2. **Never bypass hooks** (`--no-verify`, `--no-gpg-sign`, etc.) unless the user explicitly requests it.
+3. **Never commit failing code.** If format, lint, or unit tests fail, fix the failures first. Do not commit and promise to fix later.
+4. **Run gates for every area you changed.** Touching `backend/` does not excuse skipping frontend checks if you also edited `frontend/`, and vice versa.
+5. **Do not push or open PRs** unless the user explicitly asks.
+
+## Required workflow before any commit
+
+Run these steps **in order** for each area you modified. Re-run after fixes until everything passes.
+
+### 1. Autoformat
+
+| Area touched | Apply formatting |
+|--------------|------------------|
+| `backend/`, `cli/`, `shared/`, `frontend/crates/chordlib-wasm/` | `cargo fmt` in each crate directory you changed |
+| `frontend/` (TypeScript/CSS/JS) | `pnpm --filter app exec eslint . --fix` |
+
+Rust CI enforces `cargo fmt --check`. Frontend CI enforces ESLint (`pnpm -C frontend lint`); use `--fix` for auto-fixable issues.
+
+### 2. Lint and typecheck
+
+**Rust** (when you changed Rust code):
+
+```bash
+cd backend && cargo clippy -- -D warnings
+```
+
+Also run `cargo clippy` in `cli/` or `shared/` if you edited those crates.
+
+**Frontend** (when you changed frontend code):
+
+```bash
+pnpm -C frontend install          # if dependencies changed
+pnpm -C frontend build:wasm       # when chordlib-wasm or WASM consumers changed
+pnpm -C frontend lint
+pnpm -C frontend typecheck
+pnpm --filter app lint:flows      # when routes or user flows changed
+```
+
+**OpenAPI** (when you changed backend API types or routes):
+
+Regenerate and sync per [CONTRIBUTING.md](CONTRIBUTING.md#openapi), then confirm no drift:
+
+```bash
+pnpm --filter app openapi:sync
+git diff --exit-code frontend/app/src/api/schema.d.ts
+```
+
+### 3. Unit tests
+
+**Rust:**
+
+```bash
+cd backend && cargo test -- --test-threads=4
+# Also: (cd cli && cargo test) / (cd shared && cargo test) when those crates changed
+```
+
+**Frontend:**
+
+```bash
+pnpm -C frontend test
+```
+
+Add or update tests when you change behavior. Do not delete or skip tests to make the suite pass.
+
+### 4. Build (when you changed build inputs)
+
+```bash
+pnpm -C frontend build            # frontend or WASM changes
+```
+
+### 5. Full CI parity (before opening a PR or when unsure)
+
+```bash
+./scripts/verify-ci.sh
+```
+
+This is the authoritative local gate: fmt, audit, backend test/clippy, OpenAPI tri-copy + Spectral, frontend test/lint/typecheck/flow lint/build. It does **not** run Playwright e2e or Docker/Venom.
+
+## Quick reference by path
+
+| Paths changed | Minimum commands before commit |
+|---------------|--------------------------------|
+| `backend/`, `shared/`, `cli/` | `cargo fmt` → `cargo clippy -- -D warnings` → `cargo test` (in affected crates) |
+| `frontend/app/`, `frontend/packages/` | `eslint . --fix` → `pnpm -C frontend lint` → `pnpm -C frontend typecheck` → `pnpm -C frontend test` |
+| `frontend/crates/chordlib-wasm/` | `cargo fmt` → `pnpm -C frontend build:wasm` → frontend lint/typecheck/test |
+| `docs/openapi.json`, backend OpenAPI | Regenerate OpenAPI (see CONTRIBUTING) → `./scripts/verify-ci.sh` OpenAPI steps |
+| `backend/db-migrations/` | `cargo test database::migrations::tests` in `backend/` |
+
+## What not to run by default
+
+- **Playwright e2e** (`pnpm -C frontend test:e2e`) — local-only, not in CI. Run only when the user asks or when you changed e2e specs.
+- **Docker/Venom** — post-merge integration gate; see [CONTRIBUTING.md](CONTRIBUTING.md#ci-overview).
+
+## When checks fail
+
+1. Read the full error output; fix the root cause in source, not in CI config.
+2. Re-run the **same** failing command until it passes.
+3. Re-run the full gate for the touched area (format → lint → test).
+4. Only then stage and commit (if the user asked for a commit).
+
+## Project context
+
+- Monorepo: Rust backend/cli/shared + React/Vite frontend + chordlib WASM crate.
+- No root `Cargo.toml`; each Rust crate is standalone.
+- Canonical OpenAPI: `docs/openapi.json` (tri-copied to backend and frontend).
+- Tool versions: Rust **1.96.0**, Node **20**, pnpm **10.33.0** — see [CONTRIBUTING.md](CONTRIBUTING.md#prerequisites).
+
+For architecture, migrations, release notes, and CI job details, read [CONTRIBUTING.md](CONTRIBUTING.md) and [docs/README.md](docs/README.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thank you for helping improve Worship Viewer. This document covers the workflows contributors use most often.
 
+**AI coding agents:** read [AGENTS.md](AGENTS.md) in addition to this file. Agents must not commit code that has not been autoformatted, linted, and unit-tested.
+
 ## Prerequisites
 
 | Stack | Version / tool |
@@ -46,18 +48,32 @@ Runs fmt, audit, backend tests/clippy, OpenAPI tri-copy + Spectral, and the full
 
 ## Before opening a PR
 
+Run checks in this order: **format → lint/typecheck → unit tests → build**. Apply fixes and re-run until clean. The one-shot script `./scripts/verify-ci.sh` runs the full CI-equivalent gate (recommended).
+
 ### Backend / shared / CLI
 
 ```bash
-(cd backend && cargo fmt --check)
-(cd shared && cargo fmt --check)
-(cd cli && cargo fmt --check)
+# 1. Format (apply locally; CI uses --check)
+(cd backend && cargo fmt)
+(cd shared && cargo fmt)
+(cd cli && cargo fmt)
+
+# 2. Lint
 cd backend && cargo clippy -- -D warnings
+
+# 3. Unit tests
 cd backend && cargo test -- --test-threads=4
+
+# 4. Supply chain (also in verify-ci.sh)
 (cd backend && cargo audit)
 (cd cli && cargo audit)
 (cd shared && cargo audit)
 (cd frontend/crates/chordlib-wasm && cargo audit)
+
+# Verify formatting in CI mode
+(cd backend && cargo fmt --check)
+(cd shared && cargo fmt --check)
+(cd cli && cargo fmt --check)
 ```
 
 ### Frontend
@@ -65,9 +81,19 @@ cd backend && cargo test -- --test-threads=4
 ```bash
 pnpm -C frontend install
 pnpm -C frontend build:wasm
-pnpm -C frontend test
+
+# 1. Format (auto-fix ESLint issues where possible)
+pnpm --filter app exec eslint . --fix
+
+# 2. Lint and typecheck
 pnpm -C frontend lint
 pnpm -C frontend typecheck
+pnpm --filter app lint:flows
+
+# 3. Unit tests
+pnpm -C frontend test
+
+# 4. Build and audit
 pnpm -C frontend build
 pnpm -C frontend audit --audit-level=high
 ```


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` with mandatory pre-commit rules for AI coding agents (format → lint → unit tests, no `--no-verify`, no commits unless requested).
- Update `CONTRIBUTING.md` to cross-reference `AGENTS.md` and reorganize the PR checklist into the same ordered workflow.

## Test plan
- [x] Documentation-only change; no code or CI behavior modified
- [ ] Review `AGENTS.md` command references against `./scripts/verify-ci.sh`
- [ ] Confirm agent tooling picks up `AGENTS.md` in repo root