### PR TITLE
[codex] e1.2 alphabetical toc expansion

### DIFF
--- a/frontend/app/src/components/player/PlayerTocSidebar.test.tsx
+++ b/frontend/app/src/components/player/PlayerTocSidebar.test.tsx
@@ -11,6 +11,7 @@ const toggleLanguageId = vi.fn()
 const toggleTagId = vi.fn()
 
 let tocMultilingualEnabled = false
+let tocMode: 'order' | 'alphabetical' | 'liked' = 'order'
 let activeLanguageIds = new Set<string>()
 let activeTagIds = new Set<string>()
 
@@ -26,7 +27,7 @@ vi.mock('@/hooks/useTocMultilingualPreference', () => ({
 
 vi.mock('@/hooks/usePlayerIndexSearchSync', () => ({
   usePlayerTocSearchSync: () => ({
-    mode: 'order',
+    mode: tocMode,
     setMode,
     setLanguageIds,
     activeLanguageIds,
@@ -66,7 +67,11 @@ function chordPlayerItem(
 
 const toc = [{ idx: 0, nr: '1', title: 'Anchor', id: 'song-a', liked: false }]
 const items: PlayerItem[] = [
-  chordPlayerItem('song-a', { languages: ['en', 'de'], titles: ['Anchor', 'Anker'], language: 'de' }),
+  chordPlayerItem('song-a', {
+    languages: ['en', 'de'],
+    titles: ['Anchor', 'Anker'],
+    language: 'de',
+  }),
 ]
 
 beforeEach(() => {
@@ -75,14 +80,15 @@ beforeEach(() => {
   toggleLanguageId.mockReset()
   toggleTagId.mockReset()
   tocMultilingualEnabled = false
+  tocMode = 'order'
   activeLanguageIds = new Set()
   activeTagIds = new Set()
 })
 
 describe('PlayerTocSidebar', () => {
-  it('passes source index and language index when a TOC row is selected', async () => {
+  it('passes source index and language index when a translated alphabetical row is selected', async () => {
     tocMultilingualEnabled = true
-    activeLanguageIds = new Set(['de'])
+    tocMode = 'alphabetical'
     const onSelect = vi.fn()
 
     render(
@@ -100,9 +106,9 @@ describe('PlayerTocSidebar', () => {
     expect(onSelect).toHaveBeenCalledWith(0, 1)
   })
 
-  it('requires both source index and language index for the active state', () => {
+  it('highlights only the exact source and language pair', () => {
     tocMultilingualEnabled = true
-    activeLanguageIds = new Set(['de'])
+    tocMode = 'alphabetical'
 
     const { rerender } = render(
       <PlayerTocSidebar
@@ -114,6 +120,7 @@ describe('PlayerTocSidebar', () => {
       />,
     )
 
+    expect(screen.getByRole('option', { name: 'Anchor' })).toHaveAttribute('aria-current', 'true')
     expect(screen.getByRole('option', { name: 'Anker' })).not.toHaveAttribute('aria-current')
 
     rerender(
@@ -126,12 +133,13 @@ describe('PlayerTocSidebar', () => {
       />,
     )
 
+    expect(screen.getByRole('option', { name: 'Anchor' })).not.toHaveAttribute('aria-current')
     expect(screen.getByRole('option', { name: 'Anker' })).toHaveAttribute('aria-current', 'true')
   })
 
-  it('replaces the active language when multilingual TOC is enabled', async () => {
+  it('does not render numbers on translated alphabetical rows', () => {
     tocMultilingualEnabled = true
-    activeLanguageIds = new Set(['en'])
+    tocMode = 'alphabetical'
 
     render(
       <PlayerTocSidebar
@@ -143,26 +151,8 @@ describe('PlayerTocSidebar', () => {
       />,
     )
 
-    await userEvent.click(screen.getByRole('button', { name: 'de' }))
-    expect(setLanguageIds).toHaveBeenCalledWith(['de'])
-    expect(toggleLanguageId).not.toHaveBeenCalled()
-  })
-
-  it('clears the active language when the selected chip is clicked again', async () => {
-    tocMultilingualEnabled = true
-    activeLanguageIds = new Set(['de'])
-
-    render(
-      <PlayerTocSidebar
-        toc={toc}
-        items={items}
-        currentSourceIdx={0}
-        currentLanguageIndex={1}
-        onSelect={vi.fn()}
-      />,
-    )
-
-    await userEvent.click(screen.getByRole('button', { name: 'de' }))
-    expect(setLanguageIds).toHaveBeenCalledWith([])
+    expect(screen.getByRole('option', { name: 'Anchor' })).toHaveTextContent('Anchor')
+    expect(screen.getByRole('option', { name: 'Anker' })).toHaveTextContent('Anker')
+    expect(screen.getByRole('option', { name: 'Anker' })).not.toHaveTextContent('1.')
   })
 })

--- a/frontend/app/src/lib/player/toc-display.test.ts
+++ b/frontend/app/src/lib/player/toc-display.test.ts
@@ -35,22 +35,44 @@ function chordPlayerItem(
 
 const toc = [
   { idx: 0, nr: '1', title: 'Anchor', id: 'song-a', liked: false },
-  { idx: 1, nr: '2', title: 'Beta', id: 'song-b', liked: true },
-  { idx: 2, nr: '3', title: 'PDF', liked: false },
-  { idx: 3, nr: '', title: 'Anchor', id: 'song-a', liked: false },
+  { idx: 1, nr: '2', title: 'Boat', id: 'song-b', liked: true },
+  { idx: 2, nr: '3', title: 'Zzz Blob', liked: false },
+  { idx: 3, nr: '4', title: 'Cedar', id: 'song-c', liked: false },
+  { idx: 4, nr: '', title: 'Anchor', id: 'song-a', liked: false },
 ]
 
 const items: PlayerItem[] = [
-  chordPlayerItem('song-a', { languages: ['en', 'de'], titles: ['Anchor', 'Anker'], language: 'en' }),
-  chordPlayerItem('song-b', { languages: ['en'], titles: ['Beta'], language: 'en' }),
+  chordPlayerItem('song-a', {
+    languages: ['en', 'de'],
+    titles: ['Anchor', 'Anker'],
+    language: 'en',
+  }),
+  chordPlayerItem('song-b', {
+    languages: ['en'],
+    titles: ['Boat'],
+    language: 'en',
+  }),
   { type: 'blob', blob_id: 'blob:1' } as PlayerItem,
-  chordPlayerItem('song-a', { languages: ['en', 'de'], titles: ['Anchor', 'Anker'], language: 'de' }),
+  chordPlayerItem('song-c', {
+    languages: ['en', 'de', 'fr'],
+    titles: ['Cedar', 'Cedro', 'Cypress'],
+    language: 'fr',
+  }),
+  chordPlayerItem('song-a', {
+    languages: ['en', 'de'],
+    titles: ['Anchor', 'Anker'],
+    language: 'de',
+  }),
 ]
 
 const metadata = buildTocMetadataBySongId(items)
 
-function displayOrder(multilingualToc: boolean, activeLanguageIds = new Set<string>()) {
-  return displayTocEntries(toc, 'order', {
+function displayEntries(
+  mode: 'order' | 'alphabetical' | 'liked',
+  multilingualToc: boolean,
+  activeLanguageIds = new Set<string>(),
+) {
+  return displayTocEntries(toc, mode, {
     items,
     metadataBySongId: metadata,
     activeLanguageIds,
@@ -61,41 +83,60 @@ function displayOrder(multilingualToc: boolean, activeLanguageIds = new Set<stri
 
 describe('displayTocEntries', () => {
   it('keeps current order behavior when multilingual TOC is off', () => {
-    const entries = displayOrder(false)
-    expect(entries.map((row) => row.title)).toEqual(['Anchor', 'Beta', 'PDF', 'Anchor'])
-    expect(entries.map((row) => row.languageIndex)).toEqual([0, 0, null, 1])
+    const entries = displayEntries('order', false)
+    expect(entries.map((row) => row.title)).toEqual(['Anchor', 'Boat', 'Zzz Blob', 'Cedar', 'Anchor'])
+    expect(entries.map((row) => row.languageIndex)).toEqual([0, 0, null, 2, 1])
     expect(entries.every((row) => row.showNumber)).toBe(true)
     expect(new Set(entries.map((row) => row.key)).size).toBe(entries.length)
   })
 
-  it('keeps one row per source item when multilingual TOC is on without a language filter', () => {
-    const entries = displayOrder(true)
-    expect(entries.map((row) => row.title)).toEqual(['Anchor', 'Beta', 'PDF', 'Anchor'])
-    expect(entries.map((row) => row.languageIndex)).toEqual([0, 0, null, 1])
+  it('keeps one row per source item in alphabetical mode when multilingual TOC is off', () => {
+    const entries = displayEntries('alphabetical', false)
+    expect(entries.map((row) => row.title)).toEqual(['Anchor', 'Anchor', 'Boat', 'Cedar', 'Zzz Blob'])
+    expect(entries.map((row) => row.languageIndex)).toEqual([0, 1, 0, 2, null])
+    expect(entries.every((row) => row.showNumber)).toBe(true)
   })
 
-  it('uses the translated title and language index for an active language filter', () => {
-    const entries = displayOrder(true, new Set(['de']))
-    expect(entries.map((row) => row.title)).toEqual(['Anker', 'PDF', 'Anker'])
-    expect(entries.map((row) => row.languageIndex)).toEqual([1, null, 1])
-    expect(entries.map((row) => tocDisplayNr(toc, row.sourceIdx))).toEqual(['1', '3', '4'])
+  it('expands alphabetical rows to every translated title when multilingual TOC is on', () => {
+    const entries = displayEntries('alphabetical', true)
+    expect(entries.map((row) => row.title)).toEqual([
+      'Anchor',
+      'Anchor',
+      'Anker',
+      'Anker',
+      'Boat',
+      'Cedar',
+      'Cedro',
+      'Cypress',
+      'Zzz Blob',
+    ])
+    expect(entries.map((row) => row.sourceIdx)).toEqual([0, 4, 0, 4, 1, 3, 3, 3, 2])
+    expect(entries.map((row) => row.languageIndex)).toEqual([0, 0, 1, 1, 0, 0, 1, 2, null])
+    expect(entries.every((row) => !row.showNumber)).toBe(true)
+    expect(new Set(entries.map((row) => row.key)).size).toBe(entries.length)
   })
 
-  it('keeps blob rows visible when language filters are active', () => {
-    const entries = displayOrder(true, new Set(['de']))
-    expect(entries.find((row) => row.sourceIdx === 2)).toEqual(
-      expect.objectContaining({
-        title: 'PDF',
-        languageIndex: null,
-      }),
-    )
+  it('keeps translated rows stable for duplicate setlist occurrences', () => {
+    const entries = displayEntries('alphabetical', true)
+    const duplicateAnchors = entries.filter((row) => row.title === 'Anchor')
+    expect(duplicateAnchors.map((row) => row.sourceIdx)).toEqual([0, 4])
+    expect(duplicateAnchors.map((row) => row.languageIndex)).toEqual([0, 0])
+    expect(duplicateAnchors[0]?.key).not.toBe(duplicateAnchors[1]?.key)
   })
 
-  it('keeps keys stable for duplicate source items', () => {
-    const entries = displayOrder(true, new Set(['de']))
-    const keys = entries.map((row) => row.key)
-    expect(new Set(keys).size).toBe(keys.length)
-    expect(keys[0]).not.toBe(keys[2])
+  it('collapses alphabetical expansion to the active language when a language filter is set', () => {
+    const entries = displayEntries('alphabetical', true, new Set(['de']))
+    expect(entries.map((row) => row.title)).toEqual(['Anker', 'Anker', 'Cedro', 'Zzz Blob'])
+    expect(entries.map((row) => row.sourceIdx)).toEqual([0, 4, 3, 2])
+    expect(entries.map((row) => row.languageIndex)).toEqual([1, 1, 1, null])
+    expect(entries.every((row) => !row.showNumber)).toBe(true)
+  })
+
+  it('keeps liked mode one row per source item', () => {
+    const entries = displayEntries('liked', true)
+    expect(entries.map((row) => row.title)).toEqual(['Boat'])
+    expect(entries.map((row) => row.languageIndex)).toEqual([0])
+    expect(entries.every((row) => row.showNumber)).toBe(true)
   })
 })
 
@@ -105,7 +146,7 @@ describe('tocDisplayNr', () => {
   })
 
   it('falls back to 1-based order index when nr is blank', () => {
-    expect(tocDisplayNr(toc, 3)).toBe('4')
+    expect(tocDisplayNr(toc, 4)).toBe('5')
   })
 
   it('keeps collection order number when sorted alphabetically', () => {

--- a/frontend/app/src/lib/player/toc-display.ts
+++ b/frontend/app/src/lib/player/toc-display.ts
@@ -4,6 +4,7 @@ import { applyTocMetadataFilters, type TocSongMetadata } from '@/lib/player/toc-
 import {
   languageIndexForSongLink,
   songTitleForLanguage,
+  songTitleVariantsForDisplay,
 } from '@/lib/setlist-song-links'
 
 type PlayerItem = components['schemas']['PlayerItem']
@@ -63,11 +64,27 @@ function displayEntryForRow(
   items: PlayerItem[],
   multilingualToc: boolean,
   languageId: string | undefined,
+  override?: {
+    title: string
+    languageIndex: number | null
+    showNumber?: boolean
+  },
 ): TocDisplayEntry {
   const item = items[row.idx]
   const sourceIdx = row.idx
   const liked = row.liked
-  const showNumber = true
+  const showNumber = override?.showNumber ?? true
+
+  if (override) {
+    return {
+      key: displayEntryKey(sourceIdx, override.languageIndex, row.id ?? undefined),
+      sourceIdx,
+      title: override.title,
+      languageIndex: override.languageIndex,
+      liked,
+      showNumber,
+    }
+  }
 
   if (multilingualToc && item?.type === 'chords' && languageId) {
     const languageIndex = languageIndexForSongLink(item.song.data as Record<string, unknown>, languageId)
@@ -94,6 +111,57 @@ function displayEntryForRow(
     liked,
     showNumber,
   }
+}
+
+function compareDisplayEntries(a: TocDisplayEntry, b: TocDisplayEntry): number {
+  const titleCompare = a.title.localeCompare(b.title, undefined, { sensitivity: 'base' })
+  if (titleCompare !== 0) return titleCompare
+  if (a.sourceIdx !== b.sourceIdx) return a.sourceIdx - b.sourceIdx
+  const aLanguageIndex = a.languageIndex ?? -1
+  const bLanguageIndex = b.languageIndex ?? -1
+  if (aLanguageIndex !== bLanguageIndex) return aLanguageIndex - bLanguageIndex
+  return a.key.localeCompare(b.key)
+}
+
+function displayEntriesForRow(
+  row: TocItem,
+  items: PlayerItem[],
+  multilingualToc: boolean,
+  languageId: string | undefined,
+  mode: TocDisplayMode,
+): TocDisplayEntry[] {
+  const item = items[row.idx]
+  if (mode === 'alphabetical' && multilingualToc && !languageId && item?.type === 'chords') {
+    const variants = songTitleVariantsForDisplay(item.song.data as Record<string, unknown>, row.title)
+    if (variants.length > 1) {
+      return variants.map((variant) =>
+        displayEntryForRow(row, items, multilingualToc, languageId, {
+          title: variant.title,
+          languageIndex: variant.languageIndex,
+          showNumber: false,
+        }),
+      )
+    }
+    const variant = variants[0]
+    return [
+      displayEntryForRow(row, items, multilingualToc, languageId, {
+        title: variant?.title ?? row.title,
+        languageIndex: variant?.languageIndex ?? 0,
+        showNumber: false,
+      }),
+    ]
+  }
+  if (mode === 'alphabetical' && multilingualToc && item?.type === 'chords') {
+    const baseEntry = displayEntryForRow(row, items, multilingualToc, languageId)
+    return [
+      displayEntryForRow(row, items, multilingualToc, languageId, {
+        title: baseEntry.title,
+        languageIndex: baseEntry.languageIndex,
+        showNumber: false,
+      }),
+    ]
+  }
+  return [displayEntryForRow(row, items, multilingualToc, languageId)]
 }
 
 export function displayTocEntries(
@@ -135,11 +203,20 @@ export function displayTocEntries(
   }
 
   if (mode === 'alphabetical') {
-    return [...rows]
-      .sort((a, b) => a.title.localeCompare(b.title, undefined, { sensitivity: 'base' }))
-      .map((row) =>
-        displayEntryForRow(row, metadataFilters.items, metadataFilters.multilingualToc, languageId),
+    const entries = rows
+      .flatMap((row) =>
+        displayEntriesForRow(
+          row,
+          metadataFilters.items,
+          metadataFilters.multilingualToc,
+          languageId,
+          mode,
+        ),
       )
+      .sort(compareDisplayEntries)
+    return metadataFilters.multilingualToc
+      ? entries.map((entry) => ({ ...entry, showNumber: false }))
+      : entries
   }
 
   return rows.map((row) =>

--- a/frontend/app/src/lib/setlist-song-links.test.ts
+++ b/frontend/app/src/lib/setlist-song-links.test.ts
@@ -20,6 +20,7 @@ import {
   songLanguageOptions,
   songArtistForLanguage,
   songTitleForLanguage,
+  songTitleVariantsForDisplay,
   songLinkForCollectionMutation,
   songLinkForSetlistMutation,
   songLinkTempoEditorToWire,
@@ -154,6 +155,21 @@ describe('song link language helpers', () => {
     expect(songTitleForLanguage(data, 'de')).toBe('Anker')
     expect(songTitleForLanguage(data, 'fr')).toBe('Anchor')
     expect(songTitleForLanguage({ titles: [] }, null, '—')).toBe('—')
+  })
+
+  it('returns non-empty title variants in slot order for TOC expansion', () => {
+    expect(
+      songTitleVariantsForDisplay(
+        { titles: ['Anchor', ' ', 'Anker'], languages: ['en', 'de', 'fr'] },
+        'Fallback',
+      ),
+    ).toEqual([
+      { languageIndex: 0, title: 'Anchor' },
+      { languageIndex: 2, title: 'Anker' },
+    ])
+    expect(songTitleVariantsForDisplay({ titles: [], languages: [] }, 'Fallback')).toEqual([
+      { languageIndex: 0, title: 'Fallback' },
+    ])
   })
 
   it('resolves parallel artists from selected language tags', () => {

--- a/frontend/app/src/lib/setlist-song-links.ts
+++ b/frontend/app/src/lib/setlist-song-links.ts
@@ -163,6 +163,39 @@ export function songTitleForLanguage(
   return (languageIndex != null ? titleAt(languageIndex) : null) ?? titleAt(0) ?? fallback
 }
 
+export type SongTitleVariant = {
+  languageIndex: number
+  title: string
+}
+
+/**
+ * Return the non-empty title variants stored in a song's metadata.
+ *
+ * Titles are kept in language-slot order so the TOC can fan out one row per translated title.
+ * When a song has no titles at all, keep a single fallback row for the caller-provided display
+ * title so single-language songs still render.
+ */
+export function songTitleVariantsForDisplay(
+  data: Record<string, unknown> | undefined | null,
+  fallback = '',
+): SongTitleVariant[] {
+  const titles = Array.isArray(data?.titles) ? data.titles : []
+  const variants: SongTitleVariant[] = []
+
+  for (let index = 0; index < titles.length; index += 1) {
+    const value = titles[index]
+    if (typeof value !== 'string') continue
+    const title = value.trim()
+    if (!title) continue
+    variants.push({ languageIndex: index, title })
+  }
+
+  if (variants.length > 0) return variants
+
+  const fallbackTitle = fallback.trim()
+  return fallbackTitle ? [{ languageIndex: 0, title: fallbackTitle }] : []
+}
+
 /** Resolve a song artist using the setlist slot language when parallel artists are available. */
 export function songArtistForLanguage(
   data: Record<string, unknown> | undefined | null,


### PR DESCRIPTION
## Summary

Implements multilingual alphabetical TOC expansion so translated song titles fan out into separate rows when `wv_toc_multilingual` is enabled.

## What changed

- Expanded multilingual alphabetical TOC rows to one entry per non-empty translated title.
- Kept order mode behavior unchanged.
- Made numbering consistent in multilingual alphabetical mode by removing numbers from all TOC rows there.
- Added unit coverage for expansion, sorting, duplicate stability, language-filter collapse, and sidebar selection/highlight behavior.

## Validation

- `pnpm --filter app exec eslint . --fix`
- `pnpm -C frontend lint`
- `pnpm -C frontend typecheck`
- `pnpm -C frontend test`
- `pnpm -C frontend build`
