### PR TITLE
Add multilingual TOC preference and selection

### DIFF
--- a/frontend/app/src/components/player/PlayerBook.tsx
+++ b/frontend/app/src/components/player/PlayerBook.tsx
@@ -23,6 +23,7 @@ import { useIsPhoneWidth, useMediaQuery } from '@/hooks/useMediaQuery'
 import { usePlayerLayoutPreference } from '@/hooks/usePlayerScrollPreference'
 import { useOnline } from '@/hooks/use-online'
 import { usePlayerIndexSearchSync } from '@/hooks/usePlayerIndexSearchSync'
+import { useTocMultilingualPreference } from '@/hooks/useTocMultilingualPreference'
 import { useSetlistEvictionWatch } from '@/hooks/useSetlistEvictionWatch'
 import { getChordEngine } from '@/lib/chord-engine'
 import { chordFormatToRepresentation, writeChordFormatPreference } from '@/lib/chord-format'
@@ -199,6 +200,7 @@ export function PlayerBook({
   const lastViewportTapTimeRef = useRef<number | null>(null)
   const [likeBurstKey, setLikeBurstKey] = useState(0)
   const [likeBurstActive, setLikeBurstActive] = useState(false)
+  const tocMultilingualEnabled = useTocMultilingualPreference()
 
   const [viewState, setViewState] = useState<PlayerViewState>(() => readPlayerViewState(type, id))
   const serverLikes = useMemo(() => initialLikedBySongId(player), [player])
@@ -421,12 +423,27 @@ export function PlayerBook({
       ? resolvePlayerItemKey(currentItem, type, slotKey, localTranspose)
       : null
   const currentLanguageOptions =
-    currentItem?.type === 'chords' ? songLanguageOptions(currentItem.song.data as Record<string, unknown>) : []
+    currentItem?.type === 'chords'
+      ? songLanguageOptions(currentItem.song.data as Record<string, unknown>)
+      : []
   const currentLanguageIndex =
-    currentItem?.type === 'chords' ? (selectedLanguageIndexForItem(currentItem, nav.index) ?? 0) : 0
+    currentItem?.type === 'chords'
+      ? selectedLanguageIndexForItem(currentItem, nav.index)
+      : null
   const currentLanguageLabel =
-    currentLanguageOptions[currentLanguageIndex]?.label ?? `L${currentLanguageIndex + 1}`
+    currentLanguageOptions[currentLanguageIndex ?? 0]?.label ??
+    `L${(currentLanguageIndex ?? 0) + 1}`
   const showLanguageSelector = currentItem?.type === 'chords' && currentLanguageOptions.length > 1
+
+  const handleTocSelect = useCallback(
+    (sourceIdx: number, languageIndex: number | null) => {
+      if (tocMultilingualEnabled && languageIndex != null) {
+        setViewState((state) => setLanguageForItem(state, sourceIdx, languageIndex))
+      }
+      dispatch({ type: 'jump', index: sourceIdx })
+    },
+    [dispatch, setViewState, tocMultilingualEnabled],
+  )
 
   const playerReturnContext = useMemo(
     () => ({ playerType: type, playerId: id, playerIndex: nav.index }),
@@ -1029,8 +1046,9 @@ export function PlayerBook({
                 <PlayerTocSidebar
                   toc={displayToc}
                   items={player.items}
-                  currentIndex={nav.index}
-                  onSelect={(idx) => dispatch({ type: 'jump', index: idx })}
+                  currentSourceIdx={nav.index}
+                  currentLanguageIndex={currentLanguageIndex}
+                  onSelect={handleTocSelect}
                 />
               </motion.div>
             ) : null}

--- a/frontend/app/src/components/player/PlayerTocSidebar.test.tsx
+++ b/frontend/app/src/components/player/PlayerTocSidebar.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { components } from '@/api/schema'
+import { PlayerTocSidebar } from '@/components/player/PlayerTocSidebar'
+
+const setMode = vi.fn()
+const setLanguageIds = vi.fn()
+const toggleLanguageId = vi.fn()
+const toggleTagId = vi.fn()
+
+let tocMultilingualEnabled = false
+let activeLanguageIds = new Set<string>()
+let activeTagIds = new Set<string>()
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('@/hooks/useTocMultilingualPreference', () => ({
+  useTocMultilingualPreference: () => tocMultilingualEnabled,
+}))
+
+vi.mock('@/hooks/usePlayerIndexSearchSync', () => ({
+  usePlayerTocSearchSync: () => ({
+    mode: 'order',
+    setMode,
+    setLanguageIds,
+    activeLanguageIds,
+    toggleLanguageId,
+    activeTagIds,
+    toggleTagId,
+  }),
+}))
+
+type PlayerItem = components['schemas']['PlayerItem']
+
+function chordPlayerItem(
+  id: string,
+  data: {
+    languages?: string[]
+    titles?: string[]
+    language?: string | null
+  },
+): PlayerItem {
+  return {
+    type: 'chords',
+    song: {
+      id,
+      blobs: [],
+      not_a_song: false,
+      owner: 'user:test',
+      user_specific_addons: { liked: false },
+      data: {
+        sections: [],
+        languages: data.languages,
+        titles: data.titles,
+      },
+    },
+    language: data.language ?? null,
+  } as PlayerItem
+}
+
+const toc = [{ idx: 0, nr: '1', title: 'Anchor', id: 'song-a', liked: false }]
+const items: PlayerItem[] = [
+  chordPlayerItem('song-a', { languages: ['en', 'de'], titles: ['Anchor', 'Anker'], language: 'de' }),
+]
+
+beforeEach(() => {
+  setMode.mockReset()
+  setLanguageIds.mockReset()
+  toggleLanguageId.mockReset()
+  toggleTagId.mockReset()
+  tocMultilingualEnabled = false
+  activeLanguageIds = new Set()
+  activeTagIds = new Set()
+})
+
+describe('PlayerTocSidebar', () => {
+  it('passes source index and language index when a TOC row is selected', async () => {
+    tocMultilingualEnabled = true
+    activeLanguageIds = new Set(['de'])
+    const onSelect = vi.fn()
+
+    render(
+      <PlayerTocSidebar
+        toc={toc}
+        items={items}
+        currentSourceIdx={0}
+        currentLanguageIndex={1}
+        onSelect={onSelect}
+      />,
+    )
+
+    await userEvent.click(screen.getByRole('option', { name: 'Anker' }))
+
+    expect(onSelect).toHaveBeenCalledWith(0, 1)
+  })
+
+  it('requires both source index and language index for the active state', () => {
+    tocMultilingualEnabled = true
+    activeLanguageIds = new Set(['de'])
+
+    const { rerender } = render(
+      <PlayerTocSidebar
+        toc={toc}
+        items={items}
+        currentSourceIdx={0}
+        currentLanguageIndex={0}
+        onSelect={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('option', { name: 'Anker' })).not.toHaveAttribute('aria-current')
+
+    rerender(
+      <PlayerTocSidebar
+        toc={toc}
+        items={items}
+        currentSourceIdx={0}
+        currentLanguageIndex={1}
+        onSelect={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('option', { name: 'Anker' })).toHaveAttribute('aria-current', 'true')
+  })
+
+  it('replaces the active language when multilingual TOC is enabled', async () => {
+    tocMultilingualEnabled = true
+    activeLanguageIds = new Set(['en'])
+
+    render(
+      <PlayerTocSidebar
+        toc={toc}
+        items={items}
+        currentSourceIdx={0}
+        currentLanguageIndex={1}
+        onSelect={vi.fn()}
+      />,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'de' }))
+    expect(setLanguageIds).toHaveBeenCalledWith(['de'])
+    expect(toggleLanguageId).not.toHaveBeenCalled()
+  })
+
+  it('clears the active language when the selected chip is clicked again', async () => {
+    tocMultilingualEnabled = true
+    activeLanguageIds = new Set(['de'])
+
+    render(
+      <PlayerTocSidebar
+        toc={toc}
+        items={items}
+        currentSourceIdx={0}
+        currentLanguageIndex={1}
+        onSelect={vi.fn()}
+      />,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'de' }))
+    expect(setLanguageIds).toHaveBeenCalledWith([])
+  })
+})

--- a/frontend/app/src/components/player/PlayerTocSidebar.tsx
+++ b/frontend/app/src/components/player/PlayerTocSidebar.tsx
@@ -3,17 +3,22 @@ import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
+  displayTocEntries,
+  tocDisplayNr,
+  type TocDisplayMode,
+} from '@/lib/player/toc-display'
+import {
   TocSortAlphabeticalIcon,
   TocSortLikedIcon,
   TocSortOrderIcon,
 } from '@/components/icons/toc-sort-icons'
 import { usePlayerTocSearchSync } from '@/hooks/usePlayerIndexSearchSync'
-import { displayTocEntries, tocDisplayNr, type TocDisplayMode } from '@/lib/player/toc-display'
 import {
   buildTocMetadataBySongId,
   collectTocLanguageFilterOptions,
   collectTocTagFilterOptions,
 } from '@/lib/player/toc-filters'
+import { useTocMultilingualPreference } from '@/hooks/useTocMultilingualPreference'
 import { PLAYER_TOC_WIDTH_CLASS } from '@/lib/player/player-chrome'
 import { cn } from '@/lib/utils'
 
@@ -25,8 +30,9 @@ type PlayerItem = components['schemas']['PlayerItem']
 type PlayerTocSidebarProps = {
   toc: TocItem[]
   items: PlayerItem[]
-  currentIndex: number
-  onSelect: (idx: number) => void
+  currentSourceIdx: number
+  currentLanguageIndex: number | null
+  onSelect: (sourceIdx: number, languageIndex: number | null) => void
 }
 
 const MODES: TocDisplayMode[] = ['order', 'alphabetical', 'liked']
@@ -45,11 +51,19 @@ const TOC_SORT_BUTTON_CLASS =
 const TOC_FILTER_CHIP_CLASS =
   'rounded-md px-[0.72rem] py-[0.36rem] text-sm leading-snug font-medium transition-colors'
 
-export function PlayerTocSidebar({ toc, items, currentIndex, onSelect }: PlayerTocSidebarProps) {
+export function PlayerTocSidebar({
+  toc,
+  items,
+  currentSourceIdx,
+  currentLanguageIndex,
+  onSelect,
+}: PlayerTocSidebarProps) {
   const { t } = useTranslation()
+  const tocMultilingualEnabled = useTocMultilingualPreference()
   const {
     mode,
     setMode,
+    setLanguageIds,
     activeLanguageIds,
     toggleLanguageId,
     activeTagIds,
@@ -69,8 +83,11 @@ export function PlayerTocSidebar({ toc, items, currentIndex, onSelect }: PlayerT
 
   const visibleLanguageIds = useMemo(() => {
     const valid = new Set(languageFilters.map((row) => row.id))
-    return new Set([...activeLanguageIds].filter((id) => valid.has(id)))
-  }, [activeLanguageIds, languageFilters])
+    const filtered = [...activeLanguageIds].filter((id) => valid.has(id))
+    if (!tocMultilingualEnabled) return new Set(filtered)
+    const first = filtered[0]
+    return first ? new Set([first]) : new Set<string>()
+  }, [activeLanguageIds, languageFilters, tocMultilingualEnabled])
 
   const visibleTagIds = useMemo(() => {
     const valid = new Set(tagFilters.map((row) => row.id))
@@ -84,8 +101,9 @@ export function PlayerTocSidebar({ toc, items, currentIndex, onSelect }: PlayerT
         metadataBySongId,
         activeLanguageIds: visibleLanguageIds,
         activeTagIds: visibleTagIds,
+        multilingualToc: tocMultilingualEnabled,
       }),
-    [visibleLanguageIds, visibleTagIds, items, metadataBySongId, mode, toc],
+    [visibleLanguageIds, visibleTagIds, items, metadataBySongId, mode, toc, tocMultilingualEnabled],
   )
 
   const modeLabels: Record<TocDisplayMode, string> = {
@@ -166,7 +184,14 @@ export function PlayerTocSidebar({ toc, items, currentIndex, onSelect }: PlayerT
                           ? 'bg-[var(--color-primary)] text-[var(--color-primary-foreground)]'
                           : 'bg-[var(--color-muted)] text-[var(--color-foreground)] hover:bg-[var(--color-muted)]/80',
                       )}
-                      onClick={() => toggleLanguageId(filter.id)}
+                      onClick={() => {
+                        if (tocMultilingualEnabled) {
+                          if (selected && visibleLanguageIds.size === 1) setLanguageIds([])
+                          else setLanguageIds([filter.id])
+                        } else {
+                          toggleLanguageId(filter.id)
+                        }
+                      }}
                     >
                       {filter.label}
                     </button>
@@ -219,9 +244,10 @@ export function PlayerTocSidebar({ toc, items, currentIndex, onSelect }: PlayerT
           </li>
         ) : (
           entries.map((row) => {
-            const active = row.idx === currentIndex
+            const active =
+              row.sourceIdx === currentSourceIdx && row.languageIndex === currentLanguageIndex
             return (
-              <li key={`${row.idx}-${row.title}`}>
+              <li key={row.key}>
                 <button
                   type="button"
                   role="option"
@@ -231,9 +257,10 @@ export function PlayerTocSidebar({ toc, items, currentIndex, onSelect }: PlayerT
                     'player-outline-list__item',
                     active && 'player-outline-list__item--selected',
                   )}
-                  onClick={() => onSelect(row.idx)}
+                  onClick={() => onSelect(row.sourceIdx, row.languageIndex)}
                 >
-                  {tocDisplayNr(toc, row)}. {row.title}
+                  {row.showNumber ? `${tocDisplayNr(toc, row.sourceIdx)}. ` : ''}
+                  {row.title}
                   {row.liked ? (
                     <>
                       {' '}

--- a/frontend/app/src/components/player/av/PlayerAv.tsx
+++ b/frontend/app/src/components/player/av/PlayerAv.tsx
@@ -64,6 +64,7 @@ import { buildSongEditorReturnSearch } from '@/lib/player/player-editor-return'
 import { tocEntryForIndex } from '@/lib/player/player-helpers'
 import type { PlayerEntityType } from '@/lib/player-route'
 import { buildSettingsSearch } from '@/lib/settings-route'
+import { languageIndexForSongLink } from '@/lib/setlist-song-links'
 import { cn } from '@/lib/utils'
 
 import './player-av.css'
@@ -246,6 +247,10 @@ export function PlayerAv({
   )
 
   const rawItem = player.items[session.itemIndex]
+  const currentLanguageIndex =
+    rawItem?.type === 'chords'
+      ? languageIndexForSongLink(rawItem.song.data as Record<string, unknown>, rawItem.language) ?? 0
+      : null
 
   const navigateToSongEditor = useCallback(() => {
     const item = player.items[session.itemIndex]
@@ -582,7 +587,8 @@ export function PlayerAv({
             <PlayerTocSidebar
               toc={player.toc}
               items={player.items}
-              currentIndex={session.itemIndex}
+              currentSourceIdx={session.itemIndex}
+              currentLanguageIndex={currentLanguageIndex}
               onSelect={(idx) => goToItem(idx)}
             />
           </div>

--- a/frontend/app/src/components/settings/SettingsView.tsx
+++ b/frontend/app/src/components/settings/SettingsView.tsx
@@ -60,6 +60,10 @@ import {
   readSheetImageInvertPreference,
   writeSheetImageInvertPreference,
 } from '@/lib/sheet-image-invert-preference'
+import {
+  readTocMultilingualPreference,
+  writeTocMultilingualPreference,
+} from '@/lib/toc-multilingual-preference'
 import { PlayerLayoutSettingsCard } from '@/components/settings/PlayerLayoutSettingsCard'
 import type { HubViewMode } from '@/lib/hub-view-mode'
 import { clearAllLocalData } from '@/lib/clear-local'
@@ -312,6 +316,7 @@ export function SettingsView({
   const [appearancePreference, setAppearancePreference] = useState(readAppearancePreference)
   const [chordFormatPreference, setChordFormatPreference] = useState(readChordFormatPreference)
   const [hideChords, setHideChordsState] = useState(readHideChordsPreference)
+  const [tocMultilingual, setTocMultilingualState] = useState(readTocMultilingualPreference)
   const [sheetBackgroundPreference, setSheetBackgroundPreference] = useState(readSheetBackgroundPreference)
   const [invertSheetImages, setInvertSheetImagesState] = useState(readSheetImageInvertPreference)
   const [layoutPreferences, setLayoutPreferences] = useState(readPlayerLayoutPreferences)
@@ -551,6 +556,11 @@ export function SettingsView({
   function setHideChords(enabled: boolean) {
     setHideChordsState(enabled)
     writeHideChordsPreference(enabled)
+  }
+
+  function setTocMultilingual(enabled: boolean) {
+    setTocMultilingualState(enabled)
+    writeTocMultilingualPreference(enabled)
   }
 
   function setSheetBackground(next: SheetBackgroundPreference) {
@@ -839,6 +849,26 @@ export function SettingsView({
             value={chordFormatPreference}
             onChange={setChordFormat}
           />
+
+          <Card>
+            <CardContent className="p-4">
+              <label className="flex items-start gap-3 text-sm">
+                <input
+                  type="checkbox"
+                  className="mt-0.5 size-4 shrink-0 accent-[var(--color-primary)]"
+                  aria-label={t('settings.tocMultilingual.label')}
+                  checked={tocMultilingual}
+                  onChange={(e) => setTocMultilingual(e.target.checked)}
+                />
+                <span className="flex flex-col gap-0.5">
+                  <span>{t('settings.tocMultilingual.label')}</span>
+                  <span className="text-xs text-[var(--color-muted-foreground)]">
+                    {t('settings.tocMultilingual.description')}
+                  </span>
+                </span>
+              </label>
+            </CardContent>
+          </Card>
 
           <Card>
             <CardContent className="p-4">

--- a/frontend/app/src/components/settings/settings-view.test.tsx
+++ b/frontend/app/src/components/settings/settings-view.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SettingsView } from '@/components/settings/SettingsView'
+
+const navigate = vi.fn()
+const setViewMode = vi.fn()
+const ensureQueryData = vi.fn().mockResolvedValue(undefined)
+const setQueryData = vi.fn()
+const localStorageState = new Map<string, string>()
+const localStorageMock = {
+  getItem: vi.fn((key: string) => localStorageState.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    localStorageState.set(key, value)
+  }),
+  removeItem: vi.fn((key: string) => {
+    localStorageState.delete(key)
+  }),
+  clear: vi.fn(() => {
+    localStorageState.clear()
+  }),
+}
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => navigate,
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ ensureQueryData, setQueryData }),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) =>
+      options ? `${key} ${JSON.stringify(options)}` : key,
+    i18n: { changeLanguage: vi.fn().mockResolvedValue(undefined) },
+  }),
+}))
+
+vi.mock('@/hooks/useSession', () => ({
+  useSession: () => ({ data: null }),
+}))
+
+vi.mock('@/hooks/useHubViewMode', () => ({
+  useHubViewMode: () => ({ viewMode: 'list', setViewMode }),
+}))
+
+vi.mock('@/lib/clear-local', () => ({
+  clearAllLocalData: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/api/session', () => ({
+  fetchSessionUser: vi.fn().mockResolvedValue(null),
+  SESSION_QUERY_KEY: ['session'],
+  SESSION_STALE_TIME_MS: 0,
+}))
+
+vi.mock('@/lib/offline/player-mirror-cache', () => ({
+  estimateKvTableBytes: vi.fn().mockResolvedValue(0),
+  estimateOfflinePlayerCacheBytes: vi.fn().mockResolvedValue(0),
+  listPlayerMirrors: vi.fn().mockResolvedValue([]),
+  removePlayerMirror: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/lib/logout-queue', () => ({
+  performLogout: vi.fn().mockResolvedValue(undefined),
+}))
+
+beforeEach(() => {
+  navigate.mockReset()
+  setViewMode.mockReset()
+  setQueryData.mockReset()
+  ensureQueryData.mockReset().mockResolvedValue(undefined)
+  localStorageState.clear()
+  vi.stubGlobal('localStorage', localStorageMock)
+  localStorageMock.getItem.mockClear()
+  localStorageMock.setItem.mockClear()
+  localStorageMock.removeItem.mockClear()
+  localStorageMock.clear.mockClear()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('SettingsView', () => {
+  it('renders the TOC multilingual control in the Player tab and restores it from storage', async () => {
+    const user = userEvent.setup()
+
+    const { unmount } = render(<SettingsView activeTab="player" />)
+    const toggle = screen.getByRole('checkbox', {
+      name: 'settings.tocMultilingual.label',
+    })
+
+    expect(toggle).not.toBeChecked()
+
+    await user.click(toggle)
+
+    expect(toggle).toBeChecked()
+    expect(window.localStorage.getItem('wv_toc_multilingual')).toBe('true')
+
+    unmount()
+
+    render(<SettingsView activeTab="player" />)
+    expect(
+      screen.getByRole('checkbox', { name: 'settings.tocMultilingual.label' }),
+    ).toBeChecked()
+  })
+})

--- a/frontend/app/src/hooks/usePlayerIndexSearchSync.ts
+++ b/frontend/app/src/hooks/usePlayerIndexSearchSync.ts
@@ -108,6 +108,13 @@ export function usePlayerTocSearchSync() {
     [updateToc],
   )
 
+  const setLanguageIds = useCallback(
+    (languageIds: readonly string[]) => {
+      updateToc({ tocLang: languageIds })
+    },
+    [updateToc],
+  )
+
   const toggleLanguageId = useCallback(
     (languageId: string) => {
       const next = new Set(activeLanguageIds)
@@ -131,6 +138,7 @@ export function usePlayerTocSearchSync() {
   return {
     mode,
     setMode,
+    setLanguageIds,
     activeLanguageIds,
     toggleLanguageId,
     activeTagIds,

--- a/frontend/app/src/hooks/useTocMultilingualPreference.ts
+++ b/frontend/app/src/hooks/useTocMultilingualPreference.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react'
+
+import {
+  TOC_MULTILINGUAL_CHANGE_EVENT,
+  readTocMultilingualPreference,
+} from '@/lib/toc-multilingual-preference'
+
+export function useTocMultilingualPreference(): boolean {
+  const [enabled, setEnabled] = useState(readTocMultilingualPreference)
+
+  useEffect(() => {
+    const onChange = (event: Event) => {
+      const detail = (event as CustomEvent<boolean>).detail
+      setEnabled(detail ?? readTocMultilingualPreference())
+    }
+
+    globalThis.window.addEventListener(TOC_MULTILINGUAL_CHANGE_EVENT, onChange)
+    return () => globalThis.window.removeEventListener(TOC_MULTILINGUAL_CHANGE_EVENT, onChange)
+  }, [])
+
+  return enabled
+}

--- a/frontend/app/src/i18n/de.json
+++ b/frontend/app/src/i18n/de.json
@@ -493,6 +493,10 @@
       "nashville": "Nashville",
       "nashvilleDescription": "Zeigt Nashville-Ziffern wie 1, 4 und 6m."
     },
+    "tocMultilingual": {
+      "label": "Mehrsprachige Liedtitel im Inhaltsverzeichnis erweitern",
+      "description": "Zeigt im Inhaltsverzeichnis bei aktivem Sprachfilter den passenden übersetzten Titel. Die Erweiterung für A–Z und Favoriten folgt später."
+    },
     "hideChords": {
       "label": "Akkorde im Player und Export ausblenden",
       "description": "Zeigt im Player und beim Export von PDF- oder Textdateien nur Songtext. Der Song-Editor bleibt unverändert."

--- a/frontend/app/src/i18n/en.json
+++ b/frontend/app/src/i18n/en.json
@@ -493,6 +493,10 @@
       "nashville": "Nashville",
       "nashvilleDescription": "Show Nashville numbers such as 1, 4, and 6m."
     },
+    "tocMultilingual": {
+      "label": "Expand multilingual song titles in the TOC",
+      "description": "Use the matching translated title in the table of contents when a language filter is active. Alphabetical and liked expansion will come later."
+    },
     "hideChords": {
       "label": "Hide chords in player and exports",
       "description": "Show only song lyrics in the player and when exporting PDF or text files. The song editor is not affected."

--- a/frontend/app/src/lib/player/toc-display.test.ts
+++ b/frontend/app/src/lib/player/toc-display.test.ts
@@ -1,43 +1,114 @@
 import { describe, expect, it } from 'vitest'
 
+import type { components } from '@/api/schema'
+
 import { displayTocEntries, tocDisplayNr } from '@/lib/player/toc-display'
+import { buildTocMetadataBySongId } from '@/lib/player/toc-filters'
+
+type PlayerItem = components['schemas']['PlayerItem']
+
+function chordPlayerItem(
+  id: string,
+  data: {
+    languages?: string[]
+    titles?: string[]
+    language?: string | null
+  },
+): PlayerItem {
+  return {
+    type: 'chords',
+    song: {
+      id,
+      blobs: [],
+      not_a_song: false,
+      owner: 'user:test',
+      user_specific_addons: { liked: false },
+      data: {
+        sections: [],
+        languages: data.languages,
+        titles: data.titles,
+      },
+    },
+    language: data.language ?? null,
+  } as PlayerItem
+}
 
 const toc = [
-  { idx: 0, nr: '1', title: 'Zebra', liked: false },
-  { idx: 1, nr: '2', title: 'Alpha', liked: true },
-  { idx: 2, nr: '3', title: 'Beta', liked: false },
+  { idx: 0, nr: '1', title: 'Anchor', id: 'song-a', liked: false },
+  { idx: 1, nr: '2', title: 'Beta', id: 'song-b', liked: true },
+  { idx: 2, nr: '3', title: 'PDF', liked: false },
+  { idx: 3, nr: '', title: 'Anchor', id: 'song-a', liked: false },
 ]
 
+const items: PlayerItem[] = [
+  chordPlayerItem('song-a', { languages: ['en', 'de'], titles: ['Anchor', 'Anker'], language: 'en' }),
+  chordPlayerItem('song-b', { languages: ['en'], titles: ['Beta'], language: 'en' }),
+  { type: 'blob', blob_id: 'blob:1' } as PlayerItem,
+  chordPlayerItem('song-a', { languages: ['en', 'de'], titles: ['Anchor', 'Anker'], language: 'de' }),
+]
+
+const metadata = buildTocMetadataBySongId(items)
+
+function displayOrder(multilingualToc: boolean, activeLanguageIds = new Set<string>()) {
+  return displayTocEntries(toc, 'order', {
+    items,
+    metadataBySongId: metadata,
+    activeLanguageIds,
+    activeTagIds: new Set(),
+    multilingualToc,
+  })
+}
+
 describe('displayTocEntries', () => {
-  it('keeps API order by default', () => {
-    expect(displayTocEntries(toc, 'order').map((r) => r.title)).toEqual(['Zebra', 'Alpha', 'Beta'])
+  it('keeps current order behavior when multilingual TOC is off', () => {
+    const entries = displayOrder(false)
+    expect(entries.map((row) => row.title)).toEqual(['Anchor', 'Beta', 'PDF', 'Anchor'])
+    expect(entries.map((row) => row.languageIndex)).toEqual([0, 0, null, 1])
+    expect(entries.every((row) => row.showNumber)).toBe(true)
+    expect(new Set(entries.map((row) => row.key)).size).toBe(entries.length)
   })
 
-  it('sorts alphabetically by title', () => {
-    expect(displayTocEntries(toc, 'alphabetical').map((r) => r.title)).toEqual([
-      'Alpha',
-      'Beta',
-      'Zebra',
-    ])
+  it('keeps one row per source item when multilingual TOC is on without a language filter', () => {
+    const entries = displayOrder(true)
+    expect(entries.map((row) => row.title)).toEqual(['Anchor', 'Beta', 'PDF', 'Anchor'])
+    expect(entries.map((row) => row.languageIndex)).toEqual([0, 0, null, 1])
   })
 
-  it('filters to liked rows only', () => {
-    expect(displayTocEntries(toc, 'liked')).toEqual([toc[1]])
+  it('uses the translated title and language index for an active language filter', () => {
+    const entries = displayOrder(true, new Set(['de']))
+    expect(entries.map((row) => row.title)).toEqual(['Anker', 'PDF', 'Anker'])
+    expect(entries.map((row) => row.languageIndex)).toEqual([1, null, 1])
+    expect(entries.map((row) => tocDisplayNr(toc, row.sourceIdx))).toEqual(['1', '3', '4'])
+  })
+
+  it('keeps blob rows visible when language filters are active', () => {
+    const entries = displayOrder(true, new Set(['de']))
+    expect(entries.find((row) => row.sourceIdx === 2)).toEqual(
+      expect.objectContaining({
+        title: 'PDF',
+        languageIndex: null,
+      }),
+    )
+  })
+
+  it('keeps keys stable for duplicate source items', () => {
+    const entries = displayOrder(true, new Set(['de']))
+    const keys = entries.map((row) => row.key)
+    expect(new Set(keys).size).toBe(keys.length)
+    expect(keys[0]).not.toBe(keys[2])
   })
 })
 
 describe('tocDisplayNr', () => {
   it('uses explicit nr when present', () => {
-    expect(tocDisplayNr(toc, toc[1]!)).toBe('2')
+    expect(tocDisplayNr(toc, 1)).toBe('2')
   })
 
   it('falls back to 1-based order index when nr is blank', () => {
-    const row = { idx: 1, nr: '', title: 'Alpha', liked: true }
-    expect(tocDisplayNr(toc, row)).toBe('2')
+    expect(tocDisplayNr(toc, 3)).toBe('4')
   })
 
   it('keeps collection order number when sorted alphabetically', () => {
-    const row = { idx: 0, nr: '', title: 'Zebra', liked: false }
-    expect(tocDisplayNr(toc, row)).toBe('1')
+    expect(tocDisplayNr(toc, 0)).toBe('1')
   })
 })

--- a/frontend/app/src/lib/player/toc-display.ts
+++ b/frontend/app/src/lib/player/toc-display.ts
@@ -1,17 +1,36 @@
 import type { components } from '@/api/schema'
 
 import { applyTocMetadataFilters, type TocSongMetadata } from '@/lib/player/toc-filters'
+import {
+  languageIndexForSongLink,
+  songTitleForLanguage,
+} from '@/lib/setlist-song-links'
 
+type PlayerItem = components['schemas']['PlayerItem']
 type TocItem = components['schemas']['TocItem']
 
 export type TocDisplayMode = 'order' | 'alphabetical' | 'liked'
 
+export type TocDisplayEntry = {
+  key: string
+  sourceIdx: number
+  title: string
+  languageIndex: number | null
+  liked: boolean
+  showNumber: boolean
+}
+
 /** Display number for a TOC row; falls back to 1-based position in the source list. */
-export function tocDisplayNr(toc: TocItem[], row: TocItem): string {
-  const nr = row.nr.trim()
+export function tocDisplayNr(toc: TocItem[], rowOrSourceIdx: TocItem | number): string {
+  const sourceIdx = typeof rowOrSourceIdx === 'number' ? rowOrSourceIdx : rowOrSourceIdx.idx
+  const row =
+    typeof rowOrSourceIdx === 'number'
+      ? toc.find((entry) => entry.idx === sourceIdx)
+      : rowOrSourceIdx
+  const nr = row?.nr.trim() ?? ''
   if (nr) return nr
-  const orderIndex = toc.findIndex((entry) => entry.idx === row.idx)
-  return String(orderIndex >= 0 ? orderIndex + 1 : row.idx + 1)
+  const orderIndex = toc.findIndex((entry) => entry.idx === sourceIdx)
+  return String(orderIndex >= 0 ? orderIndex + 1 : sourceIdx + 1)
 }
 
 export type TocMetadataFilters = {
@@ -20,27 +39,110 @@ export type TocMetadataFilters = {
   activeTagIds: ReadonlySet<string>
 }
 
+export type TocDisplayFilters = TocMetadataFilters & {
+  items: PlayerItem[]
+  multilingualToc: boolean
+}
+
+function firstLanguageId(ids: ReadonlySet<string>): string | undefined {
+  for (const id of ids) return id
+  return undefined
+}
+
+function displayEntryKey(sourceIdx: number, languageIndex: number | null, rowId?: string): string {
+  return [rowId ?? 'toc', sourceIdx, languageIndex ?? 'slot'].join(':')
+}
+
+function resolveDisplayLanguageId(filters: TocDisplayFilters): string | undefined {
+  if (!filters.multilingualToc) return undefined
+  return firstLanguageId(filters.activeLanguageIds)
+}
+
+function displayEntryForRow(
+  row: TocItem,
+  items: PlayerItem[],
+  multilingualToc: boolean,
+  languageId: string | undefined,
+): TocDisplayEntry {
+  const item = items[row.idx]
+  const sourceIdx = row.idx
+  const liked = row.liked
+  const showNumber = true
+
+  if (multilingualToc && item?.type === 'chords' && languageId) {
+    const languageIndex = languageIndexForSongLink(item.song.data as Record<string, unknown>, languageId)
+    return {
+      key: displayEntryKey(sourceIdx, languageIndex ?? null, row.id ?? undefined),
+      sourceIdx,
+      title: songTitleForLanguage(item.song.data as Record<string, unknown>, languageId, row.title),
+      languageIndex: languageIndex ?? 0,
+      liked,
+      showNumber,
+    }
+  }
+
+  const languageIndex =
+    item?.type === 'chords'
+      ? languageIndexForSongLink(item.song.data as Record<string, unknown>, item.language) ?? 0
+      : null
+
+  return {
+    key: displayEntryKey(sourceIdx, languageIndex, row.id ?? undefined),
+    sourceIdx,
+    title: row.title,
+    languageIndex,
+    liked,
+    showNumber,
+  }
+}
+
 export function displayTocEntries(
   toc: TocItem[],
   mode: TocDisplayMode,
-  metadataFilters?: TocMetadataFilters & { items: components['schemas']['PlayerItem'][] },
-): TocItem[] {
-  let rows = metadataFilters
-    ? applyTocMetadataFilters(
-        toc,
-        metadataFilters.items,
-        metadataFilters.metadataBySongId,
-        metadataFilters.activeLanguageIds,
-        metadataFilters.activeTagIds,
-      )
-    : toc
+  metadataFilters?: TocDisplayFilters,
+): TocDisplayEntry[] {
+  if (!metadataFilters) {
+    return toc.map((row) => ({
+      key: displayEntryKey(row.idx, null, row.id ?? undefined),
+      sourceIdx: row.idx,
+      title: row.title,
+      languageIndex: null,
+      liked: row.liked,
+      showNumber: true,
+    }))
+  }
+
+  const languageId = resolveDisplayLanguageId(metadataFilters)
+  const effectiveLanguageIds =
+    metadataFilters.multilingualToc && languageId
+      ? new Set([languageId])
+      : metadataFilters.activeLanguageIds
+
+  const rows = applyTocMetadataFilters(
+    toc,
+    metadataFilters.items,
+    metadataFilters.metadataBySongId,
+    effectiveLanguageIds,
+    metadataFilters.activeTagIds,
+  )
 
   if (mode === 'liked') {
-    rows = rows.filter((row) => row.liked)
-  } else if (mode === 'alphabetical') {
-    rows = [...rows].sort((a, b) =>
-      a.title.localeCompare(b.title, undefined, { sensitivity: 'base' }),
-    )
+    return rows
+      .filter((row) => row.liked)
+      .map((row) =>
+        displayEntryForRow(row, metadataFilters.items, metadataFilters.multilingualToc, languageId),
+      )
   }
-  return rows
+
+  if (mode === 'alphabetical') {
+    return [...rows]
+      .sort((a, b) => a.title.localeCompare(b.title, undefined, { sensitivity: 'base' }))
+      .map((row) =>
+        displayEntryForRow(row, metadataFilters.items, metadataFilters.multilingualToc, languageId),
+      )
+  }
+
+  return rows.map((row) =>
+    displayEntryForRow(row, metadataFilters.items, metadataFilters.multilingualToc, languageId),
+  )
 }

--- a/frontend/app/src/lib/player/toc-filters.ts
+++ b/frontend/app/src/lib/player/toc-filters.ts
@@ -151,6 +151,8 @@ export function applyTocMetadataFilters(
   if (activeLanguageIds.size === 0 && activeTagIds.size === 0) return toc
 
   return toc.filter((row) => {
+    if (items[row.idx]?.type === 'blob') return true
+
     const meta = resolveTocRowMetadata(row, items, metadataBySongId)
     if (!meta) return false
 

--- a/frontend/app/src/lib/toc-multilingual-preference.test.ts
+++ b/frontend/app/src/lib/toc-multilingual-preference.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  TOC_MULTILINGUAL_STORAGE_KEY,
+  readTocMultilingualPreference,
+  writeTocMultilingualPreference,
+} from '@/lib/toc-multilingual-preference'
+
+describe('readTocMultilingualPreference', () => {
+  it('defaults to false when unset', () => {
+    expect(readTocMultilingualPreference({ getItem: () => null })).toBe(false)
+  })
+
+  it('reads stored boolean strings', () => {
+    expect(readTocMultilingualPreference({ getItem: () => 'true' })).toBe(true)
+    expect(readTocMultilingualPreference({ getItem: () => 'false' })).toBe(false)
+  })
+
+  it('falls back to false for malformed storage', () => {
+    expect(readTocMultilingualPreference({ getItem: () => 'yes' })).toBe(false)
+  })
+})
+
+describe('writeTocMultilingualPreference', () => {
+  it('stores and clears the preference', () => {
+    const storage = new Map<string, string>()
+    const mockStorage = {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        storage.set(key, value)
+      },
+      removeItem: (key: string) => {
+        storage.delete(key)
+      },
+    }
+
+    writeTocMultilingualPreference(true, mockStorage)
+    expect(storage.get(TOC_MULTILINGUAL_STORAGE_KEY)).toBe('true')
+    writeTocMultilingualPreference(false, mockStorage)
+    expect(storage.has(TOC_MULTILINGUAL_STORAGE_KEY)).toBe(false)
+  })
+
+  it('notifies listeners when window is available', () => {
+    const dispatchEvent = vi.fn()
+    vi.stubGlobal('window', { dispatchEvent })
+
+    writeTocMultilingualPreference(true, { setItem: vi.fn(), removeItem: vi.fn() })
+
+    expect(dispatchEvent).toHaveBeenCalledOnce()
+    vi.unstubAllGlobals()
+  })
+})

--- a/frontend/app/src/lib/toc-multilingual-preference.ts
+++ b/frontend/app/src/lib/toc-multilingual-preference.ts
@@ -1,0 +1,28 @@
+import { getLocalStorage, safeGetItem, safeRemoveItem, safeSetItem } from '@/lib/browser-storage'
+
+export const TOC_MULTILINGUAL_STORAGE_KEY = 'wv_toc_multilingual'
+
+export const TOC_MULTILINGUAL_CHANGE_EVENT = 'wv-toc-multilingual-change'
+
+export function readTocMultilingualPreference(
+  storage: Pick<Storage, 'getItem'> | null = getLocalStorage(),
+): boolean {
+  return safeGetItem(TOC_MULTILINGUAL_STORAGE_KEY, storage) === 'true'
+}
+
+export function writeTocMultilingualPreference(
+  enabled: boolean,
+  storage: Pick<Storage, 'setItem' | 'removeItem'> | null = getLocalStorage(),
+): void {
+  if (enabled) {
+    safeSetItem(TOC_MULTILINGUAL_STORAGE_KEY, 'true', storage)
+  } else {
+    safeRemoveItem(TOC_MULTILINGUAL_STORAGE_KEY, storage)
+  }
+
+  if (typeof globalThis.window !== 'undefined') {
+    globalThis.window.dispatchEvent(
+      new CustomEvent(TOC_MULTILINGUAL_CHANGE_EVENT, { detail: enabled }),
+    )
+  }
+}


### PR DESCRIPTION
Implements E1.1: language-aware TOC rendering in order mode, plus the new `wv_toc_multilingual` preference in Settings → Player.

What changed:
- Adds a persisted boolean preference for multilingual TOC expansion.
- Wires the new preference through the Book and AV player TOC selection contract.
- Updates TOC display entries to carry explicit source/language identity.
- Makes language chips single-select only when multilingual TOC is enabled.
- Adds focused tests for preference persistence, TOC display, sidebar selection, and settings UI.

Validation:
- `pnpm --filter app exec eslint . --fix`
- `pnpm -C frontend lint`
- `pnpm -C frontend typecheck`
- `pnpm -C frontend test`