### PR TITLE
[codex] fan out liked TOC translations

### DIFF
--- a/frontend/app/src/components/player/PlayerTocSidebar.test.tsx
+++ b/frontend/app/src/components/player/PlayerTocSidebar.test.tsx
@@ -106,6 +106,31 @@ describe('PlayerTocSidebar', () => {
     expect(onSelect).toHaveBeenCalledWith(0, 1)
   })
 
+  it('renders liked multilingual rows with hearts and no numbers', async () => {
+    tocMultilingualEnabled = true
+    tocMode = 'liked'
+    const onSelect = vi.fn()
+
+    render(
+      <PlayerTocSidebar
+        toc={[{ ...toc[0]!, liked: true }]}
+        items={items}
+        currentSourceIdx={0}
+        currentLanguageIndex={1}
+        onSelect={onSelect}
+      />,
+    )
+
+    const row = screen.getByRole('option', { name: 'Anker' })
+    expect(row).toHaveTextContent('Anker')
+    expect(row).toHaveTextContent('♥')
+    expect(row).not.toHaveTextContent('1.')
+
+    await userEvent.click(row)
+
+    expect(onSelect).toHaveBeenCalledWith(0, 1)
+  })
+
   it('highlights only the exact source and language pair', () => {
     tocMultilingualEnabled = true
     tocMode = 'alphabetical'
@@ -137,9 +162,10 @@ describe('PlayerTocSidebar', () => {
     expect(screen.getByRole('option', { name: 'Anker' })).toHaveAttribute('aria-current', 'true')
   })
 
-  it('does not render numbers on translated alphabetical rows', () => {
+  it('replaces the active language when multilingual TOC is enabled', async () => {
     tocMultilingualEnabled = true
     tocMode = 'alphabetical'
+    activeLanguageIds = new Set(['en'])
 
     render(
       <PlayerTocSidebar
@@ -151,8 +177,27 @@ describe('PlayerTocSidebar', () => {
       />,
     )
 
-    expect(screen.getByRole('option', { name: 'Anchor' })).toHaveTextContent('Anchor')
-    expect(screen.getByRole('option', { name: 'Anker' })).toHaveTextContent('Anker')
-    expect(screen.getByRole('option', { name: 'Anker' })).not.toHaveTextContent('1.')
+    await userEvent.click(screen.getByRole('button', { name: 'de' }))
+    expect(setLanguageIds).toHaveBeenCalledWith(['de'])
+    expect(toggleLanguageId).not.toHaveBeenCalled()
+  })
+
+  it('clears the active language when the selected chip is clicked again', async () => {
+    tocMultilingualEnabled = true
+    tocMode = 'alphabetical'
+    activeLanguageIds = new Set(['de'])
+
+    render(
+      <PlayerTocSidebar
+        toc={toc}
+        items={items}
+        currentSourceIdx={0}
+        currentLanguageIndex={1}
+        onSelect={vi.fn()}
+      />,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'de' }))
+    expect(setLanguageIds).toHaveBeenCalledWith([])
   })
 })

--- a/frontend/app/src/lib/player/toc-display.test.ts
+++ b/frontend/app/src/lib/player/toc-display.test.ts
@@ -34,11 +34,11 @@ function chordPlayerItem(
 }
 
 const toc = [
-  { idx: 0, nr: '1', title: 'Anchor', id: 'song-a', liked: false },
-  { idx: 1, nr: '2', title: 'Boat', id: 'song-b', liked: true },
-  { idx: 2, nr: '3', title: 'Zzz Blob', liked: false },
-  { idx: 3, nr: '4', title: 'Cedar', id: 'song-c', liked: false },
-  { idx: 4, nr: '', title: 'Anchor', id: 'song-a', liked: false },
+  { idx: 0, nr: '1', title: 'Anchor', id: 'song-a', liked: true },
+  { idx: 1, nr: '2', title: 'Boat', id: 'song-b', liked: false },
+  { idx: 2, nr: '3', title: 'PDF', liked: false },
+  { idx: 3, nr: '4', title: 'Cedar', id: 'song-c', liked: true },
+  { idx: 4, nr: '', title: 'Anchor', id: 'song-a', liked: true },
 ]
 
 const items: PlayerItem[] = [
@@ -55,7 +55,7 @@ const items: PlayerItem[] = [
   { type: 'blob', blob_id: 'blob:1' } as PlayerItem,
   chordPlayerItem('song-c', {
     languages: ['en', 'de', 'fr'],
-    titles: ['Cedar', 'Cedro', 'Cypress'],
+    titles: ['Cedar', ' ', 'Cypress'],
     language: 'fr',
   }),
   chordPlayerItem('song-a', {
@@ -84,20 +84,21 @@ function displayEntries(
 describe('displayTocEntries', () => {
   it('keeps current order behavior when multilingual TOC is off', () => {
     const entries = displayEntries('order', false)
-    expect(entries.map((row) => row.title)).toEqual(['Anchor', 'Boat', 'Zzz Blob', 'Cedar', 'Anchor'])
+    expect(entries.map((row) => row.title)).toEqual(['Anchor', 'Boat', 'PDF', 'Cedar', 'Anchor'])
     expect(entries.map((row) => row.languageIndex)).toEqual([0, 0, null, 2, 1])
     expect(entries.every((row) => row.showNumber)).toBe(true)
     expect(new Set(entries.map((row) => row.key)).size).toBe(entries.length)
   })
 
-  it('keeps one row per source item in alphabetical mode when multilingual TOC is off', () => {
-    const entries = displayEntries('alphabetical', false)
-    expect(entries.map((row) => row.title)).toEqual(['Anchor', 'Anchor', 'Boat', 'Cedar', 'Zzz Blob'])
-    expect(entries.map((row) => row.languageIndex)).toEqual([0, 1, 0, 2, null])
+  it('keeps current liked behavior when multilingual TOC is off', () => {
+    const entries = displayEntries('liked', false)
+    expect(entries.map((row) => row.title)).toEqual(['Anchor', 'Cedar', 'Anchor'])
+    expect(entries.map((row) => row.sourceIdx)).toEqual([0, 3, 4])
+    expect(entries.map((row) => row.languageIndex)).toEqual([0, 2, 1])
     expect(entries.every((row) => row.showNumber)).toBe(true)
   })
 
-  it('expands alphabetical rows to every translated title when multilingual TOC is on', () => {
+  it('expands alphabetical rows to every non-empty translated title and skips blanks', () => {
     const entries = displayEntries('alphabetical', true)
     expect(entries.map((row) => row.title)).toEqual([
       'Anchor',
@@ -106,37 +107,41 @@ describe('displayTocEntries', () => {
       'Anker',
       'Boat',
       'Cedar',
-      'Cedro',
       'Cypress',
-      'Zzz Blob',
+      'PDF',
     ])
-    expect(entries.map((row) => row.sourceIdx)).toEqual([0, 4, 0, 4, 1, 3, 3, 3, 2])
-    expect(entries.map((row) => row.languageIndex)).toEqual([0, 0, 1, 1, 0, 0, 1, 2, null])
+    expect(entries.map((row) => row.sourceIdx)).toEqual([0, 4, 0, 4, 1, 3, 3, 2])
+    expect(entries.map((row) => row.languageIndex)).toEqual([0, 0, 1, 1, 0, 0, 2, null])
     expect(entries.every((row) => !row.showNumber)).toBe(true)
     expect(new Set(entries.map((row) => row.key)).size).toBe(entries.length)
   })
 
-  it('keeps translated rows stable for duplicate setlist occurrences', () => {
-    const entries = displayEntries('alphabetical', true)
-    const duplicateAnchors = entries.filter((row) => row.title === 'Anchor')
-    expect(duplicateAnchors.map((row) => row.sourceIdx)).toEqual([0, 4])
-    expect(duplicateAnchors.map((row) => row.languageIndex)).toEqual([0, 0])
-    expect(duplicateAnchors[0]?.key).not.toBe(duplicateAnchors[1]?.key)
-  })
-
-  it('collapses alphabetical expansion to the active language when a language filter is set', () => {
-    const entries = displayEntries('alphabetical', true, new Set(['de']))
-    expect(entries.map((row) => row.title)).toEqual(['Anker', 'Anker', 'Cedro', 'Zzz Blob'])
-    expect(entries.map((row) => row.sourceIdx)).toEqual([0, 4, 3, 2])
-    expect(entries.map((row) => row.languageIndex)).toEqual([1, 1, 1, null])
-    expect(entries.every((row) => !row.showNumber)).toBe(true)
-  })
-
-  it('keeps liked mode one row per source item', () => {
+  it('keeps liked fan-out in source order and preserves hearts', () => {
     const entries = displayEntries('liked', true)
-    expect(entries.map((row) => row.title)).toEqual(['Boat'])
-    expect(entries.map((row) => row.languageIndex)).toEqual([0])
+    expect(entries.map((row) => row.title)).toEqual(['Anchor', 'Anker', 'Cedar', 'Cypress', 'Anchor', 'Anker'])
+    expect(entries.map((row) => row.sourceIdx)).toEqual([0, 0, 3, 3, 4, 4])
+    expect(entries.map((row) => row.languageIndex)).toEqual([0, 1, 0, 2, 0, 1])
+    expect(entries.every((row) => row.liked)).toBe(true)
+    expect(entries.every((row) => !row.showNumber)).toBe(true)
+    expect(new Set(entries.map((row) => row.key)).size).toBe(entries.length)
+    expect(entries[0]?.key).not.toBe(entries[4]?.key)
+  })
+
+  it('uses the filtered language in order mode and omits missing translated titles', () => {
+    const entries = displayEntries('order', true, new Set(['de']))
+    expect(entries.map((row) => row.title)).toEqual(['Anker', 'PDF', 'Anker'])
+    expect(entries.map((row) => row.sourceIdx)).toEqual([0, 2, 4])
+    expect(entries.map((row) => row.languageIndex)).toEqual([1, null, 1])
     expect(entries.every((row) => row.showNumber)).toBe(true)
+  })
+
+  it('collapses liked mode to the filtered language and omits missing translated titles', () => {
+    const entries = displayEntries('liked', true, new Set(['de']))
+    expect(entries.map((row) => row.title)).toEqual(['Anker', 'Anker'])
+    expect(entries.map((row) => row.sourceIdx)).toEqual([0, 4])
+    expect(entries.map((row) => row.languageIndex)).toEqual([1, 1])
+    expect(entries.every((row) => row.liked)).toBe(true)
+    expect(entries.every((row) => !row.showNumber)).toBe(true)
   })
 })
 

--- a/frontend/app/src/lib/player/toc-display.ts
+++ b/frontend/app/src/lib/player/toc-display.ts
@@ -1,11 +1,7 @@
 import type { components } from '@/api/schema'
 
 import { applyTocMetadataFilters, type TocSongMetadata } from '@/lib/player/toc-filters'
-import {
-  languageIndexForSongLink,
-  songTitleForLanguage,
-  songTitleVariantsForDisplay,
-} from '@/lib/setlist-song-links'
+import { languageIndexForSongLink, songTitleVariantsForDisplay } from '@/lib/setlist-song-links'
 
 type PlayerItem = components['schemas']['PlayerItem']
 type TocItem = components['schemas']['TocItem']
@@ -59,57 +55,55 @@ function resolveDisplayLanguageId(filters: TocDisplayFilters): string | undefine
   return firstLanguageId(filters.activeLanguageIds)
 }
 
-function displayEntryForRow(
-  row: TocItem,
-  items: PlayerItem[],
-  multilingualToc: boolean,
-  languageId: string | undefined,
-  override?: {
-    title: string
-    languageIndex: number | null
-    showNumber?: boolean
-  },
-): TocDisplayEntry {
+function titleAtLanguageIndex(
+  data: Record<string, unknown> | undefined | null,
+  languageIndex: number,
+): string | null {
+  const titles = Array.isArray(data?.titles) ? data.titles : []
+  const value = titles[languageIndex]
+  if (typeof value !== 'string') return null
+  const title = value.trim()
+  return title.length > 0 ? title : null
+}
+
+function displayEntryForRow(row: TocItem, items: PlayerItem[], showNumber: boolean): TocDisplayEntry {
   const item = items[row.idx]
-  const sourceIdx = row.idx
-  const liked = row.liked
-  const showNumber = override?.showNumber ?? true
-
-  if (override) {
-    return {
-      key: displayEntryKey(sourceIdx, override.languageIndex, row.id ?? undefined),
-      sourceIdx,
-      title: override.title,
-      languageIndex: override.languageIndex,
-      liked,
-      showNumber,
-    }
-  }
-
-  if (multilingualToc && item?.type === 'chords' && languageId) {
-    const languageIndex = languageIndexForSongLink(item.song.data as Record<string, unknown>, languageId)
-    return {
-      key: displayEntryKey(sourceIdx, languageIndex ?? null, row.id ?? undefined),
-      sourceIdx,
-      title: songTitleForLanguage(item.song.data as Record<string, unknown>, languageId, row.title),
-      languageIndex: languageIndex ?? 0,
-      liked,
-      showNumber,
-    }
-  }
-
   const languageIndex =
     item?.type === 'chords'
       ? languageIndexForSongLink(item.song.data as Record<string, unknown>, item.language) ?? 0
       : null
 
   return {
-    key: displayEntryKey(sourceIdx, languageIndex, row.id ?? undefined),
-    sourceIdx,
+    key: displayEntryKey(row.idx, languageIndex, row.id ?? undefined),
+    sourceIdx: row.idx,
     title: row.title,
     languageIndex,
-    liked,
+    liked: row.liked,
     showNumber,
+  }
+}
+
+function strictEntryForLanguageId(
+  row: TocItem,
+  items: PlayerItem[],
+  languageId: string,
+): TocDisplayEntry | null {
+  const item = items[row.idx]
+  if (item?.type !== 'chords') return null
+
+  const languageIndex = languageIndexForSongLink(item.song.data as Record<string, unknown>, languageId)
+  if (languageIndex == null) return null
+
+  const title = titleAtLanguageIndex(item.song.data as Record<string, unknown>, languageIndex)
+  if (!title) return null
+
+  return {
+    key: displayEntryKey(row.idx, languageIndex, row.id ?? undefined),
+    sourceIdx: row.idx,
+    title,
+    languageIndex,
+    liked: row.liked,
+    showNumber: true,
   }
 }
 
@@ -131,37 +125,30 @@ function displayEntriesForRow(
   mode: TocDisplayMode,
 ): TocDisplayEntry[] {
   const item = items[row.idx]
-  if (mode === 'alphabetical' && multilingualToc && !languageId && item?.type === 'chords') {
+  const showNumber = mode === 'order' || !multilingualToc
+
+  if (item?.type === 'blob') {
+    return [displayEntryForRow(row, items, showNumber)]
+  }
+
+  if (multilingualToc && languageId) {
+    const strictEntry = strictEntryForLanguageId(row, items, languageId)
+    return strictEntry ? [{ ...strictEntry, showNumber: mode === 'order' }] : []
+  }
+
+  if (multilingualToc && item?.type === 'chords' && mode !== 'order') {
     const variants = songTitleVariantsForDisplay(item.song.data as Record<string, unknown>, row.title)
-    if (variants.length > 1) {
-      return variants.map((variant) =>
-        displayEntryForRow(row, items, multilingualToc, languageId, {
-          title: variant.title,
-          languageIndex: variant.languageIndex,
-          showNumber: false,
-        }),
-      )
-    }
-    const variant = variants[0]
-    return [
-      displayEntryForRow(row, items, multilingualToc, languageId, {
-        title: variant?.title ?? row.title,
-        languageIndex: variant?.languageIndex ?? 0,
-        showNumber: false,
-      }),
-    ]
+    return variants.map((variant) => ({
+      key: displayEntryKey(row.idx, variant.languageIndex, row.id ?? undefined),
+      sourceIdx: row.idx,
+      title: variant.title,
+      languageIndex: variant.languageIndex,
+      liked: row.liked,
+      showNumber: false,
+    }))
   }
-  if (mode === 'alphabetical' && multilingualToc && item?.type === 'chords') {
-    const baseEntry = displayEntryForRow(row, items, multilingualToc, languageId)
-    return [
-      displayEntryForRow(row, items, multilingualToc, languageId, {
-        title: baseEntry.title,
-        languageIndex: baseEntry.languageIndex,
-        showNumber: false,
-      }),
-    ]
-  }
-  return [displayEntryForRow(row, items, multilingualToc, languageId)]
+
+  return [displayEntryForRow(row, items, showNumber)]
 }
 
 export function displayTocEntries(
@@ -197,13 +184,6 @@ export function displayTocEntries(
   if (mode === 'liked') {
     return rows
       .filter((row) => row.liked)
-      .map((row) =>
-        displayEntryForRow(row, metadataFilters.items, metadataFilters.multilingualToc, languageId),
-      )
-  }
-
-  if (mode === 'alphabetical') {
-    const entries = rows
       .flatMap((row) =>
         displayEntriesForRow(
           row,
@@ -213,13 +193,35 @@ export function displayTocEntries(
           mode,
         ),
       )
-      .sort(compareDisplayEntries)
+      .map((entry) => ({
+        ...entry,
+        showNumber: metadataFilters.multilingualToc ? false : entry.showNumber,
+      }))
+  }
+
+  if (mode === 'alphabetical') {
+    const entries = rows.flatMap((row) =>
+      displayEntriesForRow(
+        row,
+        metadataFilters.items,
+        metadataFilters.multilingualToc,
+        languageId,
+        mode,
+      ),
+    )
+    entries.sort(compareDisplayEntries)
     return metadataFilters.multilingualToc
       ? entries.map((entry) => ({ ...entry, showNumber: false }))
       : entries
   }
 
-  return rows.map((row) =>
-    displayEntryForRow(row, metadataFilters.items, metadataFilters.multilingualToc, languageId),
+  return rows.flatMap((row) =>
+    displayEntriesForRow(
+      row,
+      metadataFilters.items,
+      metadataFilters.multilingualToc,
+      languageId,
+      mode,
+    ),
   )
 }


### PR DESCRIPTION
## Summary
- Extend multilingual TOC expansion so `liked` mode behaves like `alphabetical` mode when `wv_toc_multilingual` is enabled.
- Skip empty translated titles and stop falling back to the source title when the selected language is missing.
- Keep blob rows and the existing TOC selection contract intact.

## Validation
- `pnpm --filter app exec vitest run src/lib/player/toc-display.test.ts src/components/player/PlayerTocSidebar.test.tsx`
- `pnpm --filter app exec eslint . --fix`
- `pnpm -C frontend lint`
- `pnpm -C frontend typecheck`
- `pnpm -C frontend test`
- `pnpm -C frontend build`