### PR TITLE
[codex] Add player song language selector

### DIFF
--- a/frontend/app/src/components/player/ChordsSlide.tsx
+++ b/frontend/app/src/components/player/ChordsSlide.tsx
@@ -26,6 +26,7 @@ type RenderState =
 type ChordsSlideProps = {
   song: Song
   displayKey?: string | null
+  languageIndex?: number | null
   chordFormat: ChordFormatPreference
   orientation: Orientation
   /** Fill a fixed-size book spread slot instead of growing with content. */
@@ -35,6 +36,7 @@ type ChordsSlideProps = {
 export function ChordsSlide({
   song,
   displayKey,
+  languageIndex,
   chordFormat,
   orientation,
   fillParent = false,
@@ -59,7 +61,7 @@ export function ChordsSlide({
 
   const songData = song.data as ChordSongData
   const representation = useMemo(() => chordFormatToRepresentation(chordFormat), [chordFormat])
-  const renderKey = `${song.id}:${displayKey ?? ''}:${renderPass}:${representation}:${hideChords ? 'hidden' : 'shown'}`
+  const renderKey = `${song.id}:${displayKey ?? ''}:${languageIndex ?? ''}:${renderPass}:${representation}:${hideChords ? 'hidden' : 'shown'}`
   const renderState = useMemo(
     (): RenderState =>
       renderCache.key === renderKey ? renderCache.state : { status: 'loading' },
@@ -101,6 +103,7 @@ export function ChordsSlide({
         const engine = await getChordEngine()
         const page = engine.renderA4Html(songData, {
           key: displayKey ?? undefined,
+          language: languageIndex ?? undefined,
           scale: 1,
           representation,
         })
@@ -116,7 +119,7 @@ export function ChordsSlide({
     return () => {
       cancelled = true
     }
-  }, [renderKey, songData, displayKey, representation, hideChords])
+  }, [renderKey, songData, displayKey, languageIndex, representation, hideChords])
 
   useLayoutEffect(() => {
     if (renderState.status !== 'ready') return

--- a/frontend/app/src/components/player/ChordsThreeColumnSlide.tsx
+++ b/frontend/app/src/components/player/ChordsThreeColumnSlide.tsx
@@ -49,8 +49,10 @@ type ColumnSection = {
 type ChordsThreeColumnSlideProps = {
   song: Song
   displayKey?: string | null
+  languageIndex?: number | null
   nextSong?: Song | null
   nextDisplayKey?: string | null
+  nextLanguageIndex?: number | null
   chordFormat: ChordFormatPreference
   columnCount?: 1 | 2 | 3
   overflowStyle?: PlayerOverflowStyle
@@ -116,6 +118,7 @@ function useMultiColumnSongRender(
   song: Song | null | undefined,
   songData: ChordSongData | undefined,
   displayKey: string | null | undefined,
+  languageIndex: number | null | undefined,
   chordFormat: ChordFormatPreference,
   hideChords: boolean,
   renderPass: number,
@@ -126,7 +129,7 @@ function useMultiColumnSongRender(
   })
   const representation = useMemo(() => chordFormatToRepresentation(chordFormat), [chordFormat])
   const renderKey = song
-    ? `${song.id}:${displayKey ?? ''}:${renderPass}:${representation}:${hideChords ? 'hidden' : 'shown'}`
+    ? `${song.id}:${displayKey ?? ''}:${languageIndex ?? ''}:${renderPass}:${representation}:${hideChords ? 'hidden' : 'shown'}`
     : ''
 
   useEffect(() => {
@@ -138,6 +141,7 @@ function useMultiColumnSongRender(
         const engine = await getChordEngine()
         const page = engine.renderA4SectionHtmls(songData, {
           key: displayKey ?? undefined,
+          language: languageIndex ?? undefined,
           representation,
         })
         if (cancelled) return
@@ -157,7 +161,7 @@ function useMultiColumnSongRender(
     return () => {
       cancelled = true
     }
-  }, [song, songData, displayKey, renderKey, representation, hideChords])
+  }, [song, songData, displayKey, languageIndex, renderKey, representation, hideChords])
 
   if (!song || !songData || renderCache.key !== renderKey) {
     return LOADING_RENDER_STATE
@@ -270,8 +274,10 @@ function columnTypographyStyle(columnLayout: {
 export function ChordsThreeColumnSlide({
   song,
   displayKey,
+  languageIndex,
   nextSong,
   nextDisplayKey,
+  nextLanguageIndex,
   chordFormat,
   columnCount = 3,
   overflowStyle = 'scroll',
@@ -310,6 +316,7 @@ export function ChordsThreeColumnSlide({
     song,
     renderSongData,
     displayKey,
+    languageIndex,
     chordFormat,
     hideChords,
     renderPass,
@@ -324,6 +331,7 @@ export function ChordsThreeColumnSlide({
     nextSong,
     nextRenderSongData,
     nextDisplayKey,
+    nextLanguageIndex,
     chordFormat,
     hideChords,
     0,

--- a/frontend/app/src/components/player/PlayerBook.tsx
+++ b/frontend/app/src/components/player/PlayerBook.tsx
@@ -63,8 +63,10 @@ import { resolveTransposeKey } from '@/lib/player/transpose-key'
 import {
   readPlayerViewState,
   clearTransposeForItem,
+  clearLanguageForItem,
   setPlayerNavPosition,
   setTransposeForItem,
+  setLanguageForItem,
   writePlayerViewState,
   type PlayerViewState,
 } from '@/lib/player/player-view-state'
@@ -77,6 +79,7 @@ import {
 import type { PlayerMode } from '@/lib/player/player-mode'
 import type { PlayerEntityType } from '@/lib/player-route'
 import { buildSongEditorReturnSearch } from '@/lib/player/player-editor-return'
+import { resolveSongLanguageIndex, songLanguageOptions } from '@/lib/player/song-language'
 import { buildSettingsSearch } from '@/lib/settings-route'
 import { MUSICAL_KEYS } from '@/lib/setlist-editor-constants'
 import { resolveSongDataKey } from '@/lib/setlist-song-links'
@@ -186,7 +189,8 @@ export function PlayerBook({
   const sheetOrientation = isLandscapeViewport ? 'landscape' : 'portrait'
   const reduceMotion = useReducedMotion()
   const chromeTransition = reduceMotion ? { duration: 0 } : { duration: 0.22, ease: PLAYER_CHROME_EASE }
-  const [popoverOpen, setPopoverOpen] = useState(false)
+  const [keyPopoverOpen, setKeyPopoverOpen] = useState(false)
+  const [languagePopoverOpen, setLanguagePopoverOpen] = useState(false)
   const [chromeVisible, setChromeVisible] = useState(false)
   const touchStartRef = useRef<{ x: number; y: number } | null>(null)
   const touchMovedRef = useRef(false)
@@ -366,7 +370,17 @@ export function PlayerBook({
           try {
             const engine = await getChordEngine()
             const key = resolveSongDataKey(nextItem.song.data as Record<string, unknown>)
-            const renderOpts = { key: key ?? undefined, representation: chordFormatToRepresentation(chordFormat) }
+            const languageOptions = songLanguageOptions(nextItem.song.data as Record<string, unknown>)
+            const selectedLanguageIndex = resolveSongLanguageIndex(
+              languageOptions,
+              viewState.languageByItem?.[prefetchIndex],
+            )
+            const languageIndex = selectedLanguageIndex > 0 ? selectedLanguageIndex : null
+            const renderOpts = {
+              key: key ?? undefined,
+              language: languageIndex ?? undefined,
+              representation: chordFormatToRepresentation(chordFormat),
+            }
             if (isMultiColumnScrollMode(effectiveScroll)) {
               engine.renderA4SectionHtmls(nextItem.song.data, renderOpts)
             } else {
@@ -380,7 +394,17 @@ export function PlayerBook({
     })()
 
     return () => controller.abort()
-  }, [nav.index, online, itemsLen, player.items, allowNetworkFetch, bookSpread, effectiveScroll, chordFormat])
+  }, [
+    nav.index,
+    online,
+    itemsLen,
+    player.items,
+    allowNetworkFetch,
+    bookSpread,
+    effectiveScroll,
+    chordFormat,
+    viewState.languageByItem,
+  ])
 
   const backTo = hubPathForPlayerType(type)
   const localTranspose = viewState.transposeByItem[nav.index]
@@ -392,6 +416,15 @@ export function PlayerBook({
     currentItem?.type === 'chords'
       ? resolvePlayerItemKey(currentItem, type, slotKey, localTranspose)
       : null
+  const currentLanguageOptions =
+    currentItem?.type === 'chords' ? songLanguageOptions(currentItem.song.data as Record<string, unknown>) : []
+  const currentLanguageIndex = resolveSongLanguageIndex(
+    currentLanguageOptions,
+    viewState.languageByItem?.[nav.index],
+  )
+  const currentLanguageLabel =
+    currentLanguageOptions[currentLanguageIndex]?.label ?? `L${currentLanguageIndex + 1}`
+  const showLanguageSelector = currentItem?.type === 'chords' && currentLanguageOptions.length > 1
 
   const playerReturnContext = useMemo(
     () => ({ playerType: type, playerId: id, playerIndex: nav.index }),
@@ -427,7 +460,10 @@ export function PlayerBook({
 
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
-      const action = playerKeyboardAction(e.key, e.target, { popoverOpen, chromeVisible })
+      const action = playerKeyboardAction(e.key, e.target, {
+        popoverOpen: keyPopoverOpen || languagePopoverOpen,
+        chromeVisible,
+      })
       if (!action) return
 
       if (action === 'prev') {
@@ -452,13 +488,16 @@ export function PlayerBook({
       }
       if (action === 'escape') {
         e.preventDefault()
-        if (popoverOpen) setPopoverOpen(false)
-        else void navigate({ to: backTo })
+        if (keyPopoverOpen || languagePopoverOpen) {
+          setKeyPopoverOpen(false)
+          setLanguagePopoverOpen(false)
+        } else void navigate({ to: backTo })
         return
       }
       if (action === 'toggleChrome') {
         e.preventDefault()
-        setPopoverOpen(false)
+        setKeyPopoverOpen(false)
+        setLanguagePopoverOpen(false)
         setChromeVisible((visible) => !visible)
         return
       }
@@ -493,13 +532,13 @@ export function PlayerBook({
       if (typeof action === 'object' && action.type === 'setTransposeKey') {
         e.preventDefault()
         setViewState((state) => setTransposeForItem(state, nav.index, action.key))
-        setPopoverOpen(false)
+        setKeyPopoverOpen(false)
         return
       }
       if (action === 'resetTranspose') {
         e.preventDefault()
         setViewState((state) => clearTransposeForItem(state, nav.index))
-        setPopoverOpen(false)
+        setKeyPopoverOpen(false)
         return
       }
       if (action === 'transposeUp') {
@@ -507,7 +546,7 @@ export function PlayerBook({
         const nextKey = resolveTransposeKey(displayKey, 1)
         if (nextKey) {
           setViewState((state) => setTransposeForItem(state, nav.index, nextKey))
-          setPopoverOpen(false)
+          setKeyPopoverOpen(false)
         }
         return
       }
@@ -516,7 +555,7 @@ export function PlayerBook({
         const nextKey = resolveTransposeKey(displayKey, -1)
         if (nextKey) {
           setViewState((state) => setTransposeForItem(state, nav.index, nextKey))
-          setPopoverOpen(false)
+          setKeyPopoverOpen(false)
         }
         return
       }
@@ -535,7 +574,8 @@ export function PlayerBook({
     nav.index,
     navBlocked,
     navigate,
-    popoverOpen,
+    keyPopoverOpen,
+    languagePopoverOpen,
     chromeVisible,
     layoutPreferences,
     sheetOrientation,
@@ -550,6 +590,23 @@ export function PlayerBook({
     if (item.type !== 'chords') return null
     const itemSlotKey = resolveSongDataKey(item.song.data as Record<string, unknown>)
     return resolvePlayerItemKey(item, type, itemSlotKey, viewState.transposeByItem[itemIndex])
+  }
+
+  function languageOptionsForItem(item: PlayerItem) {
+    if (item.type !== 'chords') return []
+    return songLanguageOptions(item.song.data as Record<string, unknown>)
+  }
+
+  function selectedLanguageIndexForItem(item: PlayerItem, itemIndex: number): number | null {
+    if (item.type !== 'chords') return null
+    const options = languageOptionsForItem(item)
+    if (options.length === 0) return null
+    return resolveSongLanguageIndex(options, viewState.languageByItem?.[itemIndex])
+  }
+
+  function renderLanguageIndexForItem(item: PlayerItem, itemIndex: number): number | null {
+    const selected = selectedLanguageIndexForItem(item, itemIndex)
+    return selected != null && selected > 0 ? selected : null
   }
 
   function renderPlayerItem(item: PlayerItem, itemIndex: number, fillParent = false) {
@@ -572,10 +629,16 @@ export function PlayerBook({
         <ChordsThreeColumnSlide
           song={item.song}
           displayKey={displayKeyForItem(item, itemIndex)}
+          languageIndex={renderLanguageIndexForItem(item, itemIndex)}
           nextSong={nextSong}
           nextDisplayKey={
             nextItem?.type === 'chords'
               ? displayKeyForItem(nextItem, itemIndex + 1)
+              : undefined
+          }
+          nextLanguageIndex={
+            nextItem?.type === 'chords'
+              ? renderLanguageIndexForItem(nextItem, itemIndex + 1)
               : undefined
           }
           chordFormat={chordFormat}
@@ -591,6 +654,7 @@ export function PlayerBook({
       <ChordsSlide
         song={item.song}
         displayKey={displayKeyForItem(item, itemIndex)}
+        languageIndex={renderLanguageIndexForItem(item, itemIndex)}
         chordFormat={chordFormat}
         orientation={sheetOrientation}
         fillParent={fillParent}
@@ -638,7 +702,8 @@ export function PlayerBook({
       const zone = viewportPointerZone(clientX, rect)
 
       if (chromeVisible) {
-        setPopoverOpen(false)
+        setKeyPopoverOpen(false)
+        setLanguagePopoverOpen(false)
         if (zone !== 'middle') {
           setChromeVisible(false)
           return true
@@ -656,7 +721,8 @@ export function PlayerBook({
         if (!navBlocked) dispatch({ type: 'next' })
         return true
       }
-      setPopoverOpen(false)
+      setKeyPopoverOpen(false)
+      setLanguagePopoverOpen(false)
       setChromeVisible(true)
       if (doubleTap) toggleCurrentSongLike()
       return true
@@ -767,53 +833,98 @@ export function PlayerBook({
 
               <div className="flex shrink-0 items-center gap-1">
                 {showChordsControls && currentItem.type === 'chords' ? (
-                  <PopoverRoot open={popoverOpen} onOpenChange={setPopoverOpen}>
-                    <PopoverTrigger asChild>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="icon"
-                        className={playerHeaderIconButtonClass}
-                        aria-label={t('player.transpose.current', {
-                          key: displayKey ?? t('player.transpose.default'),
-                        })}
-                      >
-                        <span className={cn(playerHeaderIconClass, 'text-sm font-semibold leading-none')}>
-                          {displayKey ?? '♮'}
-                        </span>
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent align="end" className="w-56 p-2">
-                      <div className="grid grid-cols-4 gap-1">
+                  <>
+                    {showLanguageSelector ? (
+                      <PopoverRoot open={languagePopoverOpen} onOpenChange={setLanguagePopoverOpen}>
+                        <PopoverTrigger asChild>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="icon"
+                            className={playerHeaderIconButtonClass}
+                            aria-label={t('player.language.current', {
+                              language: currentLanguageLabel,
+                            })}
+                          >
+                            <span className={cn(playerHeaderIconClass, 'text-xs font-semibold leading-none')}>
+                              {currentLanguageLabel}
+                            </span>
+                          </Button>
+                        </PopoverTrigger>
+                        <PopoverContent align="end" className="w-48 p-2">
+                          <div className="grid gap-1">
+                            {currentLanguageOptions.map((option) => (
+                              <Button
+                                key={option.index}
+                                type="button"
+                                size="sm"
+                                variant={currentLanguageIndex === option.index ? 'default' : 'outline'}
+                                onClick={() => {
+                                  setViewState((s) =>
+                                    option.index === 0
+                                      ? clearLanguageForItem(s, nav.index)
+                                      : setLanguageForItem(s, nav.index, option.index),
+                                  )
+                                  setLanguagePopoverOpen(false)
+                                }}
+                              >
+                                {option.index === 0
+                                  ? t('player.language.defaultOption', { language: option.label })
+                                  : option.label}
+                              </Button>
+                            ))}
+                          </div>
+                        </PopoverContent>
+                      </PopoverRoot>
+                    ) : null}
+                    <PopoverRoot open={keyPopoverOpen} onOpenChange={setKeyPopoverOpen}>
+                      <PopoverTrigger asChild>
                         <Button
                           type="button"
-                          size="sm"
-                          variant={localTranspose === undefined ? 'default' : 'outline'}
-                          className="col-span-4"
-                          onClick={() => {
-                            setViewState((s) => clearTransposeForItem(s, nav.index))
-                            setPopoverOpen(false)
-                          }}
+                          variant="outline"
+                          size="icon"
+                          className={playerHeaderIconButtonClass}
+                          aria-label={t('player.transpose.current', {
+                            key: displayKey ?? t('player.transpose.default'),
+                          })}
                         >
-                          {t('player.transpose.default')}
+                          <span className={cn(playerHeaderIconClass, 'text-sm font-semibold leading-none')}>
+                            {displayKey ?? '♮'}
+                          </span>
                         </Button>
-                        {MUSICAL_KEYS.map((key) => (
+                      </PopoverTrigger>
+                      <PopoverContent align="end" className="w-56 p-2">
+                        <div className="grid grid-cols-4 gap-1">
                           <Button
-                            key={key}
                             type="button"
                             size="sm"
-                            variant={displayKey === key ? 'default' : 'outline'}
+                            variant={localTranspose === undefined ? 'default' : 'outline'}
+                            className="col-span-4"
                             onClick={() => {
-                              setViewState((s) => setTransposeForItem(s, nav.index, key))
-                              setPopoverOpen(false)
+                              setViewState((s) => clearTransposeForItem(s, nav.index))
+                              setKeyPopoverOpen(false)
                             }}
                           >
-                            {key}
+                            {t('player.transpose.default')}
                           </Button>
-                        ))}
-                      </div>
-                    </PopoverContent>
-                  </PopoverRoot>
+                          {MUSICAL_KEYS.map((key) => (
+                            <Button
+                              key={key}
+                              type="button"
+                              size="sm"
+                              variant={displayKey === key ? 'default' : 'outline'}
+                              onClick={() => {
+                                setViewState((s) => setTransposeForItem(s, nav.index, key))
+                                setKeyPopoverOpen(false)
+                              }}
+                            >
+                              {key}
+                            </Button>
+                          ))}
+                        </div>
+                      </PopoverContent>
+                    </PopoverRoot>
+                  </>
                 ) : null}
                 <PlayerEditMenu
                   playerType={type}

--- a/frontend/app/src/i18n/de.json
+++ b/frontend/app/src/i18n/de.json
@@ -275,6 +275,10 @@
       "current": "Transponieren: {{key}}, ändern",
       "default": "Standard"
     },
+    "language": {
+      "current": "Sprache: {{language}}, ändern",
+      "defaultOption": "{{language}} (Standard)"
+    },
     "chordFormat": {
       "current": "Akkordformat: {{format}}, ändern"
     },

--- a/frontend/app/src/i18n/en.json
+++ b/frontend/app/src/i18n/en.json
@@ -275,6 +275,10 @@
       "current": "Transpose: {{key}}, change",
       "default": "Default"
     },
+    "language": {
+      "current": "Language: {{language}}, change",
+      "defaultOption": "{{language}} (default)"
+    },
     "chordFormat": {
       "current": "Chord format: {{format}}, change"
     },

--- a/frontend/app/src/lib/player/player-view-state.test.ts
+++ b/frontend/app/src/lib/player/player-view-state.test.ts
@@ -8,6 +8,8 @@ import {
   readPlayerViewState,
   writePlayerViewState,
   playerViewStorageKey,
+  setLanguageForItem,
+  clearLanguageForItem,
   setPlayerNavPosition,
 } from '@/lib/player/player-view-state'
 
@@ -29,6 +31,39 @@ describe('player-view-state', () => {
 
     const loaded = readPlayerViewState('song', 's1', mockStorage)
     expect(loaded.transposeByItem[0]).toBe('G')
+  })
+
+  it('persists and reads language settings', () => {
+    const storage = new Map<string, string>()
+    const mockStorage = {
+      getItem: (k: string) => storage.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        storage.set(k, v)
+      },
+    }
+
+    writePlayerViewState(
+      'song',
+      's1',
+      { transposeByItem: {}, languageByItem: { 0: 1 } },
+      mockStorage,
+    )
+
+    const loaded = readPlayerViewState('song', 's1', mockStorage)
+    expect(loaded.languageByItem?.[0]).toBe(1)
+  })
+
+  it('uses empty language settings for legacy stored state', () => {
+    const storage = new Map<string, string>([
+      [playerViewStorageKey('song', 's1'), JSON.stringify({ transposeByItem: { 0: 'G' } })],
+    ])
+    const mockStorage = {
+      getItem: (k: string) => storage.get(k) ?? null,
+    }
+
+    const loaded = readPlayerViewState('song', 's1', mockStorage)
+    expect(loaded.transposeByItem[0]).toBe('G')
+    expect(loaded.languageByItem).toEqual({})
   })
 
   it('persists and reads item index', () => {
@@ -70,6 +105,14 @@ describe('player-view-state', () => {
     const next = setPlayerNavPosition({ transposeByItem: {} }, 4, 2)
     expect(next.itemIndex).toBe(4)
     expect(next.pageOffset).toBe(2)
+  })
+
+  it('sets and clears language settings for an item', () => {
+    const selected = setLanguageForItem({ transposeByItem: {} }, 2, 1)
+    expect(selected.languageByItem?.[2]).toBe(1)
+
+    const cleared = clearLanguageForItem(selected, 2)
+    expect(cleared.languageByItem?.[2]).toBeUndefined()
   })
 })
 

--- a/frontend/app/src/lib/player/player-view-state.ts
+++ b/frontend/app/src/lib/player/player-view-state.ts
@@ -4,6 +4,7 @@ import { parseOptionalPlayerIndex } from '@/lib/player/player-editor-return'
 
 export type PlayerViewState = {
   transposeByItem: Record<number, string | null>
+  languageByItem?: Record<number, number>
   itemIndex?: number
   /** Intra-item page when scroll mode supports paging within an item. */
   pageOffset?: number
@@ -21,18 +22,19 @@ export function readPlayerViewState(
   try {
     const raw = safeGetItem(playerViewStorageKey(type, id), storage)
     if (!raw) {
-      return { transposeByItem: {} }
+      return { transposeByItem: {}, languageByItem: {} }
     }
     const parsed = JSON.parse(raw) as Partial<PlayerViewState>
     const itemIndex = parseOptionalPlayerIndex(parsed.itemIndex)
     const pageOffset = parseOptionalPlayerIndex(parsed.pageOffset)
     return {
       transposeByItem: parsed.transposeByItem ?? {},
+      languageByItem: parsed.languageByItem ?? {},
       ...(itemIndex != null ? { itemIndex } : {}),
       ...(pageOffset != null ? { pageOffset } : {}),
     }
   } catch {
-    return { transposeByItem: {} }
+    return { transposeByItem: {}, languageByItem: {} }
   }
 }
 
@@ -68,6 +70,23 @@ export function clearTransposeForItem(state: PlayerViewState, itemIndex: number)
   const next = { ...state.transposeByItem }
   delete next[itemIndex]
   return { ...state, transposeByItem: next }
+}
+
+export function setLanguageForItem(
+  state: PlayerViewState,
+  itemIndex: number,
+  languageIndex: number,
+): PlayerViewState {
+  return {
+    ...state,
+    languageByItem: { ...(state.languageByItem ?? {}), [itemIndex]: languageIndex },
+  }
+}
+
+export function clearLanguageForItem(state: PlayerViewState, itemIndex: number): PlayerViewState {
+  const next = { ...(state.languageByItem ?? {}) }
+  delete next[itemIndex]
+  return { ...state, languageByItem: next }
 }
 
 export function setPlayerItemIndex(state: PlayerViewState, itemIndex: number): PlayerViewState {

--- a/frontend/app/src/lib/player/song-language.test.ts
+++ b/frontend/app/src/lib/player/song-language.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  resolveSongLanguageIndex,
+  songLanguageOptions,
+} from '@/lib/player/song-language'
+import type { ChordSongData } from '@/ports/chord-engine'
+
+describe('song-language', () => {
+  it('uses song language metadata for labels', () => {
+    expect(songLanguageOptions({ languages: ['en', 'de-CH'] })).toEqual([
+      { index: 0, label: 'en' },
+      { index: 1, label: 'de-CH' },
+    ])
+  })
+
+  it('falls back to lyric track count when metadata is missing', () => {
+    const songData: ChordSongData = {
+      sections: [
+        {
+          lines: [
+            {
+              parts: [{ comment: false, languages: ['Hello', 'Hallo'] }],
+            },
+          ],
+        },
+      ],
+    }
+
+    expect(songLanguageOptions(songData)).toEqual([
+      { index: 0, label: 'L1' },
+      { index: 1, label: 'L2' },
+    ])
+  })
+
+  it('ignores saved language indexes outside available options', () => {
+    const options = [
+      { index: 0, label: 'en' },
+      { index: 1, label: 'de' },
+    ]
+
+    expect(resolveSongLanguageIndex(options, 1)).toBe(1)
+    expect(resolveSongLanguageIndex(options, 2)).toBe(0)
+    expect(resolveSongLanguageIndex(options, -1)).toBe(0)
+  })
+})

--- a/frontend/app/src/lib/player/song-language.ts
+++ b/frontend/app/src/lib/player/song-language.ts
@@ -1,0 +1,64 @@
+import type { ChordSongData } from '@/ports/chord-engine'
+
+export type SongLanguageOption = {
+  index: number
+  label: string
+}
+
+function lyricTrackCount(songData: ChordSongData): number {
+  const sections = songData.sections
+  if (!Array.isArray(sections)) return 0
+
+  let count = 0
+  for (const section of sections) {
+    if (!section || typeof section !== 'object') continue
+    const lines = (section as { lines?: unknown }).lines
+    if (!Array.isArray(lines)) continue
+    for (const line of lines) {
+      if (!line || typeof line !== 'object') continue
+      const parts = (line as { parts?: unknown }).parts
+      if (!Array.isArray(parts)) continue
+      for (const part of parts) {
+        if (!part || typeof part !== 'object') continue
+        const languages = (part as { languages?: unknown }).languages
+        if (Array.isArray(languages)) count = Math.max(count, languages.length)
+      }
+    }
+  }
+
+  return count
+}
+
+function metadataLanguages(songData: ChordSongData): string[] {
+  const languages = songData.languages
+  if (!Array.isArray(languages)) return []
+  return languages.map((value) => (typeof value === 'string' ? value.trim() : ''))
+}
+
+export function fallbackSongLanguageLabel(index: number): string {
+  return `L${index + 1}`
+}
+
+export function songLanguageOptions(songData: ChordSongData): SongLanguageOption[] {
+  const metadata = metadataLanguages(songData)
+  const count = Math.max(metadata.length, lyricTrackCount(songData))
+  return Array.from({ length: count }, (_, index) => ({
+    index,
+    label: metadata[index] || fallbackSongLanguageLabel(index),
+  }))
+}
+
+export function resolveSongLanguageIndex(
+  options: SongLanguageOption[],
+  savedIndex: number | null | undefined,
+): number {
+  if (
+    typeof savedIndex === 'number' &&
+    Number.isInteger(savedIndex) &&
+    savedIndex >= 0 &&
+    savedIndex < options.length
+  ) {
+    return savedIndex
+  }
+  return 0
+}


### PR DESCRIPTION
## Summary
- Add a per-song language selector to the normal player header, positioned before the key selector.
- Persist selected lyric language per player item alongside transpose state.
- Pass the selected language index into single-page, multi-column, next-preview, and prefetch chord rendering.

## Validation
- `pnpm --filter app exec eslint . --fix` from `frontend/`
- `pnpm -C frontend lint`
- `pnpm -C frontend typecheck`
- `pnpm -C frontend test`
- `git diff --check` for touched frontend files

Note: local Node was `v26.0.0` while the project requests `>=20 <21`; all listed frontend gates passed.