### PR TITLE
[codex] Harden Safari 16 frontend compatibility

### DIFF
--- a/frontend/app/src/components/collections/CreateCollectionDialog.tsx
+++ b/frontend/app/src/components/collections/CreateCollectionDialog.tsx
@@ -19,6 +19,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { useSession } from '@/hooks/useSession'
+import { getLocalStorage, safeGetItem, safeSetItem } from '@/lib/browser-storage'
 import { hubListRootKey } from '@/lib/hub-list-keys'
 import { teamsListRootKey } from '@/lib/teams-sessions-keys'
 import { getNextPageIndex } from '@/lib/list-pagination'
@@ -29,20 +30,12 @@ import { cn } from '@/lib/utils'
 const LAST_OWNER_LS = 'wv.collectionCreate.lastOwnerTeamId'
 
 function readLastOwnerFromLs(): string | null {
-  try {
-    const raw = globalThis.localStorage?.getItem(LAST_OWNER_LS)
-    return raw && raw.trim() ? raw.trim() : null
-  } catch {
-    return null
-  }
+  const raw = safeGetItem(LAST_OWNER_LS, getLocalStorage())
+  return raw && raw.trim() ? raw.trim() : null
 }
 
 function writeLastOwnerToLs(teamId: string) {
-  try {
-    globalThis.localStorage?.setItem(LAST_OWNER_LS, teamId)
-  } catch {
-    /* ignore */
-  }
+  safeSetItem(LAST_OWNER_LS, teamId, getLocalStorage())
 }
 
 type CreateCollectionDialogProps = {

--- a/frontend/app/src/components/hub/EntityListView.tsx
+++ b/frontend/app/src/components/hub/EntityListView.tsx
@@ -61,6 +61,7 @@ import { downloadPlayerForOffline, removeOfflinePlayerCopy } from '@/lib/offline
 import { useOnline } from '@/hooks/use-online'
 import { useSession } from '@/hooks/useSession'
 import { useTeamDetail } from '@/hooks/useTeamDetail'
+import { observeElementIntersection } from '@/lib/browser-apis'
 import { exportPdfHintTitle } from '@/lib/export-pdf-hint'
 import { runCollectionExport } from '@/lib/run-collection-export'
 import { runSetlistExport } from '@/lib/run-setlist-export'
@@ -243,7 +244,8 @@ export function EntityListView({ entity }: EntityListViewProps) {
     const sentinel = sentinelRef.current
     if (!root || !sentinel) return
 
-    const obs = new IntersectionObserver(
+    return observeElementIntersection(
+      sentinel,
       (entries) => {
         const hit = entries[0]?.isIntersecting
         if (hit && hasNextPage && !isFetchingNextPage) {
@@ -252,8 +254,6 @@ export function EntityListView({ entity }: EntityListViewProps) {
       },
       { root, rootMargin: '120px' },
     )
-    obs.observe(sentinel)
-    return () => obs.disconnect()
   }, [hasNextPage, isFetchingNextPage, fetchNextPage, items.length, scrollRef])
 
   const showSkeleton = isPending && !data

--- a/frontend/app/src/components/hub/HubShell.tsx
+++ b/frontend/app/src/components/hub/HubShell.tsx
@@ -36,6 +36,7 @@ import { useTeamDetail } from '@/hooks/useTeamDetail'
 import { useCollectionDetailQuery } from '@/hooks/useCollectionDetailQuery'
 import { useSetlistDetailQuery } from '@/hooks/useSetlistDetailQuery'
 import { useSongDetailQuery } from '@/hooks/useSongDetailQuery'
+import { listenToMediaQuery } from '@/lib/browser-apis'
 import { getTeamDisplayName, isPersonalTeamName } from '@/lib/team-display-name'
 import {
   buildPlayerReturnSearch,
@@ -677,8 +678,7 @@ export function HubShell() {
     if (!mq) return
     const fn = () => setPaletteOk(mq.matches)
     fn()
-    mq.addEventListener('change', fn)
-    return () => mq.removeEventListener('change', fn)
+    return listenToMediaQuery(mq, fn)
   }, [])
 
   if (isPending) {

--- a/frontend/app/src/components/player/ChordsSlide.tsx
+++ b/frontend/app/src/components/player/ChordsSlide.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
 import { useHideChordsPreference } from '@/hooks/useHideChordsPreference'
+import { observeElementResize } from '@/lib/browser-apis'
 import { scopeChordlibPageCss } from '@/lib/chord-page-css'
 import { getChordEngine } from '@/lib/chord-engine'
 import { cssScaleToFitViewport } from '@/lib/chord-a4-scale'
@@ -85,10 +86,8 @@ export function ChordsSlide({
       const rect = el.getBoundingClientRect()
       setViewportSize({ width: rect.width, height: rect.height })
     }
-    const observer = new ResizeObserver(() => updateSize())
-    observer.observe(el)
     updateSize()
-    return () => observer.disconnect()
+    return observeElementResize(el, () => updateSize())
   }, [])
 
   const retry = useCallback(() => {
@@ -133,9 +132,7 @@ export function ChordsSlide({
     }
 
     measure()
-    const observer = new ResizeObserver(measure)
-    observer.observe(el)
-    return () => observer.disconnect()
+    return observeElementResize(el, measure)
   }, [renderKey, renderState])
 
   const scaledReady = renderState.status === 'ready' && cssScale != null

--- a/frontend/app/src/components/player/ChordsThreeColumnSlide.tsx
+++ b/frontend/app/src/components/player/ChordsThreeColumnSlide.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
 import { useHideChordsPreference } from '@/hooks/useHideChordsPreference'
+import { observeElementResize } from '@/lib/browser-apis'
 import { scopeChordlibPageCss } from '@/lib/chord-page-css'
 import {
   columnWidthInMultiColumnLayout,
@@ -423,10 +424,9 @@ export function ChordsThreeColumnSlide({
     }
 
     updateLayout()
-    const observer = new ResizeObserver(updateLayout)
-    observer.observe(columnAreaEl)
-    if (viewportRef.current) observer.observe(viewportRef.current)
-    return () => observer.disconnect()
+    const cleanups = [observeElementResize(columnAreaEl, updateLayout)]
+    if (viewportRef.current) cleanups.push(observeElementResize(viewportRef.current, updateLayout))
+    return () => cleanups.forEach((cleanup) => cleanup())
   }, [layoutKey, columnCount, renderState.status, columnSections?.length, overflowStyle])
 
   useLayoutEffect(() => {
@@ -468,9 +468,7 @@ export function ChordsThreeColumnSlide({
     measureAndPack()
     void document.fonts.ready.then(measureAndPack)
 
-    const observer = new ResizeObserver(measureAndPack)
-    observer.observe(measureEl)
-    return () => observer.disconnect()
+    return observeElementResize(measureEl, measureAndPack)
   }, [packingContextKey, columnLayout, columnSections, combinedColumnCss, overflowStyle, columnCount])
 
   useLayoutEffect(() => {

--- a/frontend/app/src/components/player/PlayerBookSpread.tsx
+++ b/frontend/app/src/components/player/PlayerBookSpread.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 
+import { observeElementResize } from '@/lib/browser-apis'
 import { bookSpreadLayout } from '@/lib/chord-a4-scale'
 
 type PlayerBookSpreadProps = {
@@ -20,10 +21,8 @@ export function PlayerBookSpread({ left, right }: PlayerBookSpreadProps) {
       setViewportSize({ width: rect.width, height: rect.height })
     }
 
-    const observer = new ResizeObserver(updateSize)
-    observer.observe(el)
     updateSize()
-    return () => observer.disconnect()
+    return observeElementResize(el, updateSize)
   }, [])
 
   const hasTwoPages = right != null

--- a/frontend/app/src/components/player/av/AvSlideScaledStage.tsx
+++ b/frontend/app/src/components/player/av/AvSlideScaledStage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 
+import { observeElementResize } from '@/lib/browser-apis'
 import {
   AV_SLIDE_DESIGN_HEIGHT_PX,
   AV_SLIDE_DESIGN_WIDTH_PX,
@@ -23,10 +24,8 @@ export function AvSlideScaledStage({ children }: AvSlideScaledStageProps) {
       setViewportSize({ width: rect.width, height: rect.height })
     }
 
-    const observer = new ResizeObserver(updateSize)
-    observer.observe(el)
     updateSize()
-    return () => observer.disconnect()
+    return observeElementResize(el, updateSize)
   }, [])
 
   const scale = avSlideScaleToFitViewport(viewportSize.width, viewportSize.height)

--- a/frontend/app/src/components/player/av/AvSlidesPanel.tsx
+++ b/frontend/app/src/components/player/av/AvSlidesPanel.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { AvBackgroundSelector } from '@/components/player/av/AvBackgroundSelector'
 import { AvSlideView } from '@/components/player/av/AvSlideView'
+import { observeElementResize } from '@/lib/browser-apis'
 import type {
   AvBackgroundLayer,
   AvBackgroundPreset,
@@ -39,11 +40,9 @@ function useSlidePanelMultiColumn(): [RefObject<HTMLDivElement | null>, boolean]
     }
 
     update(el.getBoundingClientRect().width)
-    const observer = new ResizeObserver(([entry]) => {
-      update(entry.contentRect.width)
+    return observeElementResize(el, ([entry]) => {
+      update(entry?.contentRect.width ?? el.getBoundingClientRect().width)
     })
-    observer.observe(el)
-    return () => observer.disconnect()
   }, [])
 
   return [ref, multiColumn]

--- a/frontend/app/src/components/sessions/SessionsListView.tsx
+++ b/frontend/app/src/components/sessions/SessionsListView.tsx
@@ -22,6 +22,7 @@ import { useHubSearch } from '@/hooks/useHubSearch'
 import { useOnline } from '@/hooks/use-online'
 import { useSessionsList } from '@/hooks/useSessionsList'
 import { useSessionsMetrics } from '@/hooks/useSessionsMetrics'
+import { observeElementIntersection } from '@/lib/browser-apis'
 import { readSsoSessionIdFromDocumentCookie } from '@/lib/sso-session-cookie'
 import { sessionMetricsKey, sessionsListRootKey } from '@/lib/teams-sessions-keys'
 import { cn } from '@/lib/utils'
@@ -89,7 +90,8 @@ export function SessionsListView() {
     const root = scrollRef.current
     const sentinel = sentinelRef.current
     if (!root || !sentinel) return
-    const obs = new IntersectionObserver(
+    return observeElementIntersection(
+      sentinel,
       (entries) => {
         if (entries[0]?.isIntersecting && hasNextPage && !isFetchingNextPage) {
           void fetchNextPage()
@@ -97,8 +99,6 @@ export function SessionsListView() {
       },
       { root, rootMargin: '120px' },
     )
-    obs.observe(sentinel)
-    return () => obs.disconnect()
   }, [hasNextPage, isFetchingNextPage, fetchNextPage, items.length, scrollRef])
 
   const showSkeleton = isPending && !data

--- a/frontend/app/src/components/setlists/CreateSetlistDialog.tsx
+++ b/frontend/app/src/components/setlists/CreateSetlistDialog.tsx
@@ -19,6 +19,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { useSession } from '@/hooks/useSession'
+import { getLocalStorage, safeGetItem, safeSetItem } from '@/lib/browser-storage'
 import { hubListRootKey } from '@/lib/hub-list-keys'
 import { teamsListRootKey } from '@/lib/teams-sessions-keys'
 import { getNextPageIndex } from '@/lib/list-pagination'
@@ -29,20 +30,12 @@ import { cn } from '@/lib/utils'
 const LAST_OWNER_LS = 'wv.setlistCreate.lastOwnerTeamId'
 
 function readLastOwnerFromLs(): string | null {
-  try {
-    const raw = globalThis.localStorage?.getItem(LAST_OWNER_LS)
-    return raw && raw.trim() ? raw.trim() : null
-  } catch {
-    return null
-  }
+  const raw = safeGetItem(LAST_OWNER_LS, getLocalStorage())
+  return raw && raw.trim() ? raw.trim() : null
 }
 
 function writeLastOwnerToLs(teamId: string) {
-  try {
-    globalThis.localStorage?.setItem(LAST_OWNER_LS, teamId)
-  } catch {
-    /* ignore */
-  }
+  safeSetItem(LAST_OWNER_LS, teamId, getLocalStorage())
 }
 
 type CreateSetlistDialogProps = {

--- a/frontend/app/src/components/songs/SongEditorPreview.tsx
+++ b/frontend/app/src/components/songs/SongEditorPreview.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
 import { useChordFormatPreference } from '@/hooks/useChordFormatPreference'
+import { observeElementResize } from '@/lib/browser-apis'
 import { scopeChordlibPageCss } from '@/lib/chord-page-css'
 import { cssScaleToViewportWidth } from '@/lib/chord-a4-scale'
 import { chordFormatToRepresentation } from '@/lib/chord-format'
@@ -79,10 +80,8 @@ export function SongEditorPreview({
       const rect = el.getBoundingClientRect()
       setViewportSize({ width: rect.width, height: rect.height })
     }
-    const observer = new ResizeObserver(() => updateSize())
-    observer.observe(el)
     updateSize()
-    return () => observer.disconnect()
+    return observeElementResize(el, () => updateSize())
   }, [])
 
   const retry = useCallback(() => {
@@ -131,9 +130,7 @@ export function SongEditorPreview({
     }
 
     measure()
-    const observer = new ResizeObserver(measure)
-    observer.observe(el)
-    return () => observer.disconnect()
+    return observeElementResize(el, measure)
   }, [activeRenderKey, renderState])
 
   const scaledReady = renderState.status === 'ready' && cssScale != null

--- a/frontend/app/src/components/teams/TeamDetailView.tsx
+++ b/frontend/app/src/components/teams/TeamDetailView.tsx
@@ -34,6 +34,7 @@ import { getTeamDisplayName, isPersonalTeamName } from '@/lib/team-display-name'
 import { buildTeamInviteLink, resolveTeamInviteLink } from '@/lib/team-invite-link'
 import { isUserTeamAdmin } from '@/lib/team-permissions'
 import { teamDetailKey, teamInvitationsKey, teamsListRootKey } from '@/lib/teams-sessions-keys'
+import { observeElementIntersection } from '@/lib/browser-apis'
 import { cn } from '@/lib/utils'
 import { useHubScrollContainerRef } from '@/context/HubScrollContainerContext'
 import { useOnline } from '@/hooks/use-online'
@@ -170,7 +171,8 @@ export function TeamDetailView({ teamId, onRequestClose }: TeamDetailViewProps) 
     const root = scrollRef.current
     const el = invSentinelRef.current
     if (!root || !el || !team) return
-    const obs = new IntersectionObserver(
+    return observeElementIntersection(
+      el,
       (entries) => {
         if (entries[0]?.isIntersecting && invHasNext && !invFetchNext) {
           void invFetchNextPage()
@@ -178,8 +180,6 @@ export function TeamDetailView({ teamId, onRequestClose }: TeamDetailViewProps) 
       },
       { root, rootMargin: '120px' },
     )
-    obs.observe(el)
-    return () => obs.disconnect()
   }, [invHasNext, invFetchNext, invFetchNextPage, invitations.length, team, scrollRef])
 
   const createInvite = useMutation({

--- a/frontend/app/src/components/teams/TeamsListView.tsx
+++ b/frontend/app/src/components/teams/TeamsListView.tsx
@@ -12,6 +12,7 @@ import { useCoverImageSrc } from '@/hooks/useCoverImageSrc'
 import { useSession } from '@/hooks/useSession'
 import { useTeamsList } from '@/hooks/useTeamsList'
 import { useOnline } from '@/hooks/use-online'
+import { observeElementIntersection } from '@/lib/browser-apis'
 import { getTeamDisplayName } from '@/lib/team-display-name'
 import {
   HUB_LIST_AVATAR_CLASS,
@@ -81,7 +82,8 @@ export function TeamsListView({ createIntent, onConsumeCreateIntent }: TeamsList
     const root = scrollRef.current
     const sentinel = sentinelRef.current
     if (!root || !sentinel) return
-    const obs = new IntersectionObserver(
+    return observeElementIntersection(
+      sentinel,
       (entries) => {
         if (entries[0]?.isIntersecting && hasNextPage && !isFetchingNextPage) {
           void fetchNextPage()
@@ -89,8 +91,6 @@ export function TeamsListView({ createIntent, onConsumeCreateIntent }: TeamsList
       },
       { root, rootMargin: '120px' },
     )
-    obs.observe(sentinel)
-    return () => obs.disconnect()
   }, [hasNextPage, isFetchingNextPage, fetchNextPage, items.length, scrollRef])
 
   const openTeam = useCallback(

--- a/frontend/app/src/hooks/useEnsureTargetCollection.ts
+++ b/frontend/app/src/hooks/useEnsureTargetCollection.ts
@@ -5,6 +5,7 @@ import { api } from '@/api/client'
 import type { components } from '@/api/schema'
 import { fetchCollectionsPage } from '@/api/list-fetch'
 import { parseProblemResponse } from '@/api/problem'
+import { getLocalStorage, safeGetItem, safeSetItem } from '@/lib/browser-storage'
 import { hubListKey } from '@/lib/hub-list-keys'
 import { getNextPageIndex } from '@/lib/list-pagination'
 import { isPersonalTeamName } from '@/lib/team-display-name'
@@ -16,20 +17,12 @@ type Collection = components['schemas']['Collection']
 const LAST_COLLECTION_LS = 'wv.songCreate.lastCollectionId'
 
 function readLastCollectionFromLs(): string | null {
-  try {
-    const raw = globalThis.localStorage?.getItem(LAST_COLLECTION_LS)
-    return raw && raw.trim() ? raw.trim() : null
-  } catch {
-    return null
-  }
+  const raw = safeGetItem(LAST_COLLECTION_LS, getLocalStorage())
+  return raw && raw.trim() ? raw.trim() : null
 }
 
 export function writeLastCollectionToLs(collectionId: string) {
-  try {
-    globalThis.localStorage?.setItem(LAST_COLLECTION_LS, collectionId)
-  } catch {
-    /* ignore */
-  }
+  safeSetItem(LAST_COLLECTION_LS, collectionId, getLocalStorage())
 }
 
 export type UseEnsureTargetCollectionOptions = {

--- a/frontend/app/src/hooks/useMediaQuery.test.tsx
+++ b/frontend/app/src/hooks/useMediaQuery.test.tsx
@@ -42,4 +42,31 @@ describe('useMediaQuery viewport reflow', () => {
     const { result } = renderHook(() => useMediaQuery('(orientation: landscape)'))
     expect(result.current).toBe(true)
   })
+
+  it('falls back to Safari-style addListener and removeListener', () => {
+    let listener: (() => void) | null = null
+    const mq = {
+      matches: false,
+      media: '(min-width: 768px)',
+      addListener: vi.fn((fn: () => void) => {
+        listener = fn
+      }),
+      removeListener: vi.fn(),
+    }
+
+    vi.stubGlobal('matchMedia', () => mq)
+
+    const { result, unmount } = renderHook(() => useMediaQuery('(min-width: 768px)'))
+    expect(result.current).toBe(false)
+    expect(mq.addListener).toHaveBeenCalled()
+
+    mq.matches = true
+    act(() => {
+      listener?.()
+    })
+    expect(result.current).toBe(true)
+
+    unmount()
+    expect(mq.removeListener).toHaveBeenCalled()
+  })
 })

--- a/frontend/app/src/hooks/useMediaQuery.ts
+++ b/frontend/app/src/hooks/useMediaQuery.ts
@@ -1,17 +1,21 @@
 import { useEffect, useState } from 'react'
 
+import { listenToMediaQuery } from '@/lib/browser-apis'
+
 export function useMediaQuery(query: string): boolean {
   const [matches, setMatches] = useState(() => {
-    if (typeof globalThis.window === 'undefined') return false
+    if (typeof globalThis.window === 'undefined' || typeof globalThis.window.matchMedia !== 'function') {
+      return false
+    }
     return globalThis.window.matchMedia(query).matches
   })
 
   useEffect(() => {
+    if (typeof globalThis.window.matchMedia !== 'function') return
     const mq = globalThis.window.matchMedia(query)
     const onChange = () => setMatches(mq.matches)
     onChange()
-    mq.addEventListener('change', onChange)
-    return () => mq.removeEventListener('change', onChange)
+    return listenToMediaQuery(mq, onChange)
   }, [query])
 
   return matches

--- a/frontend/app/src/i18n/index.ts
+++ b/frontend/app/src/i18n/index.ts
@@ -10,6 +10,7 @@ import {
   ensureBrowserLocaleStorage,
   resolveInitialLocale,
 } from '@/lib/locale'
+import { getLocalStorage, safeGetItem } from '@/lib/browser-storage'
 
 export function initI18n(): void {
   if (typeof globalThis.window === 'undefined') return
@@ -17,12 +18,15 @@ export function initI18n(): void {
   ensureBrowserLocaleStorage()
 
   const params = new URLSearchParams(globalThis.window.location.search)
-  const stored = globalThis.localStorage.getItem(LOCALE_STORAGE_KEY)
-  const browserFlag = globalThis.localStorage.getItem(BROWSER_LOCALE_FLAG_KEY)
+  const storage = getLocalStorage()
+  const stored = safeGetItem(LOCALE_STORAGE_KEY, storage)
+  const browserFlag = safeGetItem(BROWSER_LOCALE_FLAG_KEY, storage)
+  const languages =
+    typeof globalThis.navigator === 'undefined' ? [] : globalThis.navigator.languages
   const lng: AppLocale = resolveInitialLocale(
     params,
     stored,
-    globalThis.navigator.languages,
+    languages,
     browserFlag,
   )
 

--- a/frontend/app/src/lib/appearance.test.ts
+++ b/frontend/app/src/lib/appearance.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   APPEARANCE_STORAGE_KEY,
   applyAppearancePreference,
+  readAppearancePreference,
   resolveAppearancePreference,
   writeAppearancePreference,
 } from '@/lib/appearance'
@@ -57,5 +58,31 @@ describe('writeAppearancePreference', () => {
 
     writeAppearancePreference('system', storage)
     expect(storage.removeItem).toHaveBeenCalledWith(APPEARANCE_STORAGE_KEY)
+  })
+})
+
+describe('appearance storage safety', () => {
+  it('falls back to system when storage reads throw', () => {
+    const storage = {
+      getItem: vi.fn(() => {
+        throw new DOMException('blocked', 'SecurityError')
+      }),
+    }
+
+    expect(readAppearancePreference(storage)).toBe('system')
+  })
+
+  it('ignores storage write failures', () => {
+    const storage = {
+      setItem: vi.fn(() => {
+        throw new DOMException('full', 'QuotaExceededError')
+      }),
+      removeItem: vi.fn(() => {
+        throw new DOMException('blocked', 'SecurityError')
+      }),
+    }
+
+    expect(() => writeAppearancePreference('dark', storage)).not.toThrow()
+    expect(() => writeAppearancePreference('system', storage)).not.toThrow()
   })
 })

--- a/frontend/app/src/lib/appearance.ts
+++ b/frontend/app/src/lib/appearance.ts
@@ -1,3 +1,5 @@
+import { getLocalStorage, safeGetItem, safeRemoveItem, safeSetItem } from '@/lib/browser-storage'
+
 export const APPEARANCE_STORAGE_KEY = 'wv_appearance'
 
 export type AppearancePreference = 'system' | 'light' | 'dark'
@@ -20,21 +22,21 @@ export function applyAppearancePreference(
 }
 
 export function readAppearancePreference(
-  storage: Pick<Storage, 'getItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem'> | null = getLocalStorage(),
 ): AppearancePreference {
-  return resolveAppearancePreference(storage.getItem(APPEARANCE_STORAGE_KEY))
+  return resolveAppearancePreference(safeGetItem(APPEARANCE_STORAGE_KEY, storage))
 }
 
 export function writeAppearancePreference(
   preference: AppearancePreference,
-  storage: Pick<Storage, 'setItem' | 'removeItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'setItem' | 'removeItem'> | null = getLocalStorage(),
 ): void {
   if (preference === 'system') {
-    storage.removeItem(APPEARANCE_STORAGE_KEY)
+    safeRemoveItem(APPEARANCE_STORAGE_KEY, storage)
     return
   }
 
-  storage.setItem(APPEARANCE_STORAGE_KEY, preference)
+  safeSetItem(APPEARANCE_STORAGE_KEY, preference, storage)
 }
 
 export function initAppearance(): void {

--- a/frontend/app/src/lib/browser-apis.ts
+++ b/frontend/app/src/lib/browser-apis.ts
@@ -1,0 +1,49 @@
+export function listenToMediaQuery(
+  mediaQuery: MediaQueryList,
+  listener: () => void,
+): () => void {
+  if (typeof mediaQuery.addEventListener === 'function') {
+    mediaQuery.addEventListener('change', listener)
+    return () => mediaQuery.removeEventListener('change', listener)
+  }
+
+  mediaQuery.addListener(listener)
+  return () => mediaQuery.removeListener(listener)
+}
+
+export function observeElementResize(
+  element: Element,
+  listener: ResizeObserverCallback,
+): () => void {
+  if (typeof globalThis.ResizeObserver !== 'function') {
+    listener([], {} as ResizeObserver)
+    return () => {}
+  }
+
+  const observer = new ResizeObserver(listener)
+  observer.observe(element)
+  return () => observer.disconnect()
+}
+
+export function observeElementIntersection(
+  element: Element,
+  listener: IntersectionObserverCallback,
+  options?: IntersectionObserverInit,
+): () => void {
+  if (typeof globalThis.IntersectionObserver !== 'function') {
+    listener(
+      [
+        {
+          isIntersecting: true,
+          target: element,
+        } as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    return () => {}
+  }
+
+  const observer = new IntersectionObserver(listener, options)
+  observer.observe(element)
+  return () => observer.disconnect()
+}

--- a/frontend/app/src/lib/browser-storage.test.ts
+++ b/frontend/app/src/lib/browser-storage.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  getLocalStorage,
+  getLocalStorageOrFallback,
+  safeGetItem,
+  safeRemoveItem,
+  safeSetItem,
+} from '@/lib/browser-storage'
+
+describe('browser storage safety', () => {
+  const originalLocalStorage = Object.getOwnPropertyDescriptor(globalThis, 'localStorage')
+
+  afterEach(() => {
+    if (originalLocalStorage) {
+      Object.defineProperty(globalThis, 'localStorage', originalLocalStorage)
+    }
+  })
+
+  it('returns null when localStorage access throws', () => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      get: () => {
+        throw new DOMException('blocked', 'SecurityError')
+      },
+    })
+
+    expect(getLocalStorage()).toBeNull()
+    expect(getLocalStorageOrFallback().getItem('x')).toBeNull()
+  })
+
+  it('catches getItem, setItem, and removeItem failures', () => {
+    const storage = {
+      getItem: vi.fn(() => {
+        throw new DOMException('blocked', 'SecurityError')
+      }),
+      setItem: vi.fn(() => {
+        throw new DOMException('full', 'QuotaExceededError')
+      }),
+      removeItem: vi.fn(() => {
+        throw new DOMException('blocked', 'SecurityError')
+      }),
+    }
+
+    expect(safeGetItem('x', storage)).toBeNull()
+    expect(safeSetItem('x', '1', storage)).toBe(false)
+    expect(safeRemoveItem('x', storage)).toBe(false)
+  })
+})

--- a/frontend/app/src/lib/browser-storage.ts
+++ b/frontend/app/src/lib/browser-storage.ts
@@ -1,0 +1,68 @@
+export type BrowserStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
+
+const noopStorage: BrowserStorage = {
+  getItem: () => null,
+  setItem: () => {},
+  removeItem: () => {},
+}
+
+export function getLocalStorage(): BrowserStorage | null {
+  try {
+    return typeof globalThis.localStorage === 'undefined' ? null : globalThis.localStorage
+  } catch {
+    return null
+  }
+}
+
+export function getLocalStorageOrFallback(): BrowserStorage {
+  const storage = getLocalStorage()
+  if (!storage) return noopStorage
+  return {
+    getItem: (key) => safeGetItem(key, storage),
+    setItem: (key, value) => {
+      safeSetItem(key, value, storage)
+    },
+    removeItem: (key) => {
+      safeRemoveItem(key, storage)
+    },
+  }
+}
+
+export function safeGetItem(
+  key: string,
+  storage: Pick<Storage, 'getItem'> | null = getLocalStorage(),
+): string | null {
+  if (!storage) return null
+  try {
+    return storage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+export function safeSetItem(
+  key: string,
+  value: string,
+  storage: Pick<Storage, 'setItem'> | null = getLocalStorage(),
+): boolean {
+  if (!storage) return false
+  try {
+    storage.setItem(key, value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function safeRemoveItem(
+  key: string,
+  storage: Pick<Storage, 'removeItem'> | null = getLocalStorage(),
+): boolean {
+  if (!storage) return false
+  try {
+    storage.removeItem(key)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/frontend/app/src/lib/chord-format.ts
+++ b/frontend/app/src/lib/chord-format.ts
@@ -1,3 +1,4 @@
+import { getLocalStorage, safeGetItem, safeSetItem } from '@/lib/browser-storage'
 import type { ChordRepresentation } from '@/ports/chord-engine'
 
 export const CHORD_FORMAT_STORAGE_KEY = 'wv_chord_format'
@@ -16,16 +17,16 @@ export function chordFormatToRepresentation(preference: ChordFormatPreference): 
 }
 
 export function readChordFormatPreference(
-  storage: Pick<Storage, 'getItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem'> | null = getLocalStorage(),
 ): ChordFormatPreference {
-  return resolveChordFormatPreference(storage.getItem(CHORD_FORMAT_STORAGE_KEY))
+  return resolveChordFormatPreference(safeGetItem(CHORD_FORMAT_STORAGE_KEY, storage))
 }
 
 export function writeChordFormatPreference(
   preference: ChordFormatPreference,
-  storage: Pick<Storage, 'setItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'setItem'> | null = getLocalStorage(),
 ): void {
-  storage.setItem(CHORD_FORMAT_STORAGE_KEY, preference)
+  safeSetItem(CHORD_FORMAT_STORAGE_KEY, preference, storage)
   if (typeof globalThis.window !== 'undefined') {
     globalThis.window.dispatchEvent(new CustomEvent(CHORD_FORMAT_CHANGE_EVENT, { detail: preference }))
   }

--- a/frontend/app/src/lib/hide-chords-preference.ts
+++ b/frontend/app/src/lib/hide-chords-preference.ts
@@ -1,21 +1,23 @@
+import { getLocalStorage, safeGetItem, safeRemoveItem, safeSetItem } from '@/lib/browser-storage'
+
 export const HIDE_CHORDS_STORAGE_KEY = 'wv_hide_chords'
 
 export const HIDE_CHORDS_CHANGE_EVENT = 'wv-hide-chords-change'
 
 export function readHideChordsPreference(
-  storage: Pick<Storage, 'getItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem'> | null = getLocalStorage(),
 ): boolean {
-  return storage.getItem(HIDE_CHORDS_STORAGE_KEY) === 'true'
+  return safeGetItem(HIDE_CHORDS_STORAGE_KEY, storage) === 'true'
 }
 
 export function writeHideChordsPreference(
   enabled: boolean,
-  storage: Pick<Storage, 'setItem' | 'removeItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'setItem' | 'removeItem'> | null = getLocalStorage(),
 ): void {
   if (enabled) {
-    storage.setItem(HIDE_CHORDS_STORAGE_KEY, 'true')
+    safeSetItem(HIDE_CHORDS_STORAGE_KEY, 'true', storage)
   } else {
-    storage.removeItem(HIDE_CHORDS_STORAGE_KEY)
+    safeRemoveItem(HIDE_CHORDS_STORAGE_KEY, storage)
   }
 
   if (typeof globalThis.window !== 'undefined') {

--- a/frontend/app/src/lib/hub-view-mode.ts
+++ b/frontend/app/src/lib/hub-view-mode.ts
@@ -1,3 +1,4 @@
+import { getLocalStorage, safeGetItem, safeSetItem } from '@/lib/browser-storage'
 import type { HubEntity } from '@/lib/hub-entity'
 
 export type HubLayoutMode = 'list' | 'card'
@@ -30,20 +31,16 @@ export function resolveCollectionsLayoutMode(
 }
 
 export function readCollectionsViewMode(
-  storage: Pick<Storage, 'getItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem'> | null = getLocalStorage(),
 ): HubViewMode {
-  try {
-    const raw = storage.getItem(COLLECTIONS_VIEW_MODE_KEY)
-    if (isHubViewMode(raw)) return raw
-  } catch {
-    /* ignore */
-  }
+  const raw = safeGetItem(COLLECTIONS_VIEW_MODE_KEY, storage)
+  if (isHubViewMode(raw)) return raw
   return 'list'
 }
 
 export function readHubViewMode(
   entity: HubEntity,
-  storage: Pick<Storage, 'getItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem'> | null = getLocalStorage(),
 ): HubViewMode {
   if (entity !== 'collections') return 'list'
   return readCollectionsViewMode(storage)
@@ -61,20 +58,16 @@ function dispatchCollectionsViewModeChange(mode: HubViewMode): void {
 
 export function writeCollectionsViewMode(
   mode: HubViewMode,
-  storage: Pick<Storage, 'setItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'setItem'> | null = getLocalStorage(),
 ): void {
-  try {
-    storage.setItem(COLLECTIONS_VIEW_MODE_KEY, mode)
-  } catch {
-    /* ignore */
-  }
+  safeSetItem(COLLECTIONS_VIEW_MODE_KEY, mode, storage)
   dispatchCollectionsViewModeChange(mode)
 }
 
 export function writeHubViewMode(
   entity: HubEntity,
   mode: HubViewMode,
-  storage: Pick<Storage, 'setItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'setItem'> | null = getLocalStorage(),
 ): void {
   if (entity !== 'collections') return
   writeCollectionsViewMode(mode, storage)

--- a/frontend/app/src/lib/locale.test.ts
+++ b/frontend/app/src/lib/locale.test.ts
@@ -105,4 +105,29 @@ describe('locale preference storage', () => {
     expect(storage.has(LOCALE_STORAGE_KEY)).toBe(false)
     expect(readLocalePreference(mockStorage)).toBe('browser')
   })
+
+  it('falls back to browser preference when storage reads throw', () => {
+    const storage = {
+      getItem: () => {
+        throw new DOMException('blocked', 'SecurityError')
+      },
+    }
+
+    expect(readLocalePreference(storage)).toBe('browser')
+  })
+
+  it('ignores storage write failures', () => {
+    const storage = {
+      getItem: () => null,
+      setItem: () => {
+        throw new DOMException('full', 'QuotaExceededError')
+      },
+      removeItem: () => {
+        throw new DOMException('blocked', 'SecurityError')
+      },
+    }
+
+    expect(() => ensureBrowserLocaleStorage(storage)).not.toThrow()
+    expect(() => writeExplicitLocalePreference('de', storage)).not.toThrow()
+  })
 })

--- a/frontend/app/src/lib/locale.ts
+++ b/frontend/app/src/lib/locale.ts
@@ -1,3 +1,5 @@
+import { getLocalStorage, safeGetItem, safeRemoveItem, safeSetItem } from '@/lib/browser-storage'
+
 /** Persisted store key — align with i18next / future Settings (E4). */
 export const LOCALE_STORAGE_KEY = 'i18nextLng'
 export const BROWSER_LOCALE_FLAG_KEY = 'wv_use_browser_locale'
@@ -30,32 +32,32 @@ export function resolveLocalePreference(
 }
 
 export function readLocalePreference(
-  storage: Pick<Storage, 'getItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem'> | null = getLocalStorage(),
 ): LocalePreference {
   return resolveLocalePreference(
-    storage.getItem(LOCALE_STORAGE_KEY),
-    storage.getItem(BROWSER_LOCALE_FLAG_KEY),
+    safeGetItem(LOCALE_STORAGE_KEY, storage),
+    safeGetItem(BROWSER_LOCALE_FLAG_KEY, storage),
   )
 }
 
 /** Browser default: follow navigator languages; do not persist an explicit locale. */
 export function writeBrowserLocalePreference(
-  storage: Pick<Storage, 'setItem' | 'removeItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'setItem' | 'removeItem'> | null = getLocalStorage(),
 ): void {
-  storage.setItem(BROWSER_LOCALE_FLAG_KEY, '1')
-  storage.removeItem(LOCALE_STORAGE_KEY)
+  safeSetItem(BROWSER_LOCALE_FLAG_KEY, '1', storage)
+  safeRemoveItem(LOCALE_STORAGE_KEY, storage)
 }
 
 export function writeExplicitLocalePreference(
   locale: AppLocale,
-  storage: Pick<Storage, 'setItem' | 'removeItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'setItem' | 'removeItem'> | null = getLocalStorage(),
 ): void {
-  storage.removeItem(BROWSER_LOCALE_FLAG_KEY)
-  storage.setItem(LOCALE_STORAGE_KEY, locale)
+  safeRemoveItem(BROWSER_LOCALE_FLAG_KEY, storage)
+  safeSetItem(LOCALE_STORAGE_KEY, locale, storage)
 }
 
 export function ensureBrowserLocaleStorage(
-  storage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> | null = getLocalStorage(),
 ): void {
   if (readLocalePreference(storage) === 'browser') {
     writeBrowserLocalePreference(storage)

--- a/frontend/app/src/lib/logout-queue.test.ts
+++ b/frontend/app/src/lib/logout-queue.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/api/client', () => ({
+  api: {
+    POST: vi.fn(async () => ({ response: { ok: true, status: 204 } })),
+  },
+}))
+
+vi.mock('@/lib/clear-local', () => ({
+  clearAllLocalData: vi.fn(async () => {}),
+}))
+
+import { initLogoutQueue, performLogout } from '@/lib/logout-queue'
+
+describe('logout queue storage safety', () => {
+  const originalLocalStorage = Object.getOwnPropertyDescriptor(globalThis, 'localStorage')
+  const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
+
+  afterEach(() => {
+    if (originalLocalStorage) {
+      Object.defineProperty(globalThis, 'localStorage', originalLocalStorage)
+    }
+    if (originalNavigator) {
+      Object.defineProperty(globalThis, 'navigator', originalNavigator)
+    }
+  })
+
+  it('does not throw when startup storage access is blocked', () => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      get: () => {
+        throw new DOMException('blocked', 'SecurityError')
+      },
+    })
+
+    expect(() => initLogoutQueue()).not.toThrow()
+  })
+
+  it('does not throw when offline queue writes are blocked', async () => {
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: { onLine: false },
+    })
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      get: () => {
+        throw new DOMException('blocked', 'SecurityError')
+      },
+    })
+
+    await expect(performLogout({} as never)).resolves.toBeUndefined()
+  })
+})

--- a/frontend/app/src/lib/logout-queue.ts
+++ b/frontend/app/src/lib/logout-queue.ts
@@ -4,41 +4,43 @@
 import type { QueryClient } from '@tanstack/react-query'
 
 import { api } from '@/api/client'
+import { getLocalStorage, safeGetItem, safeRemoveItem, safeSetItem } from '@/lib/browser-storage'
 import { clearAllLocalData } from '@/lib/clear-local'
 
 const STORAGE_KEY = 'wv_pending_server_logout'
 
 function hasPending(): boolean {
-  return globalThis.localStorage?.getItem(STORAGE_KEY) === '1'
+  return safeGetItem(STORAGE_KEY, getLocalStorage()) === '1'
 }
 
 function setPending(on: boolean): void {
-  if (on) globalThis.localStorage?.setItem(STORAGE_KEY, '1')
-  else globalThis.localStorage?.removeItem(STORAGE_KEY)
+  if (on) safeSetItem(STORAGE_KEY, '1', getLocalStorage())
+  else safeRemoveItem(STORAGE_KEY, getLocalStorage())
 }
 
 async function tryServerLogout(): Promise<boolean> {
-  if (!globalThis.navigator.onLine) return false
+  if (typeof globalThis.navigator !== 'undefined' && !globalThis.navigator.onLine) return false
   const { response } = await api.POST('/auth/logout', {})
   return response.ok || response.status === 204 || response.status === 401
 }
 
 export function initLogoutQueue(): void {
   const flush = async () => {
-    if (!hasPending() || !globalThis.navigator.onLine) return
+    if (!hasPending()) return
+    if (typeof globalThis.navigator !== 'undefined' && !globalThis.navigator.onLine) return
     const ok = await tryServerLogout()
     if (ok) setPending(false)
   }
 
   void flush()
-  globalThis.addEventListener('online', () => {
+  globalThis.addEventListener?.('online', () => {
     void flush()
   })
 }
 
 /** Call when user chooses logout: POST if online, else mark pending for flush when back online. */
 export async function performLogout(queryClient: QueryClient): Promise<void> {
-  if (globalThis.navigator.onLine) {
+  if (typeof globalThis.navigator === 'undefined' || globalThis.navigator.onLine) {
     await api.POST('/auth/logout', {})
     setPending(false)
   } else {

--- a/frontend/app/src/lib/lyric-whitespace-preference.ts
+++ b/frontend/app/src/lib/lyric-whitespace-preference.ts
@@ -1,3 +1,5 @@
+import { getLocalStorage, safeGetItem, safeSetItem } from '@/lib/browser-storage'
+
 export const LYRIC_COLLAPSE_WHITESPACE_STORAGE_KEY = 'wv_lyric_collapse_whitespace'
 
 export function normalizeLyricWhitespace(text: string): string {
@@ -5,16 +7,16 @@ export function normalizeLyricWhitespace(text: string): string {
 }
 
 export function readLyricCollapseWhitespacePreference(
-  storage: Pick<Storage, 'getItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem'> | null = getLocalStorage(),
 ): boolean {
-  const raw = storage.getItem(LYRIC_COLLAPSE_WHITESPACE_STORAGE_KEY)
+  const raw = safeGetItem(LYRIC_COLLAPSE_WHITESPACE_STORAGE_KEY, storage)
   if (raw === 'false') return false
   return true
 }
 
 export function writeLyricCollapseWhitespacePreference(
   enabled: boolean,
-  storage: Pick<Storage, 'setItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'setItem'> | null = getLocalStorage(),
 ): void {
-  storage.setItem(LYRIC_COLLAPSE_WHITESPACE_STORAGE_KEY, enabled ? 'true' : 'false')
+  safeSetItem(LYRIC_COLLAPSE_WHITESPACE_STORAGE_KEY, enabled ? 'true' : 'false', storage)
 }

--- a/frontend/app/src/lib/player-scroll-preference.ts
+++ b/frontend/app/src/lib/player-scroll-preference.ts
@@ -1,5 +1,6 @@
 import type { components } from '@/api/schema'
 
+import { getLocalStorageOrFallback } from '@/lib/browser-storage'
 import {
   DEFAULT_PLAYER_LAYOUT_PREFERENCE,
   layoutPreferenceToScrollType,
@@ -97,7 +98,7 @@ function readLinkedOrientations(
 }
 
 export function readPlayerLayoutPreferences(
-  storage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> = getLocalStorageOrFallback(),
 ): PlayerLayoutPreferences {
   const portrait = readLayoutForOrientation('portrait', storage)
   const linkedOrientations = readLinkedOrientations(storage)
@@ -109,7 +110,7 @@ export function readPlayerLayoutPreferences(
 
 /** @deprecated Use readPlayerLayoutPreferences */
 export function readPlayerScrollPreferences(
-  storage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> = getLocalStorageOrFallback(),
 ): PlayerScrollPreferences {
   const layout = readPlayerLayoutPreferences(storage)
   return {
@@ -128,7 +129,7 @@ function dispatchLayoutChange(preferences: PlayerLayoutPreferences): void {
 
 export function writePlayerLayoutLinkedOrientations(
   linked: boolean,
-  storage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> = getLocalStorageOrFallback(),
 ): void {
   storage.setItem(PLAYER_LAYOUT_LINKED_KEY, linked ? 'true' : 'false')
   if (linked) {
@@ -140,7 +141,7 @@ export function writePlayerLayoutLinkedOrientations(
 
 export function writePlayerLayoutPortrait(
   preference: PlayerLayoutPreference,
-  storage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> = getLocalStorageOrFallback(),
 ): void {
   const normalized = normalizeLayoutPreference(preference)
   storage.setItem(PLAYER_LAYOUT_PORTRAIT_KEY, JSON.stringify(normalized))
@@ -152,7 +153,7 @@ export function writePlayerLayoutPortrait(
 
 export function writePlayerLayoutLandscape(
   preference: PlayerLayoutPreference,
-  storage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> = getLocalStorageOrFallback(),
 ): void {
   storage.setItem(
     PLAYER_LAYOUT_LANDSCAPE_KEY,
@@ -164,7 +165,7 @@ export function writePlayerLayoutLandscape(
 /** Update the shared layout when orientations are linked, or portrait only otherwise. */
 export function writePlayerLayoutUnified(
   preference: PlayerLayoutPreference,
-  storage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> = getLocalStorageOrFallback(),
 ): void {
   writePlayerLayoutPortrait(preference, storage)
 }
@@ -172,7 +173,7 @@ export function writePlayerLayoutUnified(
 /** @deprecated Use writePlayerLayoutPortrait */
 export function writePlayerScrollPortrait(
   scrollType: PlayerScrollType,
-  storage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> = getLocalStorageOrFallback(),
 ): void {
   writePlayerLayoutPortrait(scrollTypeToLayoutPreference(scrollType), storage)
 }
@@ -180,7 +181,7 @@ export function writePlayerScrollPortrait(
 /** @deprecated Use writePlayerLayoutLandscape */
 export function writePlayerScrollLandscape(
   scrollType: PlayerScrollType,
-  storage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> = getLocalStorageOrFallback(),
 ): void {
   writePlayerLayoutLandscape(scrollTypeToLayoutPreference(scrollType), storage)
 }

--- a/frontend/app/src/lib/player/av-preferences.ts
+++ b/frontend/app/src/lib/player/av-preferences.ts
@@ -1,3 +1,4 @@
+import { getLocalStorage, safeGetItem, safeSetItem } from '@/lib/browser-storage'
 import type { PlayerMode } from '@/lib/player/player-mode'
 
 export type AvTextAlign = 'left' | 'center' | 'right'
@@ -151,10 +152,10 @@ function mergeProjection(raw: Partial<AvProjectionPrefs> | undefined): AvProject
 }
 
 export function readAvPreferences(
-  storage: Pick<Storage, 'getItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem'> | null = getLocalStorage(),
 ): AvPreferences {
   try {
-    const raw = storage.getItem(AV_PREFERENCES_STORAGE_KEY)
+    const raw = safeGetItem(AV_PREFERENCES_STORAGE_KEY, storage)
     if (!raw) return DEFAULT_AV_PREFERENCES
     const parsed = JSON.parse(raw) as Partial<AvPreferences>
     return {
@@ -170,9 +171,9 @@ export function readAvPreferences(
 
 export function writeAvPreferences(
   prefs: AvPreferences,
-  storage: Pick<Storage, 'setItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'setItem'> | null = getLocalStorage(),
 ): void {
-  storage.setItem(AV_PREFERENCES_STORAGE_KEY, JSON.stringify(prefs))
+  safeSetItem(AV_PREFERENCES_STORAGE_KEY, JSON.stringify(prefs), storage)
 }
 
 export function effectiveAvTransition(

--- a/frontend/app/src/lib/player/av-projection-sync.ts
+++ b/frontend/app/src/lib/player/av-projection-sync.ts
@@ -1,4 +1,5 @@
 import type { AvProjectionPayload } from '@/lib/player/av-preferences'
+import { getLocalStorage, safeGetItem, safeSetItem } from '@/lib/browser-storage'
 
 export const AV_PROJECTION_STORAGE_PREFIX = 'wvAvProjection:'
 
@@ -23,10 +24,10 @@ export type AvProjectionSync = {
 
 export function readAvProjectionSnapshot(
   sessionId: string,
-  storage: Pick<Storage, 'getItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem'> | null = getLocalStorage(),
 ): AvProjectionPayload | null {
   try {
-    const raw = storage.getItem(storageKey(sessionId))
+    const raw = safeGetItem(storageKey(sessionId), storage)
     if (!raw) return null
     return JSON.parse(raw) as AvProjectionPayload
   } catch {
@@ -37,14 +38,14 @@ export function readAvProjectionSnapshot(
 export function writeAvProjectionSnapshot(
   sessionId: string,
   payload: AvProjectionPayload,
-  storage: Pick<Storage, 'setItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'setItem'> | null = getLocalStorage(),
 ): void {
-  storage.setItem(storageKey(sessionId), JSON.stringify(payload))
+  safeSetItem(storageKey(sessionId), JSON.stringify(payload), storage)
 }
 
 export function createAvProjectionSync(
   sessionId: string,
-  storage: Pick<Storage, 'getItem' | 'setItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem' | 'setItem'> | null = getLocalStorage(),
 ): AvProjectionSync {
   let channel: BroadcastChannel | null = null
   let storageTimer: ReturnType<typeof setTimeout> | null = null
@@ -90,7 +91,7 @@ export type AvProjectionListener = {
 export function subscribeAvProjectionSync(
   sessionId: string,
   onPayload: (payload: AvProjectionPayload) => void,
-  storage: Pick<Storage, 'getItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem'> | null = getLocalStorage(),
 ): AvProjectionListener {
   const latest = readAvProjectionSnapshot(sessionId, storage)
   if (latest) onPayload(latest)

--- a/frontend/app/src/lib/player/av-session-state.ts
+++ b/frontend/app/src/lib/player/av-session-state.ts
@@ -1,3 +1,4 @@
+import { getLocalStorage, safeGetItem, safeSetItem } from '@/lib/browser-storage'
 import type { PlayerEntityType } from '@/lib/player-route'
 import type { AvScreenState } from '@/lib/player/av-preferences'
 import { parseOptionalPlayerIndex } from '@/lib/player/player-editor-return'
@@ -23,10 +24,10 @@ function parseScreenState(parsed: Partial<AvSessionState> & { blackout?: boolean
 export function readAvSessionState(
   type: PlayerEntityType,
   id: string,
-  storage: Pick<Storage, 'getItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem'> | null = getLocalStorage(),
 ): AvSessionState {
   try {
-    const raw = storage.getItem(avSessionStorageKey(type, id))
+    const raw = safeGetItem(avSessionStorageKey(type, id), storage)
     if (!raw) {
       return { itemIndex: 0, slideIndex: 0, screenState: 'live' }
     }
@@ -47,7 +48,7 @@ export function writeAvSessionState(
   type: PlayerEntityType,
   id: string,
   state: AvSessionState,
-  storage: Pick<Storage, 'setItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'setItem'> | null = getLocalStorage(),
 ): void {
-  storage.setItem(avSessionStorageKey(type, id), JSON.stringify(state))
+  safeSetItem(avSessionStorageKey(type, id), JSON.stringify(state), storage)
 }

--- a/frontend/app/src/lib/player/player-mode-preference.ts
+++ b/frontend/app/src/lib/player/player-mode-preference.ts
@@ -1,17 +1,18 @@
+import { getLocalStorage, safeGetItem, safeSetItem } from '@/lib/browser-storage'
 import type { PlayerMode } from '@/lib/player/player-mode'
 
 export const PLAYER_DEFAULT_MODE_STORAGE_KEY = 'playerDefaultMode'
 
 export function readPlayerDefaultMode(
-  storage: Pick<Storage, 'getItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem'> | null = getLocalStorage(),
 ): PlayerMode {
-  const raw = storage.getItem(PLAYER_DEFAULT_MODE_STORAGE_KEY)
+  const raw = safeGetItem(PLAYER_DEFAULT_MODE_STORAGE_KEY, storage)
   return raw === 'av' ? 'av' : 'normal'
 }
 
 export function writePlayerDefaultMode(
   mode: PlayerMode,
-  storage: Pick<Storage, 'setItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'setItem'> | null = getLocalStorage(),
 ): void {
-  storage.setItem(PLAYER_DEFAULT_MODE_STORAGE_KEY, mode)
+  safeSetItem(PLAYER_DEFAULT_MODE_STORAGE_KEY, mode, storage)
 }

--- a/frontend/app/src/lib/player/player-view-state.ts
+++ b/frontend/app/src/lib/player/player-view-state.ts
@@ -1,3 +1,4 @@
+import { getLocalStorage, safeGetItem, safeRemoveItem, safeSetItem } from '@/lib/browser-storage'
 import type { PlayerEntityType } from '@/lib/player-route'
 import { parseOptionalPlayerIndex } from '@/lib/player/player-editor-return'
 
@@ -15,10 +16,10 @@ export function playerViewStorageKey(type: PlayerEntityType, id: string): string
 export function readPlayerViewState(
   type: PlayerEntityType,
   id: string,
-  storage: Pick<Storage, 'getItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem'> | null = getLocalStorage(),
 ): PlayerViewState {
   try {
-    const raw = storage.getItem(playerViewStorageKey(type, id))
+    const raw = safeGetItem(playerViewStorageKey(type, id), storage)
     if (!raw) {
       return { transposeByItem: {} }
     }
@@ -39,17 +40,17 @@ export function writePlayerViewState(
   type: PlayerEntityType,
   id: string,
   state: PlayerViewState,
-  storage: Pick<Storage, 'setItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'setItem'> | null = getLocalStorage(),
 ): void {
-  storage.setItem(playerViewStorageKey(type, id), JSON.stringify(state))
+  safeSetItem(playerViewStorageKey(type, id), JSON.stringify(state), storage)
 }
 
 export function clearPlayerViewStateForResource(
   type: PlayerEntityType,
   id: string,
-  storage: Pick<Storage, 'removeItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'removeItem'> | null = getLocalStorage(),
 ): void {
-  storage.removeItem(playerViewStorageKey(type, id))
+  safeRemoveItem(playerViewStorageKey(type, id), storage)
 }
 
 export function setTransposeForItem(

--- a/frontend/app/src/lib/query-persistence.test.ts
+++ b/frontend/app/src/lib/query-persistence.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { kv } = vi.hoisted(() => ({
+  kv: {
+    get: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/dexie-db', () => ({
+  appDb: { kv },
+}))
+
+import {
+  createHubListsQueryPersister,
+  readHubListsUpdatedAt,
+} from '@/lib/query-persistence'
+
+describe('query persistence', () => {
+  beforeEach(() => {
+    kv.get.mockReset()
+    kv.put.mockReset()
+    kv.delete.mockReset()
+  })
+
+  it('returns null when Dexie reads reject', async () => {
+    kv.get.mockRejectedValue(new Error('indexeddb unavailable'))
+
+    await expect(readHubListsUpdatedAt()).resolves.toBeNull()
+  })
+
+  it('continues when Dexie writes and deletes reject', async () => {
+    kv.put.mockRejectedValue(new Error('indexeddb unavailable'))
+    kv.delete.mockRejectedValue(new Error('indexeddb unavailable'))
+
+    const persister = createHubListsQueryPersister()
+    await expect(
+      persister.persistClient({
+        buster: 'test',
+        timestamp: Date.now(),
+        clientState: { mutations: [], queries: [] },
+      }),
+    ).resolves.toBeUndefined()
+    await expect(persister.removeClient()).resolves.toBeUndefined()
+  })
+})

--- a/frontend/app/src/lib/query-persistence.ts
+++ b/frontend/app/src/lib/query-persistence.ts
@@ -19,9 +19,28 @@ export const HUB_LISTS_STORAGE_KEY = 'tanstack-query-hub-lists'
 export const HUB_LISTS_UPDATED_AT_KEY = 'tanstack-query-hub-lists-updated-at'
 
 const dexieKvStorage: AsyncStorage<string> = {
-  getItem: (key: string) => appDb.kv.get(key).then((row) => row?.value ?? null),
-  setItem: (key: string, value: string) => appDb.kv.put({ key, value }),
-  removeItem: (key: string) => appDb.kv.delete(key),
+  getItem: async (key: string) => {
+    try {
+      const row = await appDb.kv.get(key)
+      return row?.value ?? null
+    } catch {
+      return null
+    }
+  },
+  setItem: async (key: string, value: string) => {
+    try {
+      await appDb.kv.put({ key, value })
+    } catch {
+      /* Persistence is best-effort; online usage must continue without IndexedDB. */
+    }
+  },
+  removeItem: async (key: string) => {
+    try {
+      await appDb.kv.delete(key)
+    } catch {
+      /* Persistence is best-effort; online usage must continue without IndexedDB. */
+    }
+  },
 }
 
 const hubListsStorage: AsyncStorage<string> = {

--- a/frontend/app/src/lib/sheet-background.test.ts
+++ b/frontend/app/src/lib/sheet-background.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   applySheetBackgroundPreference,
+  readSheetBackgroundPreference,
   resolveSheetBackgroundPreference,
   SHEET_BACKGROUND_STORAGE_KEY,
   writeSheetBackgroundPreference,
@@ -67,5 +68,31 @@ describe('writeSheetBackgroundPreference', () => {
 
     expect(globalThis.window.dispatchEvent).toHaveBeenCalled()
     vi.unstubAllGlobals()
+  })
+})
+
+describe('sheet background storage safety', () => {
+  it('falls back to app when storage reads throw', () => {
+    const storage = {
+      getItem: vi.fn(() => {
+        throw new DOMException('blocked', 'SecurityError')
+      }),
+    }
+
+    expect(readSheetBackgroundPreference(storage)).toBe('app')
+  })
+
+  it('ignores storage write failures', () => {
+    const storage = {
+      setItem: vi.fn(() => {
+        throw new DOMException('full', 'QuotaExceededError')
+      }),
+      removeItem: vi.fn(() => {
+        throw new DOMException('blocked', 'SecurityError')
+      }),
+    }
+
+    expect(() => writeSheetBackgroundPreference('white', storage)).not.toThrow()
+    expect(() => writeSheetBackgroundPreference('app', storage)).not.toThrow()
   })
 })

--- a/frontend/app/src/lib/sheet-background.ts
+++ b/frontend/app/src/lib/sheet-background.ts
@@ -1,3 +1,5 @@
+import { getLocalStorage, safeGetItem, safeRemoveItem, safeSetItem } from '@/lib/browser-storage'
+
 export const SHEET_BACKGROUND_STORAGE_KEY = 'wv_sheet_background'
 
 export const SHEET_BACKGROUND_CHANGE_EVENT = 'wv-sheet-background-change'
@@ -22,19 +24,19 @@ export function applySheetBackgroundPreference(
 }
 
 export function readSheetBackgroundPreference(
-  storage: Pick<Storage, 'getItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem'> | null = getLocalStorage(),
 ): SheetBackgroundPreference {
-  return resolveSheetBackgroundPreference(storage.getItem(SHEET_BACKGROUND_STORAGE_KEY))
+  return resolveSheetBackgroundPreference(safeGetItem(SHEET_BACKGROUND_STORAGE_KEY, storage))
 }
 
 export function writeSheetBackgroundPreference(
   preference: SheetBackgroundPreference,
-  storage: Pick<Storage, 'setItem' | 'removeItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'setItem' | 'removeItem'> | null = getLocalStorage(),
 ): void {
   if (preference === 'app') {
-    storage.removeItem(SHEET_BACKGROUND_STORAGE_KEY)
+    safeRemoveItem(SHEET_BACKGROUND_STORAGE_KEY, storage)
   } else {
-    storage.setItem(SHEET_BACKGROUND_STORAGE_KEY, preference)
+    safeSetItem(SHEET_BACKGROUND_STORAGE_KEY, preference, storage)
   }
 
   if (typeof globalThis.document !== 'undefined') {

--- a/frontend/app/src/lib/sheet-image-invert-preference.ts
+++ b/frontend/app/src/lib/sheet-image-invert-preference.ts
@@ -1,21 +1,23 @@
+import { getLocalStorage, safeGetItem, safeRemoveItem, safeSetItem } from '@/lib/browser-storage'
+
 export const SHEET_IMAGE_INVERT_STORAGE_KEY = 'wv_sheet_image_invert'
 
 export const SHEET_IMAGE_INVERT_CHANGE_EVENT = 'wv-sheet-image-invert-change'
 
 export function readSheetImageInvertPreference(
-  storage: Pick<Storage, 'getItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'getItem'> | null = getLocalStorage(),
 ): boolean {
-  return storage.getItem(SHEET_IMAGE_INVERT_STORAGE_KEY) === 'true'
+  return safeGetItem(SHEET_IMAGE_INVERT_STORAGE_KEY, storage) === 'true'
 }
 
 export function writeSheetImageInvertPreference(
   enabled: boolean,
-  storage: Pick<Storage, 'setItem' | 'removeItem'> = globalThis.localStorage,
+  storage: Pick<Storage, 'setItem' | 'removeItem'> | null = getLocalStorage(),
 ): void {
   if (enabled) {
-    storage.setItem(SHEET_IMAGE_INVERT_STORAGE_KEY, 'true')
+    safeSetItem(SHEET_IMAGE_INVERT_STORAGE_KEY, 'true', storage)
   } else {
-    storage.removeItem(SHEET_IMAGE_INVERT_STORAGE_KEY)
+    safeRemoveItem(SHEET_IMAGE_INVERT_STORAGE_KEY, storage)
   }
 
   if (typeof globalThis.window !== 'undefined') {

--- a/frontend/app/src/main.tsx
+++ b/frontend/app/src/main.tsx
@@ -9,10 +9,18 @@ import { initAppearance } from '@/lib/appearance'
 import { initSheetBackground } from '@/lib/sheet-background'
 import { initLogoutQueue } from '@/lib/logout-queue'
 
-initAppearance()
-initSheetBackground()
-initI18n()
-initLogoutQueue()
+function runBootstrapStep(step: () => void): void {
+  try {
+    step()
+  } catch {
+    /* Keep React mount non-fatal when an older browser rejects a startup API. */
+  }
+}
+
+runBootstrapStep(initAppearance)
+runBootstrapStep(initSheetBackground)
+runBootstrapStep(initI18n)
+runBootstrapStep(initLogoutQueue)
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/frontend/app/src/pwa/PwaInstallProvider.tsx
+++ b/frontend/app/src/pwa/PwaInstallProvider.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
+import { listenToMediaQuery } from '@/lib/browser-apis'
 import { isIosOrIpadosDevice, isMacDesktopSafari } from '@/lib/platform'
 import { PwaInstallContext } from '@/pwa/pwa-install-context'
 import { cn } from '@/lib/utils'
@@ -89,12 +90,12 @@ export function PwaInstallProvider({ children }: { children: React.ReactNode }) 
   }, [])
 
   useEffect(() => {
+    if (typeof globalThis.matchMedia !== 'function') return
     const mq = globalThis.matchMedia('(display-mode: standalone)')
     const sync = () => {
       setIsStandalone(getIsStandalone())
     }
-    mq.addEventListener('change', sync)
-    return () => mq.removeEventListener('change', sync)
+    return listenToMediaQuery(mq, sync)
   }, [])
 
   useEffect(() => {

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -86,6 +86,8 @@ export default defineConfig(({ mode }) => {
       },
     },
     build: {
+      // Pin Safari 16 support instead of inheriting Vite's moving baseline target.
+      target: ['safari16', 'es2020'],
       rollupOptions: {
         output: {
           manualChunks(id) {


### PR DESCRIPTION
## Summary
- Add safe browser storage helpers and route startup/preferences through them so storage failures do not block React from mounting.
- Make Dexie query persistence best-effort and pin the Vite build target for Safari 16.
- Add media query, resize observer, intersection observer, and AV projection fallbacks for older WebKit behavior.

## Why
Older Safari/iPadOS WebKit can throw from storage, IndexedDB, or browser API access during startup and component effects. Those failures could surface as a white screen before the app reached a visible route or fallback.

## Validation
- `pnpm --filter app exec eslint . --fix`
- `pnpm -C frontend lint`
- `pnpm -C frontend typecheck`
- `pnpm -C frontend test`
- `pnpm -C frontend build`

Note: local commands warned that the shell is running Node 26 while the project expects Node 20, but all listed gates passed.