### PR TITLE
[codex] Fix duplicate setlist song player loading

### DIFF
--- a/backend/src/resources/common.rs
+++ b/backend/src/resources/common.rs
@@ -148,6 +148,13 @@ pub async fn song_links_to_owned(
     let records: Vec<SongRecord> = response
         .take(0)
         .map_err(|e| crate::log_and_convert!(AppError::database, "song.batch_by_id.take", e))?;
+    song_link_records_to_owned(links, records)
+}
+
+fn song_link_records_to_owned(
+    links: Vec<SongLinkRecord>,
+    records: Vec<SongRecord>,
+) -> Result<Vec<SongLinkOwned>, AppError> {
     let mut by_id: HashMap<String, SongRecord> = HashMap::with_capacity(records.len());
     for r in records {
         let Some(ref rid) = r.id else {
@@ -158,7 +165,7 @@ pub async fn song_links_to_owned(
     let mut out = Vec::with_capacity(links.len());
     for link in links {
         let sid = record_id_string(&link.id);
-        let rec = by_id.remove(&sid).ok_or_else(|| {
+        let rec = by_id.get(&sid).cloned().ok_or_else(|| {
             AppError::database(
                 "referenced song not found (collection or setlist data may be inconsistent)",
             )
@@ -212,6 +219,8 @@ impl From<SongLink> for SongLinkRecord {
 mod tests {
     use std::collections::HashSet;
 
+    use chordlib::types::Song as SongData;
+    use shared::song::CreateSong;
     use shared::song::Song;
     use surrealdb::types::RecordId;
 
@@ -307,5 +316,41 @@ mod tests {
         assert_eq!(toc.len(), 2);
         assert_eq!(toc[0].nr, "1");
         assert_eq!(toc[1].nr, "x");
+    }
+
+    #[test]
+    fn song_link_records_to_owned_allows_duplicate_song_links() {
+        let links = vec![
+            SongLinkRecord {
+                id: RecordId::new("song", "dup"),
+                nr: Some("1".into()),
+                key: None,
+                tempo: None,
+            },
+            SongLinkRecord {
+                id: RecordId::new("song", "dup"),
+                nr: Some("2".into()),
+                key: None,
+                tempo: None,
+            },
+        ];
+        let records = vec![SongRecord::from_payload(
+            Some(RecordId::new("song", "dup")),
+            Some(RecordId::new("team", "team-1")),
+            CreateSong {
+                collection: "collection-1".into(),
+                not_a_song: false,
+                blobs: vec![],
+                data: SongData::default(),
+            },
+        )];
+
+        let owned = song_link_records_to_owned(links, records).unwrap();
+
+        assert_eq!(owned.len(), 2);
+        assert_eq!(owned[0].song.id, "dup");
+        assert_eq!(owned[1].song.id, "dup");
+        assert_eq!(owned[0].nr.as_deref(), Some("1"));
+        assert_eq!(owned[1].nr.as_deref(), Some("2"));
     }
 }

--- a/frontend/app/src/lib/setlist-field-diff.test.ts
+++ b/frontend/app/src/lib/setlist-field-diff.test.ts
@@ -120,6 +120,16 @@ describe('buildSetlistPatchBody', () => {
     ).toEqual({ owner: 'team-b' })
   })
 
+  it('omits empty owner drafts', () => {
+    expect(
+      buildSetlistPatchBody(base, {
+        title: 'A',
+        owner: '',
+        songs: [{ id: 'x', key: 'C' }],
+      }),
+    ).toBeNull()
+  })
+
   it('detects slot tempo drift', () => {
     expect(
       buildSetlistPatchBody(base, {

--- a/frontend/app/src/lib/setlist-field-diff.ts
+++ b/frontend/app/src/lib/setlist-field-diff.ts
@@ -36,8 +36,9 @@ export function buildSetlistPatchBody(
   if (draft.title !== baseline.title) {
     body.title = draft.title
   }
-  if (draft.owner !== baseline.owner) {
-    body.owner = draft.owner
+  const draftOwner = draft.owner.trim()
+  if (draftOwner && draftOwner !== baseline.owner) {
+    body.owner = draftOwner
   }
   if (!songsEqual(draft.songs, baseline.songs)) {
     body.songs = draft.songs.map((l) => songLinkForSetlistMutation(l))

--- a/shared/src/player/player.rs
+++ b/shared/src/player/player.rs
@@ -273,12 +273,13 @@ impl Add for Player {
         }
         let self_len = self.items.len();
         let last_self_item = self.items.last().expect("non-empty").clone();
+        let skip_leading_shared_blob = |item: &PlayerItem| matches!((&last_self_item, item), (PlayerItem::Blob(a), PlayerItem::Blob(b)) if a == b);
         Self {
             toc: self
                 .toc
                 .into_iter()
                 .chain(other.toc.iter().map(|item| TocItem {
-                    idx: if !other.items.is_empty() && self.items.last() == other.items.first() {
+                    idx: if other.items.first().is_some_and(skip_leading_shared_blob) {
                         item.idx + self_len.saturating_sub(1)
                     } else {
                         item.idx + self_len
@@ -292,12 +293,7 @@ impl Add for Player {
             items: self
                 .items
                 .into_iter()
-                .chain(
-                    other
-                        .items
-                        .into_iter()
-                        .skip_while(|item| *item == last_self_item),
-                )
+                .chain(other.items.into_iter().skip_while(skip_leading_shared_blob))
                 .collect(),
             scroll_type: self.scroll_type,
             scroll_type_cache_other_orientation: self.scroll_type_cache_other_orientation,
@@ -406,5 +402,50 @@ mod tests {
             PlayerItem::Chords(chords) => assert_eq!(chords.song.data.tempo, Some(120)),
             _ => panic!("expected chords player item"),
         }
+    }
+
+    #[test]
+    fn add_keeps_identical_chord_songs_as_separate_items() {
+        let song = song_with_tempo(Some(120));
+        let link = |song: Song| SongLinkOwned {
+            song,
+            nr: None,
+            key: None,
+            tempo: None,
+            liked: false,
+        };
+        let player = Player::from(link(song.clone())) + Player::from(link(song));
+
+        assert_eq!(player.items.len(), 2);
+        assert!(matches!(player.items[0], PlayerItem::Chords(_)));
+        assert!(matches!(player.items[1], PlayerItem::Chords(_)));
+        assert_eq!(player.toc.len(), 2);
+        assert_eq!(player.toc[0].idx, 0);
+        assert_eq!(player.toc[1].idx, 1);
+    }
+
+    #[test]
+    fn add_condenses_identical_adjacent_blob_items() {
+        let song = Song {
+            id: "blob-song".into(),
+            blobs: vec![crate::blob::BlobLink {
+                id: "blob-1".into(),
+            }],
+            ..Default::default()
+        };
+        let link = |song: Song| SongLinkOwned {
+            song,
+            nr: None,
+            key: None,
+            tempo: None,
+            liked: false,
+        };
+        let player = Player::from(link(song.clone())) + Player::from(link(song));
+
+        assert_eq!(player.items.len(), 1);
+        assert!(matches!(player.items[0], PlayerItem::Blob(_)));
+        assert_eq!(player.toc.len(), 2);
+        assert_eq!(player.toc[0].idx, 0);
+        assert_eq!(player.toc[1].idx, 0);
     }
 }


### PR DESCRIPTION
## Summary

Fixes the player endpoint and frontend autosave edge cases seen when the same chord song appears twice in a row in a setlist.

## Root Cause

The backend batch resolver for setlist and collection song links stored fetched songs in a map, then used `remove()` while walking the link list. When the same song appeared twice, the first link consumed the only fetched record and the second link was treated as a missing referenced song, causing `/api/v1/setlists/{id}/player` to return 500.

The shared player combiner also treated any identical adjacent player items as collapsible, which collapsed repeated chord songs. That is correct for adjacent identical blob pages, but not for chord songs that represent distinct setlist slots.

## Changes

- Reuse fetched song records while resolving duplicate setlist/collection song links.
- Keep repeated chord songs as separate player items.
- Preserve existing condensation for identical adjacent blob items.
- Prevent setlist autosave from sending `owner: ""` during transient empty draft state.
- Add regression tests for duplicate link resolution, chord item preservation, blob condensation, and empty owner drafts.

## Validation

- `cargo fmt` in `backend/` and `shared/`
- `cargo clippy -- -D warnings` in `backend/` and `shared/`
- `cargo test -- --test-threads=4` in `backend/`
- `cargo test` in `shared/`
- `pnpm -C frontend lint`
- `pnpm -C frontend typecheck`
- `pnpm -C frontend test`

Note: frontend commands passed with the local Node version warning (`v26.0.0`; project wants Node 20).