### PR TITLE
[codex] Add hub team filter UI

### DIFF
--- a/frontend/app/src/api/list-fetch.test.ts
+++ b/frontend/app/src/api/list-fetch.test.ts
@@ -1,0 +1,130 @@
+import type { QueryClient } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getMock = vi.fn()
+
+vi.mock('@/api/client', () => ({
+  api: {
+    GET: (...args: unknown[]) => getMock(...args),
+  },
+}))
+
+import { fetchCollectionsPage, fetchSetlistsPage, fetchSongsPage } from '@/api/list-fetch'
+
+const queryClient = {} as QueryClient
+
+function okListResponse(data: unknown[] = []) {
+  return {
+    data,
+    error: undefined,
+    response: new Response(JSON.stringify(data), {
+      status: 200,
+      headers: { 'x-total-count': String(data.length) },
+    }),
+  }
+}
+
+describe('hub list fetchers', () => {
+  beforeEach(() => {
+    getMock.mockReset()
+    getMock.mockResolvedValue(okListResponse())
+  })
+
+  it('omits team when fetching all collections', async () => {
+    await fetchCollectionsPage(queryClient, { page: 0, q: '' })
+
+    expect(getMock).toHaveBeenCalledWith('/api/v1/collections', {
+      params: {
+        query: {
+          page: 0,
+          page_size: 50,
+          q: undefined,
+          team: undefined,
+        },
+      },
+      signal: undefined,
+    })
+  })
+
+  it('passes team when fetching filtered collections', async () => {
+    await fetchCollectionsPage(queryClient, { page: 1, q: 'advent', teamId: 'team-1' })
+
+    expect(getMock).toHaveBeenCalledWith('/api/v1/collections', {
+      params: {
+        query: {
+          page: 1,
+          page_size: 50,
+          q: 'advent',
+          team: 'team-1',
+        },
+      },
+      signal: undefined,
+    })
+  })
+
+  it('passes team when fetching filtered setlists', async () => {
+    await fetchSetlistsPage(queryClient, { page: 0, q: '', teamId: 'team-2' })
+
+    expect(getMock).toHaveBeenCalledWith('/api/v1/setlists', {
+      params: {
+        query: {
+          page: 0,
+          page_size: 50,
+          q: undefined,
+          team: 'team-2',
+        },
+      },
+      signal: undefined,
+    })
+  })
+
+  it('omits team when fetching all setlists', async () => {
+    await fetchSetlistsPage(queryClient, { page: 0, q: 'sunday' })
+
+    expect(getMock).toHaveBeenCalledWith('/api/v1/setlists', {
+      params: {
+        query: {
+          page: 0,
+          page_size: 50,
+          q: 'sunday',
+          team: undefined,
+        },
+      },
+      signal: undefined,
+    })
+  })
+
+  it('keeps song relevance sorting while passing search and team', async () => {
+    await fetchSongsPage(queryClient, { page: 0, q: 'grace', teamId: 'team-3' })
+
+    expect(getMock).toHaveBeenCalledWith('/api/v1/songs', {
+      params: {
+        query: {
+          page: 0,
+          page_size: 50,
+          q: 'grace',
+          team: 'team-3',
+          sort: 'relevance',
+        },
+      },
+      signal: undefined,
+    })
+  })
+
+  it('omits team when fetching all songs', async () => {
+    await fetchSongsPage(queryClient, { page: 0, q: '' })
+
+    expect(getMock).toHaveBeenCalledWith('/api/v1/songs', {
+      params: {
+        query: {
+          page: 0,
+          page_size: 50,
+          q: undefined,
+          team: undefined,
+          sort: undefined,
+        },
+      },
+      signal: undefined,
+    })
+  })
+})

--- a/frontend/app/src/api/list-fetch.ts
+++ b/frontend/app/src/api/list-fetch.ts
@@ -30,14 +30,16 @@ async function on401(queryClient: QueryClient): Promise<never> {
 
 export async function fetchCollectionsPage(
   queryClient: QueryClient,
-  args: { page: number; q: string; signal?: AbortSignal },
+  args: { page: number; q: string; teamId?: string | null; signal?: AbortSignal },
 ): Promise<{ items: Collection[]; total: number | undefined }> {
+  const team = args.teamId?.trim() || undefined
   const { data, response, error } = await api.GET('/api/v1/collections', {
     params: {
       query: {
         page: args.page,
         page_size: PAGE_SIZE,
         q: args.q.trim() || undefined,
+        team,
       },
     },
     signal: args.signal,
@@ -51,14 +53,16 @@ export async function fetchCollectionsPage(
 
 export async function fetchSetlistsPage(
   queryClient: QueryClient,
-  args: { page: number; q: string; signal?: AbortSignal },
+  args: { page: number; q: string; teamId?: string | null; signal?: AbortSignal },
 ): Promise<{ items: Setlist[]; total: number | undefined }> {
+  const team = args.teamId?.trim() || undefined
   const { data, response, error } = await api.GET('/api/v1/setlists', {
     params: {
       query: {
         page: args.page,
         page_size: PAGE_SIZE,
         q: args.q.trim() || undefined,
+        team,
       },
     },
     signal: args.signal,
@@ -72,15 +76,17 @@ export async function fetchSetlistsPage(
 
 export async function fetchSongsPage(
   queryClient: QueryClient,
-  args: { page: number; q: string; signal?: AbortSignal },
+  args: { page: number; q: string; teamId?: string | null; signal?: AbortSignal },
 ): Promise<{ items: Song[]; total: number | undefined }> {
   const q = args.q.trim()
+  const team = args.teamId?.trim() || undefined
   const { data, response, error } = await api.GET('/api/v1/songs', {
     params: {
       query: {
         page: args.page,
         page_size: PAGE_SIZE,
         q: q || undefined,
+        team,
         sort: q ? 'relevance' : undefined,
       },
     },

--- a/frontend/app/src/api/teams-sessions-fetch.ts
+++ b/frontend/app/src/api/teams-sessions-fetch.ts
@@ -14,6 +14,7 @@ export type CreateTeam = components['schemas']['CreateTeam']
 export type PatchTeam = components['schemas']['PatchTeam']
 export type TeamRole = components['schemas']['TeamRole']
 
+export const TEAMS_PAGE_SIZE = 50
 const PAGE_SIZE = 50
 
 export class ApiUnauthorizedError extends Error {
@@ -54,7 +55,7 @@ export async function fetchTeamsPage(
     params: {
       query: {
         page: args.page,
-        page_size: PAGE_SIZE,
+        page_size: TEAMS_PAGE_SIZE,
         q: args.q.trim() || undefined,
       },
     },

--- a/frontend/app/src/components/hub/EntityListView.tsx
+++ b/frontend/app/src/components/hub/EntityListView.tsx
@@ -103,7 +103,7 @@ const tapTransition = { duration: 0.12, ease: [0.25, 0.1, 0.25, 1] as const }
 
 export function EntityListView({ entity }: EntityListViewProps) {
   const { t } = useTranslation()
-  const { debouncedQ, setQInput } = useHubSearch()
+  const { debouncedQ, selectedTeamId, setQInput } = useHubSearch()
   const reduceMotion = useReducedMotion()
   const queryClient = useQueryClient()
   const scrollRef = useHubScrollContainerRef()
@@ -167,10 +167,10 @@ export function EntityListView({ entity }: EntityListViewProps) {
       toast.info(t('hub.refresh.offlineBlocked'))
       return
     }
-    await queryClient.resetQueries({ queryKey: hubListKey(entity, debouncedQ) })
+    await queryClient.resetQueries({ queryKey: hubListKey(entity, debouncedQ, selectedTeamId) })
     await refetch()
     scrollRef.current?.scrollTo({ top: 0, behavior: 'smooth' })
-  }, [queryClient, entity, debouncedQ, refetch, scrollRef, networkOnline, t])
+  }, [queryClient, entity, debouncedQ, selectedTeamId, refetch, scrollRef, networkOnline, t])
 
   useEffect(() => {
     const el = scrollRef.current
@@ -351,6 +351,10 @@ export function EntityListView({ entity }: EntityListViewProps) {
                   {t('hub.empty.clearSearch')}
                 </Button>
               </>
+            ) : selectedTeamId ? (
+              <p className="text-sm text-[var(--color-muted-foreground)]">
+                {t(`hub.empty.filtered.${entity}`)}
+              </p>
             ) : !networkOnline ? (
               <p className="text-sm text-[var(--color-muted-foreground)]">{t('hub.empty.offlineNone')}</p>
             ) : (

--- a/frontend/app/src/components/hub/HubShell.tsx
+++ b/frontend/app/src/components/hub/HubShell.tsx
@@ -2,6 +2,7 @@ import { Outlet, useNavigate, useRouterState } from '@tanstack/react-router'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import { useEffect, useRef, useState } from 'react'
+import type { RefObject } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
@@ -22,7 +23,9 @@ import {
 import { HUB_TAB_LABEL_CLASS } from '@/components/hub/hub-list-styles'
 import { HUB_SEARCH_INPUT_CLASS, HUB_SEARCH_PILL_TEXT_CLASS } from '@/components/hub/hub-search-styles'
 import { HubTabBar } from '@/components/hub/HubTabBar'
+import { HubTeamFilterSelect } from '@/components/hub/HubTeamFilterSelect'
 import { ChevronLeftIcon } from '@/components/icons/lucide-animated/chevron-left-icon'
+import { FilterIcon } from '@/components/icons/filter-icon'
 import { PencilIcon } from '@/components/icons/lucide-animated/pencil-icon'
 import { SearchIcon } from '@/components/icons/lucide-animated/search-icon'
 import { IconHubPlus } from '@/components/icons/hub-tab-icons'
@@ -81,6 +84,99 @@ function OfflineBanner() {
   )
 }
 
+function isLibraryListPath(pathname: string): boolean {
+  return pathname === '/collections' || pathname === '/songs' || pathname === '/setlists'
+}
+
+function HubLibrarySearchField({
+  searchAnchorRef,
+  searchInputRef,
+  paletteOpen,
+  qInput,
+  setQInput,
+  searchIconActive,
+  onSearchFocus,
+  onSearchBlur,
+  onSearchMouseEnter,
+  onSearchMouseLeave,
+}: {
+  searchAnchorRef: RefObject<HTMLDivElement | null>
+  searchInputRef: RefObject<HTMLInputElement | null>
+  paletteOpen: boolean
+  qInput: string
+  setQInput: (value: string) => void
+  searchIconActive: boolean
+  onSearchFocus: () => void
+  onSearchBlur: () => void
+  onSearchMouseEnter: () => void
+  onSearchMouseLeave: () => void
+}) {
+  const { t } = useTranslation()
+  const { selectedTeamId } = useHubSearch()
+  const [filtersOpen, setFiltersOpen] = useState(false)
+  const filterActive = filtersOpen || selectedTeamId != null
+
+  return (
+    <div
+      ref={searchAnchorRef}
+      className="relative my-[0.36rem] min-w-0 flex-1"
+      onMouseEnter={onSearchMouseEnter}
+      onMouseLeave={onSearchMouseLeave}
+    >
+      <div
+        className={cn(
+          'flex h-[3.6rem] w-full min-w-0 items-center rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-elevated)] transition-[max-width]',
+          paletteOpen && 'pointer-events-none invisible',
+        )}
+        aria-hidden={paletteOpen}
+      >
+        <SearchIcon
+          aria-hidden
+          className="pointer-events-none ml-[0.65rem] shrink-0 text-[var(--color-muted-foreground)]"
+          isHovered={searchIconActive}
+          size={18}
+        />
+        <Input
+          ref={searchInputRef}
+          type="search"
+          value={qInput}
+          onChange={(e) => setQInput(e.target.value)}
+          onFocus={onSearchFocus}
+          onBlur={onSearchBlur}
+          placeholder={t('hub.searchPlaceholder')}
+          aria-label={t('hub.searchAria')}
+          tabIndex={paletteOpen ? -1 : 0}
+          className="h-full min-w-0 flex-1 rounded-full border-0 bg-transparent pl-2 pr-1 shadow-none focus-visible:outline-none"
+        />
+        <button
+          type="button"
+          aria-label={filtersOpen ? t('hub.filters.closeAria') : t('hub.filters.openAria')}
+          aria-pressed={filtersOpen}
+          onClick={() => setFiltersOpen((open) => !open)}
+          className={cn(
+            'mr-1 flex size-10 shrink-0 items-center justify-center rounded-full text-[var(--color-muted-foreground)] outline-none transition-colors',
+            'hover:bg-[var(--color-muted)] hover:text-[var(--color-foreground)]',
+            'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary)]',
+            filterActive && 'bg-[var(--color-muted)] text-[var(--color-foreground)]',
+          )}
+        >
+          <FilterIcon />
+        </button>
+        {filtersOpen ? (
+          <>
+            <div className="h-8 w-px shrink-0 bg-[var(--color-border)]" aria-hidden />
+            <HubTeamFilterSelect
+              id="hub-team-filter-inline"
+              className="mr-2 w-[min(12rem,42vw)] shrink-0"
+              triggerClassName="h-9 border-0 bg-transparent px-2 shadow-none"
+            />
+          </>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
 function HubChrome({
   children,
   searchAnchorRef,
@@ -95,7 +191,7 @@ function HubChrome({
   const { t } = useTranslation()
   const { data: user } = useSession()
   const queryClient = useQueryClient()
-  const { qInput, setQInput } = useHubSearch()
+  const { qInput, setQInput, setSelectedTeamId } = useHubSearch()
   const navigate = useNavigate()
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   const locationSearch = useRouterState({ select: (s) => s.location.search })
@@ -111,6 +207,7 @@ function HubChrome({
   const isSettings = pathname === '/settings'
   const isSessions = pathname === '/sessions'
   const isAbout = pathname === '/about'
+  const showLibraryFilters = isLibraryListPath(pathname)
   const songEditorPlayerReturn = isSongDetail
     ? parsePlayerEditorReturnSearch(locationSearch as Record<string, unknown>)
     : null
@@ -187,8 +284,15 @@ function HubChrome({
     if (prev !== null && hubSectionKey !== null && hubSectionKey !== prev) {
       setQInput('')
     }
+    if (
+      hubSectionKey !== 'collections' &&
+      hubSectionKey !== 'songs' &&
+      hubSectionKey !== 'setlists'
+    ) {
+      setSelectedTeamId(null)
+    }
     prevHubSectionRef.current = hubSectionKey
-  }, [hubSectionKey, setQInput])
+  }, [hubSectionKey, setQInput, setSelectedTeamId])
 
   useEffect(() => {
     const prev = prevOnlineRef.current
@@ -531,6 +635,19 @@ function HubChrome({
                 </div>
               </div>
             </>
+          ) : showLibraryFilters ? (
+            <HubLibrarySearchField
+              searchAnchorRef={searchAnchorRef}
+              searchInputRef={searchInputRef}
+              paletteOpen={paletteOpen}
+              qInput={qInput}
+              setQInput={setQInput}
+              searchIconActive={searchIconActive}
+              onSearchFocus={() => setSearchFocused(true)}
+              onSearchBlur={() => setSearchFocused(false)}
+              onSearchMouseEnter={() => setSearchFieldHovered(true)}
+              onSearchMouseLeave={() => setSearchFieldHovered(false)}
+            />
           ) : (
             <div
               ref={searchAnchorRef}

--- a/frontend/app/src/components/hub/HubTeamFilterSelect.tsx
+++ b/frontend/app/src/components/hub/HubTeamFilterSelect.tsx
@@ -1,0 +1,118 @@
+import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query'
+import { useEffect, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { fetchTeamsPage, TEAMS_PAGE_SIZE, type Team } from '@/api/teams-sessions-fetch'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useHubSearch } from '@/hooks/useHubSearch'
+import { useOnline } from '@/hooks/use-online'
+import { useSession } from '@/hooks/useSession'
+import { getNextPageIndex } from '@/lib/list-pagination'
+import { getTeamDisplayName } from '@/lib/team-display-name'
+import { teamsListRootKey } from '@/lib/teams-sessions-keys'
+import { cn } from '@/lib/utils'
+
+const allTeamsSelectValue = '__all_teams__'
+
+type HubTeamFilterSelectProps = {
+  id?: string
+  className?: string
+  triggerClassName?: string
+}
+
+export function HubTeamFilterSelect({
+  id = 'hub-team-filter',
+  className,
+  triggerClassName,
+}: HubTeamFilterSelectProps) {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const { data: user } = useSession()
+  const online = useOnline()
+  const { selectedTeamId, setSelectedTeamId } = useHubSearch()
+  const teamsQ = useInfiniteQuery({
+    queryKey: [...teamsListRootKey, 'hubTeamFilter', ''] as const,
+    initialPageParam: 0,
+    enabled: online,
+    networkMode: 'always',
+    staleTime: online ? 0 : Number.POSITIVE_INFINITY,
+    queryFn: async ({ pageParam, signal }) => {
+      const page = pageParam as number
+      return fetchTeamsPage(queryClient, { page, q: '', signal })
+    },
+    getNextPageParam: (last, all) => {
+      const nextFromTotal = getNextPageIndex(all)
+      if (nextFromTotal !== undefined) return nextFromTotal
+      if (last.total !== undefined) return undefined
+      return last.items.length >= TEAMS_PAGE_SIZE ? all.length : undefined
+    },
+  })
+  const { data, fetchNextPage, hasNextPage, isError, isFetchingNextPage, isPending } = teamsQ
+
+  useEffect(() => {
+    if (!online) return
+    if (hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage()
+    }
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage, online])
+
+  const teams = useMemo(() => {
+    const byId = new Map<string, Team>()
+    for (const page of data?.pages ?? []) {
+      for (const team of page.items) byId.set(team.id, team)
+    }
+    return Array.from(byId.values())
+  }, [data?.pages])
+
+  useEffect(() => {
+    if (selectedTeamId && teams.length > 0 && !teams.some((team) => team.id === selectedTeamId)) {
+      setSelectedTeamId(null)
+    }
+  }, [selectedTeamId, setSelectedTeamId, teams])
+
+  if (teams.length === 0 && (!online || isError)) return null
+  const isLoadingTeams = teams.length === 0 && isPending
+
+  return (
+    <div className={cn('min-w-0', className)}>
+      <label htmlFor={id} className="sr-only">
+        {t('hub.filters.teamLabel')}
+      </label>
+      <Select
+        value={selectedTeamId ?? allTeamsSelectValue}
+        onValueChange={(value) => {
+          setSelectedTeamId(value === allTeamsSelectValue ? null : value)
+        }}
+        disabled={teams.length === 0}
+      >
+        <SelectTrigger
+          id={id}
+          aria-label={t('hub.filters.teamAria')}
+          className={cn('h-9 rounded-full bg-[var(--color-surface)] shadow-sm', triggerClassName)}
+        >
+          {isLoadingTeams ? (
+            <span className="truncate text-[var(--color-muted-foreground)]">
+              {t('hub.filters.loadingTeams')}
+            </span>
+          ) : (
+            <SelectValue />
+          )}
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={allTeamsSelectValue}>{t('hub.filters.allTeams')}</SelectItem>
+          {teams.map((team) => (
+            <SelectItem key={team.id} value={team.id}>
+              {getTeamDisplayName(team, user?.id, t)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}

--- a/frontend/app/src/components/icons/filter-icon.tsx
+++ b/frontend/app/src/components/icons/filter-icon.tsx
@@ -1,0 +1,26 @@
+import type { HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
+
+export function FilterIcon({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={cn(className)} {...props}>
+      <svg
+        aria-hidden
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path d="M3 5h18" />
+        <path d="M6 12h12" />
+        <path d="M10 19h4" />
+      </svg>
+    </div>
+  )
+}

--- a/frontend/app/src/context/HubSearchProvider.tsx
+++ b/frontend/app/src/context/HubSearchProvider.tsx
@@ -7,6 +7,7 @@ const DEBOUNCE_MS = 300
 export function HubSearchProvider({ children }: { children: React.ReactNode }) {
   const [qInput, setQInputState] = useState('')
   const [debouncedQ, setDebouncedQ] = useState('')
+  const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null)
 
   useEffect(() => {
     const t = window.setTimeout(() => setDebouncedQ(qInput), DEBOUNCE_MS)
@@ -22,8 +23,10 @@ export function HubSearchProvider({ children }: { children: React.ReactNode }) {
       qInput,
       setQInput,
       debouncedQ,
+      selectedTeamId,
+      setSelectedTeamId,
     }),
-    [qInput, setQInput, debouncedQ],
+    [qInput, setQInput, debouncedQ, selectedTeamId],
   )
 
   return <HubSearchContext.Provider value={value}>{children}</HubSearchContext.Provider>

--- a/frontend/app/src/context/hub-search-context.ts
+++ b/frontend/app/src/context/hub-search-context.ts
@@ -6,6 +6,9 @@ export type HubSearchContextValue = {
   setQInput: (value: string) => void
   /** Debounced value passed to list queries (`q` API param). */
   debouncedQ: string
+  /** Selected owning team filter for library lists; `null` means all accessible teams. */
+  selectedTeamId: string | null
+  setSelectedTeamId: (value: string | null) => void
 }
 
 export const HubSearchContext = createContext<HubSearchContextValue | null>(null)

--- a/frontend/app/src/hooks/useInfiniteHubList.ts
+++ b/frontend/app/src/hooks/useInfiniteHubList.ts
@@ -30,13 +30,13 @@ const hubListNotifyOnChangeProps = [
 const hubListNotify: NotifyOnChangeProps = hubListNotifyOnChangeProps as unknown as NotifyOnChangeProps
 
 export function useInfiniteHubList(entity: HubEntity) {
-  const { debouncedQ } = useHubSearch()
+  const { debouncedQ, selectedTeamId } = useHubSearch()
   const queryClient = useQueryClient()
   const q = debouncedQ
   const online = useOnline()
 
   return useInfiniteQuery({
-    queryKey: hubListKey(entity, q),
+    queryKey: hubListKey(entity, q, selectedTeamId),
     initialPageParam: 0,
     notifyOnChangeProps: hubListNotify,
     /** Fresh after restore: refetch when online; snapshots never expire on disk. */
@@ -48,11 +48,11 @@ export function useInfiniteHubList(entity: HubEntity) {
       const page = pageParam as number
       switch (entity) {
         case 'collections':
-          return fetchCollectionsPage(queryClient, { page, q, signal })
+          return fetchCollectionsPage(queryClient, { page, q, teamId: selectedTeamId, signal })
         case 'songs':
-          return fetchSongsPage(queryClient, { page, q, signal })
+          return fetchSongsPage(queryClient, { page, q, teamId: selectedTeamId, signal })
         case 'setlists':
-          return fetchSetlistsPage(queryClient, { page, q, signal })
+          return fetchSetlistsPage(queryClient, { page, q, teamId: selectedTeamId, signal })
       }
     },
     getNextPageParam: (_last, allPages) => getNextPageIndex(allPages),

--- a/frontend/app/src/i18n/de.json
+++ b/frontend/app/src/i18n/de.json
@@ -84,6 +84,14 @@
     "createCollectionAria": "Sammlung erstellen",
     "createSongAria": "Song erstellen",
     "createLabel": "Neu",
+    "filters": {
+      "teamLabel": "Team",
+      "teamAria": "Bibliothek nach Team filtern",
+      "openAria": "Bibliotheksfilter öffnen",
+      "closeAria": "Bibliotheksfilter schließen",
+      "allTeams": "Alle Teams",
+      "loadingTeams": "Teams werden geladen…"
+    },
     "profile": {
       "openMenu": "Profilmenü öffnen",
       "openMenuOffline": "Profilmenü öffnen (offline)",
@@ -123,6 +131,11 @@
       "noResults": "Keine Treffer für deine Suche.",
       "clearSearch": "Suche löschen",
       "offlineNone": "Keine gespeicherten Daten für diesen Tab. Verbinde dich, um zu laden.",
+      "filtered": {
+        "collections": "Keine Sammlungen für dieses Team.",
+        "songs": "Keine Lieder für dieses Team.",
+        "setlists": "Keine Setlisten für dieses Team."
+      },
       "none": {
         "collections": "Noch keine Sammlungen.",
         "songs": "Noch keine Lieder.",

--- a/frontend/app/src/i18n/en.json
+++ b/frontend/app/src/i18n/en.json
@@ -84,6 +84,14 @@
     "createCollectionAria": "Create collection",
     "createSongAria": "Create song",
     "createLabel": "Add",
+    "filters": {
+      "teamLabel": "Team",
+      "teamAria": "Filter library by team",
+      "openAria": "Open library filters",
+      "closeAria": "Close library filters",
+      "allTeams": "All teams",
+      "loadingTeams": "Loading teams…"
+    },
     "profile": {
       "openMenu": "Open profile menu",
       "openMenuOffline": "Open profile menu (offline)",
@@ -123,6 +131,11 @@
       "noResults": "No results match your search.",
       "clearSearch": "Clear search",
       "offlineNone": "No saved data for this tab. Connect to load.",
+      "filtered": {
+        "collections": "No collections for this team.",
+        "songs": "No songs for this team.",
+        "setlists": "No setlists for this team."
+      },
       "none": {
         "collections": "No collections yet.",
         "songs": "No songs yet.",

--- a/frontend/app/src/lib/hub-list-keys.test.ts
+++ b/frontend/app/src/lib/hub-list-keys.test.ts
@@ -11,6 +11,17 @@ describe('isHubListQueryKey', () => {
     expect(isHubListQueryKey(hubListKey('setlists', ''))).toBe(true)
   })
 
+  it('separates all-team and team-filtered list caches', () => {
+    expect(hubListKey('songs', 'grace')).toEqual(['hubLists', 'songs', 'grace', null])
+    expect(hubListKey('songs', 'grace', null)).toEqual(['hubLists', 'songs', 'grace', null])
+    expect(hubListKey('songs', 'grace', 'team-1')).toEqual([
+      'hubLists',
+      'songs',
+      'grace',
+      'team-1',
+    ])
+  })
+
   it('is false for session, teams, and other roots', () => {
     expect(isHubListQueryKey(SESSION_QUERY_KEY)).toBe(false)
     expect(isHubListQueryKey(teamsListKey(''))).toBe(false)

--- a/frontend/app/src/lib/hub-list-keys.ts
+++ b/frontend/app/src/lib/hub-list-keys.ts
@@ -2,8 +2,8 @@ import type { HubEntity } from '@/lib/hub-entity'
 
 export const hubListRootKey = ['hubLists'] as const
 
-export function hubListKey(entity: HubEntity, q: string) {
-  return [...hubListRootKey, entity, q] as const
+export function hubListKey(entity: HubEntity, q: string, teamId?: string | null) {
+  return [...hubListRootKey, entity, q, teamId ?? null] as const
 }
 
 /** True for collections, songs, and setlists list query keys. */


### PR DESCRIPTION
## Summary
- add team filtering to collection, song, and setlist hub list API calls and query keys
- add a reusable hub team filter selector that loads all accessible teams
- move the team filter into an expandable filter area in the search bar
- add English/German copy and fetch/query-key tests

## Validation
- `pnpm -C frontend lint`
- `pnpm -C frontend typecheck`
- `pnpm -C frontend test`

Note: local pnpm emitted the existing Node engine warning because this machine is on Node v26 while the project expects Node >=20 <21, but all checks passed.