### PR TITLE
[codex] Add team filter to library list endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,10 @@ pnpm -C frontend test
 
 Add or update tests when you change behavior. Do not delete or skip tests to make the suite pass.
 
+When backend API behavior changes, also update the relevant
+`docs/business-logic-constraints/` page(s) in the same change and add/update
+HTTP/API coverage for the public contract.
+
 ### 4. Build (when you changed build inputs)
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,10 @@ cd backend && cargo test -- --test-threads=4
 (cd cli && cargo fmt --check)
 ```
 
+When backend API behavior changes, update the relevant
+[`docs/business-logic-constraints/`](docs/business-logic-constraints/) page(s)
+in the same PR and add/update HTTP/API tests for the public contract.
+
 ### Frontend
 
 ```bash

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2059,7 +2059,8 @@
           "page": 0,
           "page_size": 50,
           "q": "grace",
-          "sort": "-id"
+          "sort": "-id",
+          "team": "team_example"
         },
         "properties": {
           "lang": {
@@ -2101,6 +2102,12 @@
           },
           "tag": {
             "description": "Case-insensitive substring match against the stringified `data.tags` object (keys and values).",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "team": {
             "type": [
               "string",
               "null"
@@ -3609,6 +3616,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Filter by owning team id. Must be a plain team id, not `team:...`.",
+            "in": "query",
+            "name": "team",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5078,6 +5094,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Filter by owning team id. Must be a plain team id, not `team:...`.",
+            "in": "query",
+            "name": "team",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5988,6 +6013,15 @@
             "description": "Search query: full-text on titles (plus case-insensitive title substring), artists, and line lyrics via text_search analyzer (stemming)",
             "in": "query",
             "name": "q",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by owning team id. Must be a plain team id, not `team:...`.",
+            "in": "query",
+            "name": "team",
             "required": false,
             "schema": {
               "type": "string"

--- a/backend/src/http_tests.rs
+++ b/backend/src/http_tests.rs
@@ -1355,6 +1355,234 @@ mod list_pagination {
 }
 
 #[cfg(test)]
+mod team_filter {
+    use super::*;
+    use actix_web::http::StatusCode;
+    use actix_web::http::header::{HeaderName, LINK};
+    use shared::api::ListQuery;
+    use shared::collection::CreateCollection;
+    use shared::setlist::CreateSetlist;
+    use shared::song::CreateSong;
+
+    use crate::test_helpers::{
+        auth_ctx_for_user, collection_service, minimal_song_data, setlist_service,
+        two_shared_teams_for_user,
+    };
+
+    async fn authed_user_and_token(db: &Arc<Database>, email: &str) -> (User, String) {
+        let user = create_user(db, email).await.unwrap();
+        let token = create_session_token(db, user.clone()).await.unwrap();
+        (user, token)
+    }
+
+    fn total_count(resp: &actix_web::dev::ServiceResponse) -> u64 {
+        resp.headers()
+            .get(HeaderName::from_static("x-total-count"))
+            .expect("X-Total-Count")
+            .to_str()
+            .expect("total count header")
+            .parse()
+            .expect("numeric total count")
+    }
+
+    async fn seed_team_filter_data(db: &Arc<Database>, user: &User) -> (String, String) {
+        let (team_a, team_b) = two_shared_teams_for_user(db, user).await.expect("teams");
+        let ctx = auth_ctx_for_user(db, user).await.expect("auth");
+
+        let coll_svc = collection_service(db);
+        let collection_a = coll_svc
+            .create_collection_for_user(
+                &ctx,
+                CreateCollection {
+                    owner: Some(team_a.clone()),
+                    title: "Team A Collection".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![],
+                },
+            )
+            .await
+            .expect("collection a");
+        coll_svc
+            .create_collection_for_user(
+                &ctx,
+                CreateCollection {
+                    owner: Some(team_a.clone()),
+                    title: "Team A Collection 2".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![],
+                },
+            )
+            .await
+            .expect("collection a 2");
+        let collection_b = coll_svc
+            .create_collection_for_user(
+                &ctx,
+                CreateCollection {
+                    owner: Some(team_b.clone()),
+                    title: "Team B Collection".into(),
+                    cover: "mysongs".into(),
+                    songs: vec![],
+                },
+            )
+            .await
+            .expect("collection b");
+
+        let song_svc = crate::test_helpers::song_service(db);
+        for (collection, title) in [
+            (collection_a.id.as_str(), "Team A Song 1"),
+            (collection_a.id.as_str(), "Team A Song 2"),
+            (collection_b.id.as_str(), "Team B Song"),
+        ] {
+            let mut data = minimal_song_data();
+            data.titles = vec![title.to_string()];
+            song_svc
+                .create_song_for_user(
+                    &ctx,
+                    CreateSong {
+                        collection: collection.to_string(),
+                        not_a_song: false,
+                        blobs: vec![],
+                        data,
+                    },
+                )
+                .await
+                .expect("song");
+        }
+
+        let setlist_svc = setlist_service(db);
+        for (owner, title) in [
+            (team_a.as_str(), "Team A Setlist 1"),
+            (team_a.as_str(), "Team A Setlist 2"),
+            (team_b.as_str(), "Team B Setlist"),
+        ] {
+            setlist_svc
+                .create_setlist_for_user(
+                    &ctx,
+                    CreateSetlist {
+                        owner: Some(owner.to_string()),
+                        title: title.into(),
+                        songs: vec![],
+                    },
+                )
+                .await
+                .expect("setlist");
+        }
+
+        (team_a, team_b)
+    }
+
+    async fn assert_team_filter_for_endpoint(path: &str, owner_field: &str) {
+        let db = test_db().await.unwrap();
+        let (user, token) = authed_user_and_token(&db, "team-filter-owner@test.local").await;
+        let (team_a, _) = seed_team_filter_data(&db, &user).await;
+        let app = test::init_service(build_app(db.clone())).await;
+
+        let req = test::TestRequest::get()
+            .uri(&format!("{path}?team={team_a}"))
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(total_count(&resp), 2);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        let items = body.as_array().expect("array");
+        assert_eq!(items.len(), 2);
+        assert!(
+            items
+                .iter()
+                .all(|item| item[owner_field].as_str() == Some(team_a.as_str())),
+            "all returned items should belong to requested team"
+        );
+    }
+
+    #[actix_web::test]
+    async fn team_filter_limits_songs_to_requested_team() {
+        assert_team_filter_for_endpoint("/api/v1/songs", "owner").await;
+    }
+
+    #[actix_web::test]
+    async fn team_filter_limits_collections_to_requested_team() {
+        assert_team_filter_for_endpoint("/api/v1/collections", "owner").await;
+    }
+
+    #[actix_web::test]
+    async fn team_filter_limits_setlists_to_requested_team() {
+        assert_team_filter_for_endpoint("/api/v1/setlists", "owner").await;
+    }
+
+    #[actix_web::test]
+    async fn team_filter_link_header_preserves_team() {
+        let db = test_db().await.unwrap();
+        let (user, token) = authed_user_and_token(&db, "team-filter-link@test.local").await;
+        let (team_a, _) = seed_team_filter_data(&db, &user).await;
+        let app = test::init_service(build_app(db.clone())).await;
+
+        let req = test::TestRequest::get()
+            .uri(&format!("/api/v1/songs?team={team_a}&page=0&page_size=1"))
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(total_count(&resp), 2);
+        let link = resp
+            .headers()
+            .get(LINK)
+            .expect("Link header")
+            .to_str()
+            .expect("link header string");
+        assert!(link.contains(&format!("team={team_a}")), "got {link}");
+    }
+
+    #[actix_web::test]
+    async fn team_filter_invalid_values_return_400() {
+        let db = test_db().await.unwrap();
+        let (_, token) = authed_user_and_token(&db, "team-filter-invalid@test.local").await;
+        let app = test::init_service(build_app(db.clone())).await;
+
+        for uri in ["/api/v1/songs?team=", "/api/v1/songs?team=team:abc"] {
+            let req = test::TestRequest::get()
+                .uri(uri)
+                .insert_header(("Authorization", format!("Bearer {token}")))
+                .to_request();
+            let resp = test::call_service(&app, req).await;
+            assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "uri {uri}");
+            let body: serde_json::Value = test::read_body_json(resp).await;
+            assert_eq!(body["code"], "invalid_request");
+        }
+    }
+
+    #[actix_web::test]
+    async fn team_filter_inaccessible_team_returns_empty_results() {
+        let db = test_db().await.unwrap();
+        let (owner, _) = authed_user_and_token(&db, "team-filter-access-owner@test.local").await;
+        let (team_a, _) = seed_team_filter_data(&db, &owner).await;
+        let (_, token) = authed_user_and_token(&db, "team-filter-access-other@test.local").await;
+        let app = test::init_service(build_app(db.clone())).await;
+
+        let req = test::TestRequest::get()
+            .uri(&format!("/api/v1/songs?team={team_a}"))
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(total_count(&resp), 0);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert!(body.as_array().expect("array").is_empty());
+    }
+
+    #[actix_web::test]
+    async fn list_query_preserves_team_in_pagination_links() {
+        assert_eq!(
+            ListQuery::new()
+                .with_team("abc")
+                .with_page_size(1)
+                .query_string_for_page(2),
+            "page=2&page_size=1&team=abc"
+        );
+    }
+}
+
+#[cfg(test)]
 mod monitoring_http {
     use super::*;
     use actix_web::http::StatusCode;

--- a/backend/src/resources/collection/rest.rs
+++ b/backend/src/resources/collection/rest.rs
@@ -48,7 +48,8 @@ pub fn scope(cover_upload_max_bytes: usize) -> Scope {
     params(
         ("page" = Option<u32>, Query, description = "Zero-based page (default 0). `X-Total-Count` = filtered total before pagination; last page when `items.len() < page_size` or empty (`list-pagination.md`).", minimum = 0, nullable = true),
         ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50.", minimum = 1, maximum = 500, example = 50, nullable = true),
-        ("q" = Option<String>, Query, description = "Search query (title): full-text via text_search analyzer (stemming) plus case-insensitive substring match")
+        ("q" = Option<String>, Query, description = "Search query (title): full-text via text_search analyzer (stemming) plus case-insensitive substring match"),
+        ("team" = Option<String>, Query, description = "Filter by owning team id. Must be a plain team id, not `team:...`.")
     ),
     responses(
         (status = 200, description = "Return all collections. `X-Total-Count` header contains the total number of matching collections.", body = [Collection]),
@@ -74,14 +75,11 @@ async fn get_collections(
         .into_inner()
         .validate()
         .map_err(crate::error::map_list_query_error)?;
-    let q_ref = query.q.clone();
     let q_link = query.clone();
     let page = query.page.unwrap_or(0);
     let page_size = query.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
-    let collections = svc.list_collections_for_user(&ctx, query).await?;
-    let total = svc
-        .count_collections_for_user(&ctx, q_ref.as_deref())
-        .await?;
+    let collections = svc.list_collections_for_user(&ctx, query.clone()).await?;
+    let total = svc.count_collections_for_user(&ctx, &query).await?;
     Ok(HttpResponse::Ok()
         .insert_header((
             header::HeaderName::from_static("x-total-count"),

--- a/backend/src/resources/collection/service.rs
+++ b/backend/src/resources/collection/service.rs
@@ -16,7 +16,9 @@ use crate::auth::AuthorizationContext;
 use crate::database::Database;
 use crate::error::AppError;
 use crate::resources::blob::service::BlobServiceHandle;
-use crate::resources::common::{player_from_song_links, resolve_owner_team, song_thing};
+use crate::resources::common::{
+    player_from_song_links, read_teams_for_query, resolve_owner_team, song_thing,
+};
 use crate::resources::song::LikedSongIds;
 use crate::resources::team::{parse_owner_record_id, thing_record_key};
 use crate::resources::user::profile_picture;
@@ -71,7 +73,7 @@ impl<R: CollectionRepository, L: LikedSongIds> CollectionService<R, L> {
         ctx: &AuthorizationContext,
         pagination: ListQuery,
     ) -> Result<Vec<Collection>, AppError> {
-        let read_teams = ctx.read_teams();
+        let read_teams = read_teams_for_query(&ctx.read_teams(), pagination.team.as_deref())?;
         self.repo.get_collections(&read_teams, pagination).await
     }
 
@@ -79,10 +81,12 @@ impl<R: CollectionRepository, L: LikedSongIds> CollectionService<R, L> {
     pub async fn count_collections_for_user(
         &self,
         ctx: &AuthorizationContext,
-        q: Option<&str>,
+        query: &ListQuery,
     ) -> Result<u64, AppError> {
-        let read_teams = ctx.read_teams();
-        self.repo.count_collections(&read_teams, q).await
+        let read_teams = read_teams_for_query(&ctx.read_teams(), query.team.as_deref())?;
+        self.repo
+            .count_collections(&read_teams, query.q.as_deref())
+            .await
     }
 
     #[instrument(level = "debug", err, skip(self, ctx))]

--- a/backend/src/resources/common.rs
+++ b/backend/src/resources/common.rs
@@ -78,6 +78,25 @@ pub fn team_thing(id: &str) -> Result<RecordId, AppError> {
     Ok(RecordId::new(tb, sid))
 }
 
+/// Narrow readable teams by an optional plain team id query filter.
+pub fn read_teams_for_query(
+    read_teams: &[RecordId],
+    team: Option<&str>,
+) -> Result<Vec<RecordId>, AppError> {
+    let Some(team) = team else {
+        return Ok(read_teams.to_vec());
+    };
+    if team.trim().is_empty() {
+        return Err(AppError::invalid_request("team must not be empty"));
+    }
+    let team = team_thing(team)?;
+    if read_teams.contains(&team) {
+        Ok(vec![team])
+    } else {
+        Ok(Vec::new())
+    }
+}
+
 /// Resolve optional `owner` from PUT/PATCH bodies: must be a team the caller may write.
 pub fn resolve_owner_team(
     write_teams: &[RecordId],

--- a/backend/src/resources/setlist/rest.rs
+++ b/backend/src/resources/setlist/rest.rs
@@ -41,7 +41,8 @@ pub fn scope() -> Scope {
     params(
         ("page" = Option<u32>, Query, description = "Zero-based page (default 0). `X-Total-Count` = filtered total before pagination; last page when `items.len() < page_size` or empty (`list-pagination.md`).", minimum = 0, nullable = true),
         ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50.", minimum = 1, maximum = 500, example = 50, nullable = true),
-        ("q" = Option<String>, Query, description = "Search query (title): full-text via text_search analyzer (stemming) plus case-insensitive substring match")
+        ("q" = Option<String>, Query, description = "Search query (title): full-text via text_search analyzer (stemming) plus case-insensitive substring match"),
+        ("team" = Option<String>, Query, description = "Filter by owning team id. Must be a plain team id, not `team:...`.")
     ),
     responses(
         (status = 200, description = "Return all setlists. `X-Total-Count` header contains the total number of matching setlists.", body = [Setlist]),
@@ -67,12 +68,11 @@ async fn get_setlists(
         .into_inner()
         .validate()
         .map_err(crate::error::map_list_query_error)?;
-    let q_ref = query.q.clone();
     let q_link = query.clone();
     let page = query.page.unwrap_or(0);
     let page_size = query.page_size.unwrap_or(PAGE_SIZE_DEFAULT);
-    let setlists = svc.list_setlists_for_user(&ctx, query).await?;
-    let total = svc.count_setlists_for_user(&ctx, q_ref.as_deref()).await?;
+    let setlists = svc.list_setlists_for_user(&ctx, query.clone()).await?;
+    let total = svc.count_setlists_for_user(&ctx, &query).await?;
     Ok(HttpResponse::Ok()
         .insert_header((
             header::HeaderName::from_static("x-total-count"),

--- a/backend/src/resources/setlist/service.rs
+++ b/backend/src/resources/setlist/service.rs
@@ -9,7 +9,7 @@ use tracing::instrument;
 
 use crate::auth::AuthorizationContext;
 use crate::error::AppError;
-use crate::resources::common::resolve_owner_team;
+use crate::resources::common::{read_teams_for_query, resolve_owner_team};
 use crate::resources::song::LikedSongIds;
 use crate::resources::team::{parse_owner_record_id, thing_record_key};
 
@@ -36,7 +36,7 @@ impl<R: SetlistRepository, L: LikedSongIds> SetlistService<R, L> {
         ctx: &AuthorizationContext,
         pagination: ListQuery,
     ) -> Result<Vec<Setlist>, AppError> {
-        let read_teams = ctx.read_teams();
+        let read_teams = read_teams_for_query(&ctx.read_teams(), pagination.team.as_deref())?;
         self.repo.get_setlists(&read_teams, pagination).await
     }
 
@@ -44,10 +44,12 @@ impl<R: SetlistRepository, L: LikedSongIds> SetlistService<R, L> {
     pub async fn count_setlists_for_user(
         &self,
         ctx: &AuthorizationContext,
-        q: Option<&str>,
+        query: &ListQuery,
     ) -> Result<u64, AppError> {
-        let read_teams = ctx.read_teams();
-        self.repo.count_setlists(&read_teams, q).await
+        let read_teams = read_teams_for_query(&ctx.read_teams(), query.team.as_deref())?;
+        self.repo
+            .count_setlists(&read_teams, query.q.as_deref())
+            .await
     }
 
     #[instrument(level = "debug", err, skip(self, ctx))]

--- a/backend/src/resources/song/rest.rs
+++ b/backend/src/resources/song/rest.rs
@@ -44,6 +44,7 @@ pub fn scope() -> Scope {
         ("page" = Option<u32>, Query, description = "Zero-based page index (default 0). `X-Total-Count` is the total before pagination; the last page is when `items.len() < page_size` or the list is empty (see `docs/business-logic-constraints/list-pagination.md`).", minimum = 0, nullable = true),
         ("page_size" = Option<u32>, Query, description = "Items per page. Must be 1–500. Defaults to 50.", minimum = 1, maximum = 500, example = 50, nullable = true),
         ("q" = Option<String>, Query, description = "Search query: full-text on titles (plus case-insensitive title substring), artists, and line lyrics via text_search analyzer (stemming)"),
+        ("team" = Option<String>, Query, description = "Filter by owning team id. Must be a plain team id, not `team:...`."),
         ("sort" = Option<String>, Query, description = "Sort: JSON:API-style comma-separated keys (`-` = descending), e.g. `-id`, `title`, `relevance` (with `q`). Legacy `id_desc` / … still accepted."),
         ("lang" = Option<String>, Query, description = "Filter: song must list this language in `data.languages`."),
         ("tag" = Option<String>, Query, description = "Filter: case-insensitive substring match on stringified `data.tags`.")

--- a/backend/src/resources/song/service.rs
+++ b/backend/src/resources/song/service.rs
@@ -13,7 +13,7 @@ use crate::auth::AuthorizationContext;
 use crate::database::Database;
 use crate::error::AppError;
 use crate::resources::collection::CollectionRepository;
-use crate::resources::common::resolve_owner_team;
+use crate::resources::common::{read_teams_for_query, resolve_owner_team};
 
 use crate::resources::team::{parse_owner_record_id, thing_record_key};
 use tracing::instrument;
@@ -95,7 +95,7 @@ impl<R: SongRepository, L: LikedSongIds, C: CollectionRepository> SongService<R,
     ) -> Result<Vec<Song>, AppError> {
         let user_id = ctx.user.id.clone();
         let liked_set = self.likes.liked_song_ids(&user_id).await?;
-        let read_teams = ctx.read_teams();
+        let read_teams = read_teams_for_query(&ctx.read_teams(), query.team.as_deref())?;
         Ok(self
             .repo
             .get_songs(&read_teams, query)
@@ -114,7 +114,7 @@ impl<R: SongRepository, L: LikedSongIds, C: CollectionRepository> SongService<R,
         ctx: &AuthorizationContext,
         query: &SongListQuery,
     ) -> Result<u64, AppError> {
-        let read_teams = ctx.read_teams();
+        let read_teams = read_teams_for_query(&ctx.read_teams(), query.team.as_deref())?;
         self.repo.count_songs(&read_teams, query).await
     }
 

--- a/docs/business-logic-constraints/collection.md
+++ b/docs/business-logic-constraints/collection.md
@@ -10,7 +10,7 @@
 
 ## List pagination and search
 
-- **BLC-COLL-005:** **`GET /collections`** supports **`page`**, **`page_size`**, optional **`q`** (title search), and [list-pagination.md](./list-pagination.md).
+- **BLC-COLL-005:** **`GET /collections`** supports **`page`**, **`page_size`**, optional **`q`** (title search), optional **`team`**, and [list-pagination.md](./list-pagination.md).
 
 ## When / then
 
@@ -18,7 +18,7 @@
 - **BLC-COLL-007:** WHEN the caller is **guest** on the owning team and attempts **POST**/**PUT**/**DELETE** THEN the API responds **404**.
 - **BLC-COLL-008:** WHEN the caller is the personal-team **owner**, or **admin** / **content_maintainer** on the owning team, THEN mutations are allowed (subject to validation).
 - **BLC-COLL-009:** WHEN **POST** omits **`owner`** THEN the new collection’s **`owner`** IS the caller’s **personal** team. WHEN **POST** includes **`owner`** THEN it MUST name a team id the caller may **edit** (library content); **guest** on that team THEN **404**; unknown team or no edit access THEN **404** (malformed id THEN **400**).
-- **BLC-COLL-010:** WHEN **GET /collections** runs THEN only collections whose **`owner`** team the caller may read are returned; optional **`q`** filters by **title** (full-text plus case-insensitive substring).
+- **BLC-COLL-010:** WHEN **GET /collections** runs THEN only collections whose **`owner`** team the caller may read are returned; optional **`team`** narrows that visible set to one owning team and returns an empty list/count when the caller cannot read that team; optional **`q`** filters by **title** (full-text plus case-insensitive substring).
 - **BLC-COLL-011:** WHEN **GET /collections/{id}**, **…/songs**, or **…/player** runs THEN visibility matches **GET /collections/{id}**.
 - **BLC-COLL-012:** WHEN **GET …/songs** runs AND a stored song id does not resolve THEN behavior is defined by the implementation (partial list, omission, or error); **500** is reserved for genuine server/infrastructure failures, not as an optional substitute for **200**.
 - **BLC-COLL-013:** WHEN **PUT** includes a **song** id that does not exist THEN the API MAY still return **200** and persist the slot; clients SHOULD validate ids.

--- a/docs/business-logic-constraints/list-pagination.md
+++ b/docs/business-logic-constraints/list-pagination.md
@@ -7,12 +7,14 @@ Applies to **GET** list routes that support paging, including **`/users`** (admi
 - **BLC-LP-001:** **`page`** — 0-based index of the page.
 - **BLC-LP-002:** **`page_size`** — maximum number of items per page.
 - **BLC-LP-003:** **`q`** — optional search filter: **`/songs`** (full-text on titles, artists, and line lyrics per analyzer rules; titles also match case-insensitive substring), **`/collections`** and **`/setlists`** (full-text on **title** plus case-insensitive title substring), **`/users`** (admin list: **email** or **user id** substring, case-insensitive), **`/teams`** (full-text **name**; case-insensitive substring on **team id**, personal **owner** email, and **member** emails), **`/users/me/sessions`** and **`/users/{id}/sessions`** (substring on **session id**, **user id**, or **user email**), **`/blobs`** (**OCR** substring, case-insensitive). Whitespace-only **`q`** is treated as absent everywhere.
+- **BLC-LP-003a:** **`team`** — optional owning-team filter on top-level library lists **`/songs`**, **`/collections`**, and **`/setlists`**. The value MUST be a plain team id (the same string returned in resource **`owner`** fields), not a `team:...` record string. The filter narrows the caller's existing read scope; it never grants access to a team the caller cannot already read.
 
 ## Validation
 
 - **BLC-LP-004:** WHEN **`page`** or **`page_size`** is present but not a valid integer THEN the API responds **400**.
 - **BLC-LP-004a:** WHEN **`page_size`** IS **`0`** THEN the API responds **400** (zero is not a valid page size) with Problem `code` **`invalid_page_size`**.
 - **BLC-LP-004b:** WHEN **`page_size`** EXCEEDS **500** THEN the API responds **400** with Problem `code` **`invalid_page_size`**.
+- **BLC-LP-004c:** WHEN **`team`** is present but empty or contains a table prefix such as **`team:abc`** THEN the API responds **400** with Problem `code` **`invalid_request`**.
 - **BLC-LP-005:** WHEN **`q`** IS only whitespace THEN it IS treated as absent: the same result as omitting **`q`**, after applying visibility rules for the caller.
 
 ## Pagination behavior
@@ -21,7 +23,7 @@ Applies to **GET** list routes that support paging, including **`/users`** (admi
 - **BLC-LP-007:** WHEN **`page`** is absent it defaults to **0**. WHEN **`page_size`** is absent it defaults to **50**. The server hard cap is **500**. This default applies to all paginated list routes above.
 - **BLC-LP-007a (nested sub-lists):** For **GET** routes that list items **nested under another resource** (for example **`GET /collections/{id}/songs`**, **`GET /setlists/{id}/songs`**), when **both** **`page`** and **`page_size`** are **omitted**, the implementation MAY return **all** items in one response for backward compatibility. When **either** **`page`** or **`page_size`** is present, normal pagination (**BLC-LP-007**) applies.
 - **BLC-LP-008:** WHEN **`page`** IS beyond the last page THEN the API responds **200** with an **empty array** (not **404**).
-- **BLC-LP-009:** WHEN **`q`** IS combined with **`page`** / **`page_size`** THEN filtering runs first, then pagination over those results.
+- **BLC-LP-009:** WHEN **`q`** or **`team`** IS combined with **`page`** / **`page_size`** THEN filtering runs first, then pagination over those results.
 
 **Track A (current):** All list responses include an **`X-Total-Count`** header: the **total number of matching records after filters and before pagination**. Clients detect the last page when the returned **`items.len() < page_size`** or the page is **empty** (including “beyond last page” pages).
 

--- a/docs/business-logic-constraints/setlist.md
+++ b/docs/business-logic-constraints/setlist.md
@@ -12,7 +12,7 @@
 
 ## List pagination and search
 
-- **BLC-SETL-005:** **`GET /setlists`** supports **`page`**, **`page_size`**, optional **`q`** (title search), and [list-pagination.md](./list-pagination.md) (including whitespace-only **`q`** as no filter).
+- **BLC-SETL-005:** **`GET /setlists`** supports **`page`**, **`page_size`**, optional **`q`** (title search), optional **`team`**, and [list-pagination.md](./list-pagination.md) (including whitespace-only **`q`** as no filter).
 
 ## When / then
 
@@ -20,7 +20,7 @@
 - **BLC-SETL-007:** WHEN the caller is **guest** on the owning team and attempts **PUT** or **DELETE** THEN the API responds **404**.
 - **BLC-SETL-008:** WHEN the caller is the personal-team **owner**, or **admin** / **content_maintainer** on the owning team, THEN **PUT**/**DELETE** are allowed (subject to validation).
 - **BLC-SETL-009:** WHEN **POST** omits **`owner`** THEN the new setlist’s **`owner`** IS the caller’s **personal** team. WHEN **POST** includes **`owner`**, the same team ACL rules apply as for collections ([collection.md](./collection.md) **BLC-COLL-009**).
-- **BLC-SETL-010:** WHEN **GET /setlists** runs THEN only setlists whose **`owner`** team the caller may read are returned; optional **`q`** filters by **title**.
+- **BLC-SETL-010:** WHEN **GET /setlists** runs THEN only setlists whose **`owner`** team the caller may read are returned; optional **`team`** narrows that visible set to one owning team and returns an empty list/count when the caller cannot read that team; optional **`q`** filters by **title**.
 - **BLC-SETL-011:** WHEN **GET /setlists/{id}**, **…/songs**, or **…/player** runs THEN visibility matches **GET /setlists/{id}**.
 - **BLC-SETL-012:** WHEN **DELETE** succeeds THEN the setlist no longer appears under the same read rules.
 - **BLC-SETL-018:** WHEN **PATCH /setlists/{id}** runs THEN only fields present in the body are updated; omitted fields are unchanged; unknown fields are rejected (**`deny_unknown_fields`**), matching **BLC-SONG-019**. Optimistic concurrency uses **`If-Match`** with the resource **ETag**.

--- a/docs/business-logic-constraints/song.md
+++ b/docs/business-logic-constraints/song.md
@@ -9,7 +9,7 @@
 
 ## List pagination and search
 
-- **BLC-SONG-005:** **`GET /songs`** supports **`page`**, **`page_size`**, optional **`q`**, and the shared rules in [list-pagination.md](./list-pagination.md) (including whitespace-only **`q`** treated as no filter).
+- **BLC-SONG-005:** **`GET /songs`** supports **`page`**, **`page_size`**, optional **`q`**, optional **`team`**, and the shared rules in [list-pagination.md](./list-pagination.md) (including whitespace-only **`q`** treated as no filter and **`team`** as a plain owning-team id).
 
 ## When / then
 
@@ -18,7 +18,7 @@
 - **BLC-SONG-008:** WHEN the caller is the personal-team **owner**, or **admin** / **content_maintainer** on the owning team, THEN **PUT**/**DELETE** are allowed (subject to validation).
 - **BLC-SONG-009:** **POST** MUST include **`collection`** (collection id). The new song’s **`owner`** IS the **owning team of that collection**. The caller MUST have **library edit** access to that team; otherwise **404** (or **400** for malformed id / missing **`collection`**), same visibility pattern as collections.
 - **BLC-SONG-010:** WHEN **POST** completes THEN the new song IS appended to the given **`collection`**’s **`songs`** list. Songs are never created without a collection placement (no server-side default collection).
-- **BLC-SONG-011:** WHEN **GET /songs** runs THEN only songs whose **`owner`** team the caller may read are returned; optional **`q`** matches **title**, **artists**, and lyric text as defined by the list-search behavior (stemmed where applicable).
+- **BLC-SONG-011:** WHEN **GET /songs** runs THEN only songs whose **`owner`** team the caller may read are returned; optional **`team`** narrows that visible set to one owning team and returns an empty list/count when the caller cannot read that team; optional **`q`** matches **title**, **artists**, and lyric text as defined by the list-search behavior (stemmed where applicable).
 - **BLC-SONG-012:** WHEN **GET /songs/{id}** runs THEN visibility matches the list rule AND the response includes **`liked`** for the current user.
 - **BLC-SONG-013:** WHEN **GET …/player** runs THEN visibility matches **GET /songs/{id}**.
 - **BLC-SONG-014:** WHEN **DELETE /songs/{id}** succeeds THEN the song no longer appears via the API under the same access rules as **PUT**.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2059,7 +2059,8 @@
           "page": 0,
           "page_size": 50,
           "q": "grace",
-          "sort": "-id"
+          "sort": "-id",
+          "team": "team_example"
         },
         "properties": {
           "lang": {
@@ -2101,6 +2102,12 @@
           },
           "tag": {
             "description": "Case-insensitive substring match against the stringified `data.tags` object (keys and values).",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "team": {
             "type": [
               "string",
               "null"
@@ -3609,6 +3616,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Filter by owning team id. Must be a plain team id, not `team:...`.",
+            "in": "query",
+            "name": "team",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5078,6 +5094,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Filter by owning team id. Must be a plain team id, not `team:...`.",
+            "in": "query",
+            "name": "team",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5988,6 +6013,15 @@
             "description": "Search query: full-text on titles (plus case-insensitive title substring), artists, and line lyrics via text_search analyzer (stemming)",
             "in": "query",
             "name": "q",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by owning team id. Must be a plain team id, not `team:...`.",
+            "in": "query",
+            "name": "team",
             "required": false,
             "schema": {
               "type": "string"

--- a/frontend/app/src/api/openapi.json
+++ b/frontend/app/src/api/openapi.json
@@ -2059,7 +2059,8 @@
           "page": 0,
           "page_size": 50,
           "q": "grace",
-          "sort": "-id"
+          "sort": "-id",
+          "team": "team_example"
         },
         "properties": {
           "lang": {
@@ -2101,6 +2102,12 @@
           },
           "tag": {
             "description": "Case-insensitive substring match against the stringified `data.tags` object (keys and values).",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "team": {
             "type": [
               "string",
               "null"
@@ -3609,6 +3616,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Filter by owning team id. Must be a plain team id, not `team:...`.",
+            "in": "query",
+            "name": "team",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5078,6 +5094,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Filter by owning team id. Must be a plain team id, not `team:...`.",
+            "in": "query",
+            "name": "team",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5988,6 +6013,15 @@
             "description": "Search query: full-text on titles (plus case-insensitive title substring), artists, and line lyrics via text_search analyzer (stemming)",
             "in": "query",
             "name": "q",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by owning team id. Must be a plain team id, not `team:...`.",
+            "in": "query",
+            "name": "team",
             "required": false,
             "schema": {
               "type": "string"

--- a/frontend/app/src/api/schema.d.ts
+++ b/frontend/app/src/api/schema.d.ts
@@ -1595,7 +1595,8 @@ export interface components {
          *       "page": 0,
          *       "page_size": 50,
          *       "q": "grace",
-         *       "sort": "-id"
+         *       "sort": "-id",
+         *       "team": "team_example"
          *     }
          */
         SongListQuery: {
@@ -1614,6 +1615,7 @@ export interface components {
             sort?: string | null;
             /** @description Case-insensitive substring match against the stringified `data.tags` object (keys and values). */
             tag?: string | null;
+            team?: string | null;
         };
         SongUserSpecificAddons: {
             liked: boolean;
@@ -2517,6 +2519,8 @@ export interface operations {
                 page_size?: number | null;
                 /** @description Search query (title): full-text via text_search analyzer (stemming) plus case-insensitive substring match */
                 q?: string;
+                /** @description Filter by owning team id. Must be a plain team id, not `team:...`. */
+                team?: string;
             };
             header?: never;
             path?: never;
@@ -3583,6 +3587,8 @@ export interface operations {
                 page_size?: number | null;
                 /** @description Search query (title): full-text via text_search analyzer (stemming) plus case-insensitive substring match */
                 q?: string;
+                /** @description Filter by owning team id. Must be a plain team id, not `team:...`. */
+                team?: string;
             };
             header?: never;
             path?: never;
@@ -4255,6 +4261,8 @@ export interface operations {
                 page_size?: number | null;
                 /** @description Search query: full-text on titles (plus case-insensitive title substring), artists, and line lyrics via text_search analyzer (stemming) */
                 q?: string;
+                /** @description Filter by owning team id. Must be a plain team id, not `team:...`. */
+                team?: string;
                 /** @description Sort: JSON:API-style comma-separated keys (`-` = descending), e.g. `-id`, `title`, `relevance` (with `q`). Legacy `id_desc` / … still accepted. */
                 sort?: string;
                 /** @description Filter: song must list this language in `data.languages`. */

--- a/shared/src/api/list_query.rs
+++ b/shared/src/api/list_query.rs
@@ -10,6 +10,7 @@ pub struct ListQuery {
     pub page: Option<u32>,
     pub page_size: Option<u32>,
     pub q: Option<String>,
+    pub team: Option<String>,
 }
 
 impl ListQuery {
@@ -32,6 +33,11 @@ impl ListQuery {
         self
     }
 
+    pub fn with_team(mut self, team: impl Into<String>) -> Self {
+        self.team = Some(team.into());
+        self
+    }
+
     /// Validate the query parameters and return `Err` with a human-readable
     /// message when they are out of range.
     ///
@@ -44,6 +50,14 @@ impl ListQuery {
             }
             if ps > PAGE_SIZE_MAX {
                 return Err(format!("page_size must not exceed {PAGE_SIZE_MAX}"));
+            }
+        }
+        if let Some(ref team) = self.team {
+            if team.trim().is_empty() {
+                return Err("team must not be empty".into());
+            }
+            if team.contains(':') {
+                return Err("invalid team id".into());
             }
         }
         Ok(self)
@@ -107,6 +121,9 @@ impl ListQuery {
         if let Some(ref q) = self.q {
             parts.push(format!("q={}", encode_query_value(q)));
         }
+        if let Some(ref team) = self.team {
+            parts.push(format!("team={}", encode_query_value(team)));
+        }
         if parts.is_empty() {
             String::new()
         } else {
@@ -114,7 +131,7 @@ impl ListQuery {
         }
     }
 
-    /// Query string without `?`, with `page` overridden (keeps `page_size`, `q`).
+    /// Query string without `?`, with `page` overridden (keeps `page_size`, `q`, `team`).
     pub fn query_string_for_page(&self, page: u32) -> String {
         let mut q = self.clone();
         q.page = Some(page);
@@ -152,6 +169,7 @@ impl PageQuery {
             page: self.page,
             page_size: self.page_size,
             q: None,
+            team: None,
         }
         .validate()
         .map(|lq| Self {
@@ -165,6 +183,7 @@ impl PageQuery {
             page: self.page,
             page_size: self.page_size,
             q: None,
+            team: None,
         }
     }
 

--- a/shared/src/api/song_list_query.rs
+++ b/shared/src/api/song_list_query.rs
@@ -17,6 +17,7 @@ use super::ListQuery;
         "page": 0,
         "page_size": 50,
         "q": "grace",
+        "team": "team_example",
         "sort": "-id"
     }))
 )]
@@ -25,6 +26,7 @@ pub struct SongListQuery {
     pub page: Option<u32>,
     pub page_size: Option<u32>,
     pub q: Option<String>,
+    pub team: Option<String>,
     /// Sort: comma-separated fields, `-` prefix for descending (e.g. `-id`, `title`, `-id,title`).
     /// Use `relevance` when searching (`q` non-empty). Legacy tokens (`id_desc`, …) accepted with a warning.
     #[cfg_attr(feature = "backend", schema(value_type = Option<String>, example = "-id"))]
@@ -119,6 +121,7 @@ impl From<ListQuery> for SongListQuery {
             page: list.page,
             page_size: list.page_size,
             q: list.q,
+            team: list.team,
             sort: None,
             lang: None,
             tag: None,
@@ -133,6 +136,7 @@ impl SongListQuery {
             page: self.page,
             page_size: self.page_size,
             q: self.q.clone(),
+            team: self.team.clone(),
         }
     }
 


### PR DESCRIPTION
## Summary
- Add optional `team` query filtering for top-level songs, collections, and setlists lists
- Preserve the filter through pagination links and apply it to `X-Total-Count`
- Document the behavior in BLC docs and add workflow reminders for future API behavior changes

## Validation
- `cd shared && cargo test`
- `cd backend && cargo test team_filter -- --test-threads=4`
- `cd backend && cargo test -- --test-threads=4`
- `cd backend && cargo clippy -- -D warnings`