### PR TITLE
feat(cli): restore API parity with hub search, transfer, and covers

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2289,6 +2289,7 @@ dependencies = [
  "chrono",
  "clap",
  "dirs",
+ "reqwest",
  "serde",
  "serde_json",
  "shared",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,4 +17,5 @@ serde_json = "1.0.149"
 toml = "1.1.2"
 dirs = "6.0.0"
 shared = { path = "../shared", features = ["cli"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -8,30 +8,63 @@ use crate::output::OutputFormat;
 #[command(
     name = "worshipviewer",
     version,
-    about = "CLI for the Worship Viewer REST API"
+    about = "AI-friendly CLI for the Worship Viewer REST API",
+    long_about = "Talk to Worship Viewer from the terminal. Output is JSON by default when \
+                  piped; use --output pretty for human-readable output on a TTY.\n\n\
+                  Authenticate with --sso-session, --bearer-token, or `auth otp-verify`. \
+                  Configure defaults in ~/.worshipviewer/config.toml.\n\n\
+                  Examples:\n  \
+                  worshipviewer songs list --q grace --sort relevance\n  \
+                  worshipviewer collections transfer-song COL_ID SONG_ID --json '{\"target\":\"OTHER_COL\"}'\n  \
+                  worshipviewer setlists player SETLIST_ID --output pretty"
 )]
 pub struct Cli {
-    #[arg(long, global = true)]
+    #[arg(
+        long,
+        global = true,
+        env = "WORSHIPVIEWER_BASE_URL",
+        help = "API base URL (default http://127.0.0.1:8080 or config file)"
+    )]
     pub base_url: Option<String>,
 
-    #[arg(long, global = true)]
+    #[arg(
+        long,
+        global = true,
+        env = "WORSHIPVIEWER_SSO_SESSION",
+        help = "Session cookie value for sso_session"
+    )]
     pub sso_session: Option<String>,
 
-    #[arg(long, env = "WORSHIPVIEWER_BEARER_TOKEN", global = true)]
+    #[arg(
+        long,
+        env = "WORSHIPVIEWER_BEARER_TOKEN",
+        global = true,
+        help = "Bearer token (session id) for Authorization header"
+    )]
     pub bearer_token: Option<String>,
 
     #[arg(
         long,
         env = "WORSHIPVIEWER_OUTPUT",
         default_value = "auto",
-        global = true
+        global = true,
+        help = "Output format: auto, json, pretty, ndjson (one JSON object per line for lists)"
     )]
     pub output: OutputFormat,
 
-    #[arg(long, global = true)]
+    #[arg(
+        long,
+        global = true,
+        help = "Print planned HTTP request without sending (mutations only)"
+    )]
     pub dry_run: bool,
 
-    #[arg(long, env = "WORSHIPVIEWER_TIMEOUT_SECS", global = true)]
+    #[arg(
+        long,
+        env = "WORSHIPVIEWER_TIMEOUT_SECS",
+        global = true,
+        help = "HTTP timeout in seconds"
+    )]
     pub timeout_secs: Option<u64>,
 
     #[command(subcommand)]
@@ -42,7 +75,9 @@ pub struct Cli {
 pub enum Command {
     /// Public server metadata (no auth).
     About,
+    /// Fetch or inspect the live OpenAPI schema.
     Schema(SchemaArgs),
+    /// OTP login and logout.
     Auth {
         #[command(subcommand)]
         command: AuthCommand,
@@ -81,28 +116,93 @@ pub enum Command {
     },
 }
 
+/// Pagination flags shared by list commands.
+#[derive(Debug, Args, Clone, Default)]
+pub struct PageArgs {
+    #[arg(long, help = "Zero-based page index")]
+    pub page: Option<u32>,
+
+    #[arg(long, help = "Items per page (default 50, max 500)")]
+    pub page_size: Option<u32>,
+
+    #[arg(
+        long,
+        help = "Include X-Total-Count and Link headers in a pagination wrapper (json/pretty only)"
+    )]
+    pub with_meta: bool,
+}
+
+/// Search and team filter for hub list routes.
+#[derive(Debug, Args, Clone, Default)]
+pub struct HubFilterArgs {
+    #[arg(
+        long,
+        help = "Search query (title, name, or lyrics depending on resource)"
+    )]
+    pub q: Option<String>,
+
+    #[arg(long, help = "Filter by owning team id")]
+    pub team: Option<String>,
+}
+
+/// List flags for collections, setlists, and teams.
+#[derive(Debug, Args, Clone, Default)]
+pub struct HubListArgs {
+    #[command(flatten)]
+    pub page: PageArgs,
+
+    #[command(flatten)]
+    pub filter: HubFilterArgs,
+}
+
+/// List flags for songs (includes sort, language, and tag filters).
+#[derive(Debug, Args, Clone, Default)]
+pub struct SongListArgs {
+    #[command(flatten)]
+    pub page: PageArgs,
+
+    #[command(flatten)]
+    pub filter: HubFilterArgs,
+
+    #[arg(
+        long,
+        help = "Sort order: -id (default), title, -title, relevance (requires --q), id"
+    )]
+    pub sort: Option<String>,
+
+    #[arg(
+        long,
+        help = "Filter songs whose metadata includes this BCP 47 language tag"
+    )]
+    pub lang: Option<String>,
+
+    #[arg(long, help = "Filter by tag substring")]
+    pub tag: Option<String>,
+}
+
 #[derive(Debug, Args)]
 pub struct SchemaArgs {
     #[command(subcommand)]
     pub command: Option<SchemaCommand>,
 
-    #[arg(long)]
+    #[arg(long, help = "Only include OpenAPI paths starting with this prefix")]
     pub path_prefix: Option<String>,
 }
 
 #[derive(Debug, Subcommand)]
 pub enum SchemaCommand {
+    /// Resolve a CLI domain/action pair to request/response schemas.
     Inspect { domain: String, action: String },
 }
 
 #[derive(Debug, Subcommand)]
 pub enum AuthCommand {
     OtpRequest {
-        #[arg(long)]
+        #[arg(long, help = "JSON body, e.g. {\"email\":\"you@example.com\"}")]
         json: String,
     },
     OtpVerify {
-        #[arg(long)]
+        #[arg(long, help = "JSON body with email and code")]
         json: String,
     },
     Logout,
@@ -110,12 +210,10 @@ pub enum AuthCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum UsersCommand {
-    /// List all users.
+    /// List all users (admin).
     List {
-        #[arg(long)]
-        page: Option<u32>,
-        #[arg(long)]
-        page_size: Option<u32>,
+        #[command(flatten)]
+        page: PageArgs,
     },
     /// Get a single user by id.
     Get {
@@ -132,7 +230,7 @@ pub enum UsersCommand {
     /// Upload profile picture from a file (`PUT .../profile-picture`).
     ProfilePicturePut {
         file: PathBuf,
-        #[arg(long)]
+        #[arg(long, help = "MIME type (inferred from extension when omitted)")]
         content_type: Option<String>,
     },
     /// Remove profile picture.
@@ -149,10 +247,8 @@ pub enum UsersCommand {
 #[derive(Debug, Subcommand)]
 pub enum SessionsCommand {
     ListMine {
-        #[arg(long)]
-        page: Option<u32>,
-        #[arg(long)]
-        page_size: Option<u32>,
+        #[command(flatten)]
+        page: PageArgs,
     },
     GetMine {
         id: String,
@@ -173,10 +269,8 @@ pub enum SessionsCommand {
     },
     ListForUser {
         user_id: String,
-        #[arg(long)]
-        page: Option<u32>,
-        #[arg(long)]
-        page_size: Option<u32>,
+        #[command(flatten)]
+        page: PageArgs,
     },
     GetForUser {
         user_id: String,
@@ -195,22 +289,21 @@ pub enum SessionsCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum SongsCommand {
-    /// List all songs.
+    /// List songs with optional search and filters.
     List {
-        #[arg(long)]
-        page: Option<u32>,
-        #[arg(long)]
-        page_size: Option<u32>,
+        #[command(flatten)]
+        list: SongListArgs,
     },
     /// Get a song by id.
     Get {
         id: String,
     },
+    /// Player payload for a single song.
     Player {
         id: String,
     },
     Create {
-        #[arg(long)]
+        #[arg(long, help = "JSON CreateSong body")]
         json: String,
     },
     Update {
@@ -225,7 +318,7 @@ pub enum SongsCommand {
     },
     Move {
         id: String,
-        #[arg(long)]
+        #[arg(long, help = "JSON MoveOwner body, e.g. {\"owner\":\"team_id\"}")]
         json: String,
     },
     Delete {
@@ -242,24 +335,22 @@ pub enum SongsCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum CollectionsCommand {
-    /// List all collections.
+    /// List collections with optional search and team filter.
     List {
-        #[arg(long)]
-        page: Option<u32>,
-        #[arg(long)]
-        page_size: Option<u32>,
+        #[command(flatten)]
+        list: HubListArgs,
     },
     /// Get a collection by id.
     Get {
         id: String,
     },
+    /// Resolved songs for collection slots.
     Songs {
         id: String,
-        #[arg(long)]
-        page: Option<u32>,
-        #[arg(long)]
-        page_size: Option<u32>,
+        #[command(flatten)]
+        page: PageArgs,
     },
+    /// Aggregated player payload (items + toc).
     Player {
         id: String,
     },
@@ -285,33 +376,51 @@ pub enum CollectionsCommand {
     Delete {
         id: String,
     },
+    /// Move a song link to another collection atomically.
+    TransferSong {
+        id: String,
+        song_id: String,
+        #[arg(
+            long,
+            help = "JSON TransferCollectionSong body, e.g. {\"target\":\"col_id\",\"language\":\"de\"}"
+        )]
+        json: String,
+    },
+    /// Upload a cover image (JPEG or PNG).
+    CoverPut {
+        id: String,
+        file: PathBuf,
+        #[arg(long, help = "MIME type (inferred from extension when omitted)")]
+        content_type: Option<String>,
+    },
 }
 
 #[derive(Debug, Subcommand)]
 pub enum SetlistsCommand {
-    /// List all setlists.
+    /// List setlists with optional search and team filter.
     List {
-        #[arg(long)]
-        page: Option<u32>,
-        #[arg(long)]
-        page_size: Option<u32>,
+        #[command(flatten)]
+        list: HubListArgs,
     },
     /// Get a setlist by id.
     Get {
         id: String,
     },
+    /// Resolved songs for setlist slots.
     Songs {
         id: String,
-        #[arg(long)]
-        page: Option<u32>,
-        #[arg(long)]
-        page_size: Option<u32>,
+        #[command(flatten)]
+        page: PageArgs,
     },
+    /// Aggregated player payload (items + toc).
     Player {
         id: String,
     },
     Create {
-        #[arg(long)]
+        #[arg(
+            long,
+            help = "JSON CreateSetlist body; slots support key, tempo, and language overrides"
+        )]
         json: String,
     },
     Update {
@@ -338,10 +447,8 @@ pub enum SetlistsCommand {
 pub enum TeamsCommand {
     /// List teams visible to the current user.
     List {
-        #[arg(long)]
-        page: Option<u32>,
-        #[arg(long)]
-        page_size: Option<u32>,
+        #[command(flatten)]
+        list: HubListArgs,
     },
     /// Get a team by id.
     Get {
@@ -368,16 +475,21 @@ pub enum TeamsCommand {
     Delete {
         id: String,
     },
+    /// Upload a team cover image (JPEG or PNG).
+    CoverPut {
+        id: String,
+        file: PathBuf,
+        #[arg(long)]
+        content_type: Option<String>,
+    },
 }
 
 #[derive(Debug, Subcommand)]
 pub enum TeamInvitationsCommand {
     List {
         team_id: String,
-        #[arg(long)]
-        page: Option<u32>,
-        #[arg(long)]
-        page_size: Option<u32>,
+        #[command(flatten)]
+        page: PageArgs,
     },
     Create {
         team_id: String,
@@ -404,10 +516,8 @@ pub enum TeamInvitationsCommand {
 pub enum BlobsCommand {
     /// List all blobs.
     List {
-        #[arg(long)]
-        page: Option<u32>,
-        #[arg(long)]
-        page_size: Option<u32>,
+        #[command(flatten)]
+        page: PageArgs,
     },
     /// Get a blob by id.
     Get {
@@ -435,13 +545,14 @@ pub enum BlobsCommand {
     Delete {
         id: String,
     },
+    /// Absolute download URL for blob data.
     DownloadUrl {
         id: String,
     },
     /// Download raw bytes (`GET /api/v1/blobs/{id}/data`).
     DownloadData {
         id: String,
-        #[arg(long)]
+        #[arg(long, help = "Write to file instead of stdout")]
         output: Option<PathBuf>,
     },
     /// Upload raw bytes (`PUT /api/v1/blobs/{id}/data`).
@@ -457,16 +568,14 @@ pub enum BlobsCommand {
 pub enum MonitoringCommand {
     /// Admin: paginated HTTP audit log.
     AuditLogs {
-        #[arg(long)]
-        page: Option<u32>,
-        #[arg(long)]
-        page_size: Option<u32>,
+        #[command(flatten)]
+        page: PageArgs,
     },
     /// Admin: daily metrics for inclusive UTC RFC 3339 timestamps.
     Metrics {
-        #[arg(long)]
+        #[arg(long, help = "Start timestamp (RFC 3339 UTC)")]
         start: String,
-        #[arg(long)]
+        #[arg(long, help = "End timestamp (RFC 3339 UTC)")]
         end: String,
     },
 }

--- a/cli/src/handlers/blobs.rs
+++ b/cli/src/handlers/blobs.rs
@@ -1,30 +1,34 @@
 use std::fs;
 use std::io::{self, Write};
 
-use shared::api::ApiClient;
 use shared::blob::{CreateBlob, UpdateBlob};
 use shared::move_owner::MoveOwner;
-use shared::net::DefaultHttpClient;
 
 use crate::commands::BlobsCommand;
 use crate::output::{self, OutputFormat};
-use crate::validate::{list_query_from_opts, validate_resource_id};
+use crate::session::CliSession;
+use crate::validate::{list_query_from_page_args, validate_resource_id};
 
 pub async fn handle_blobs(
-    client: &ApiClient<DefaultHttpClient>,
+    session: &CliSession,
     output: OutputFormat,
     dry_run: bool,
-    effective_base_url: &str,
     cmd: &BlobsCommand,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let client = session.api();
+    let effective_base_url = session.base_url();
     match cmd {
-        BlobsCommand::List { page, page_size } => {
-            let query = list_query_from_opts(*page, *page_size);
-            let blobs = client.list_blobs(query).await?;
-            match output::effective_output_format(&output) {
-                OutputFormat::Ndjson => output::print_ndjson_list(&blobs),
-                _ => output::print_json(&blobs, &output),
-            }
+        BlobsCommand::List { page } => {
+            let query = list_query_from_page_args(page)?;
+            crate::list_output::print_list(
+                session,
+                "api/v1/blobs",
+                &query.to_query_string(),
+                page.with_meta,
+                &output,
+                || async { client.list_blobs(query.clone()).await },
+            )
+            .await
         }
         BlobsCommand::Get { id } => {
             validate_resource_id(id)?;

--- a/cli/src/handlers/collections.rs
+++ b/cli/src/handlers/collections.rs
@@ -1,45 +1,51 @@
-use shared::api::ApiClient;
-use shared::collection::{CreateCollection, UpdateCollection};
+use std::fs;
+
+use shared::collection::{CreateCollection, TransferCollectionSong, UpdateCollection};
 use shared::move_owner::MoveOwner;
-use shared::net::DefaultHttpClient;
 
 use crate::commands::CollectionsCommand;
+use crate::http_extra::{transfer_collection_song, upload_collection_cover};
+use crate::list_output::print_list;
 use crate::output::{self, OutputFormat};
-use crate::validate::{list_query_from_opts, validate_resource_id};
+use crate::session::CliSession;
+use crate::validate::{
+    image_content_type_for_path, list_query_from_hub_args, list_query_from_page_args,
+    validate_resource_id,
+};
 
 pub async fn handle_collections(
-    client: &ApiClient<DefaultHttpClient>,
+    session: &CliSession,
     output: OutputFormat,
     dry_run: bool,
-    _effective_base_url: &str,
     cmd: &CollectionsCommand,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let client = session.api();
     match cmd {
-        CollectionsCommand::List { page, page_size } => {
-            let query = list_query_from_opts(*page, *page_size);
-            let collections = client.list_collections(query).await?;
-            match output::effective_output_format(&output) {
-                OutputFormat::Ndjson => output::print_ndjson_list(&collections),
-                _ => output::print_json(&collections, &output),
-            }
+        CollectionsCommand::List { list } => {
+            let query = list_query_from_hub_args(list)?;
+            print_list(
+                session,
+                "api/v1/collections",
+                &query.to_query_string(),
+                list.page.with_meta,
+                &output,
+                || async { client.list_collections(query.clone()).await },
+            )
+            .await
         }
         CollectionsCommand::Get { id } => {
             validate_resource_id(id)?;
             let collection = client.get_collection(id).await?;
             output::print_json(&collection, &output)
         }
-        CollectionsCommand::Songs {
-            id,
-            page,
-            page_size,
-        } => {
+        CollectionsCommand::Songs { id, page } => {
             validate_resource_id(id)?;
-            let query = list_query_from_opts(*page, *page_size);
-            let songs = client.get_collection_songs(id, query).await?;
-            match output::effective_output_format(&output) {
-                OutputFormat::Ndjson => output::print_ndjson_list(&songs),
-                _ => output::print_json(&songs, &output),
-            }
+            let query = list_query_from_page_args(page)?;
+            let path = format!("api/v1/collections/{id}/songs{}", query.to_query_string());
+            print_list(session, &path, "", page.with_meta, &output, || async {
+                client.get_collection_songs(id, query.clone()).await
+            })
+            .await
         }
         CollectionsCommand::Player { id } => {
             validate_resource_id(id)?;
@@ -117,6 +123,43 @@ pub async fn handle_collections(
             }
             client.delete_collection(id).await?;
             output::print_json(&serde_json::json!({"deleted": true}), &output)
+        }
+        CollectionsCommand::TransferSong { id, song_id, json } => {
+            validate_resource_id(id)?;
+            validate_resource_id(song_id)?;
+            let payload: TransferCollectionSong = serde_json::from_str(json)?;
+            if dry_run {
+                let planned = serde_json::json!({
+                    "method": "POST",
+                    "path": format!("api/v1/collections/{id}/songs/{song_id}/transfer"),
+                    "body": payload,
+                });
+                output::print_json(&planned, &output)?;
+                return Ok(());
+            }
+            let result = transfer_collection_song(session.http(), id, song_id, payload).await?;
+            output::print_json(&result, &output)
+        }
+        CollectionsCommand::CoverPut {
+            id,
+            file,
+            content_type,
+        } => {
+            validate_resource_id(id)?;
+            let ct = image_content_type_for_path(file, content_type.as_deref())?;
+            let body = fs::read(file)?;
+            if dry_run {
+                let planned = serde_json::json!({
+                    "method": "PUT",
+                    "path": format!("api/v1/collections/{id}/cover"),
+                    "content_type": ct,
+                    "body_len": body.len(),
+                });
+                output::print_json(&planned, &output)?;
+                return Ok(());
+            }
+            let collection = upload_collection_cover(session.http(), id, &ct, &body).await?;
+            output::print_json(&collection, &output)
         }
     }
 }

--- a/cli/src/handlers/mod.rs
+++ b/cli/src/handlers/mod.rs
@@ -1,7 +1,5 @@
-use shared::api::ApiClient;
-use shared::net::DefaultHttpClient;
-
 use crate::commands::{Cli, Command, SchemaCommand};
+use crate::session::CliSession;
 
 mod about;
 mod auth;
@@ -15,11 +13,8 @@ mod songs;
 mod teams;
 mod users;
 
-pub async fn dispatch(
-    client: &ApiClient<DefaultHttpClient>,
-    cli: &Cli,
-    effective_base_url: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn dispatch(session: &CliSession, cli: &Cli) -> Result<(), Box<dyn std::error::Error>> {
+    let client = session.api();
     match &cli.command {
         Command::About => about::handle_about(client, cli.output.clone()).await,
         Command::Schema(args) => match &args.command {
@@ -34,53 +29,25 @@ pub async fn dispatch(
             auth::handle_auth(client, cli.output.clone(), cli.dry_run, command).await
         }
         Command::Users { command } => {
-            users::handle_users(client, cli.output.clone(), cli.dry_run, command).await
+            users::handle_users(session, cli.output.clone(), cli.dry_run, command).await
         }
         Command::Sessions { command } => {
             sessions::handle_sessions(client, cli.output.clone(), cli.dry_run, command).await
         }
         Command::Songs { command } => {
-            songs::handle_songs(
-                client,
-                cli.output.clone(),
-                cli.dry_run,
-                effective_base_url,
-                command,
-            )
-            .await
+            songs::handle_songs(session, cli.output.clone(), cli.dry_run, command).await
         }
         Command::Collections { command } => {
-            collections::handle_collections(
-                client,
-                cli.output.clone(),
-                cli.dry_run,
-                effective_base_url,
-                command,
-            )
-            .await
+            collections::handle_collections(session, cli.output.clone(), cli.dry_run, command).await
         }
         Command::Setlists { command } => {
-            setlists::handle_setlists(
-                client,
-                cli.output.clone(),
-                cli.dry_run,
-                effective_base_url,
-                command,
-            )
-            .await
+            setlists::handle_setlists(session, cli.output.clone(), cli.dry_run, command).await
         }
         Command::Blobs { command } => {
-            blobs::handle_blobs(
-                client,
-                cli.output.clone(),
-                cli.dry_run,
-                effective_base_url,
-                command,
-            )
-            .await
+            blobs::handle_blobs(session, cli.output.clone(), cli.dry_run, command).await
         }
         Command::Teams { command } => {
-            teams::handle_teams(client, cli.output.clone(), cli.dry_run, command).await
+            teams::handle_teams(session, cli.output.clone(), cli.dry_run, command).await
         }
         Command::Monitoring { command } => {
             monitoring::handle_monitoring(client, cli.output.clone(), cli.dry_run, command).await

--- a/cli/src/handlers/monitoring.rs
+++ b/cli/src/handlers/monitoring.rs
@@ -1,11 +1,11 @@
 use chrono::{DateTime, Utc};
-use shared::api::{ApiClient, PageQuery};
+use shared::api::ApiClient;
 use shared::monitoring::MonitoringMetricsQuery;
 use shared::net::DefaultHttpClient;
 
 use crate::commands::MonitoringCommand;
 use crate::output::OutputFormat;
-use crate::validate::page_query_from_opts;
+use crate::validate::page_query_from_page_args;
 
 pub async fn handle_monitoring(
     client: &ApiClient<DefaultHttpClient>,
@@ -14,8 +14,8 @@ pub async fn handle_monitoring(
     cmd: &MonitoringCommand,
 ) -> Result<(), Box<dyn std::error::Error>> {
     match cmd {
-        MonitoringCommand::AuditLogs { page, page_size } => {
-            let query: PageQuery = page_query_from_opts(*page, *page_size);
+        MonitoringCommand::AuditLogs { page } => {
+            let query = page_query_from_page_args(page)?;
             if dry_run {
                 crate::output::print_json(
                     &serde_json::json!({

--- a/cli/src/handlers/schema.rs
+++ b/cli/src/handlers/schema.rs
@@ -100,6 +100,7 @@ fn map_cli_command_to_openapi_operation(
         ("teams", "update") => ("put", "/api/v1/teams/{id}"),
         ("teams", "patch") => ("patch", "/api/v1/teams/{id}"),
         ("teams", "delete") => ("delete", "/api/v1/teams/{id}"),
+        ("teams", "cover-put") => ("put", "/api/v1/teams/{id}/cover"),
         ("team-invitations", "list") => ("get", "/api/v1/teams/{team_id}/invitations"),
         ("team-invitations", "create") => ("post", "/api/v1/teams/{team_id}/invitations"),
         ("team-invitations", "get") => {
@@ -140,6 +141,10 @@ fn map_cli_command_to_openapi_operation(
         ("collections", "patch") => ("patch", "/api/v1/collections/{id}"),
         ("collections", "move") => ("post", "/api/v1/collections/{id}/move"),
         ("collections", "delete") => ("delete", "/api/v1/collections/{id}"),
+        ("collections", "transfer-song") | ("collections", "transfer") => {
+            ("post", "/api/v1/collections/{id}/songs/{song_id}/transfer")
+        }
+        ("collections", "cover-put") => ("put", "/api/v1/collections/{id}/cover"),
         ("setlists", "list") => ("get", "/api/v1/setlists"),
         ("setlists", "get") => ("get", "/api/v1/setlists/{id}"),
         ("setlists", "songs") => ("get", "/api/v1/setlists/{id}/songs"),

--- a/cli/src/handlers/sessions.rs
+++ b/cli/src/handlers/sessions.rs
@@ -3,7 +3,7 @@ use shared::net::DefaultHttpClient;
 
 use crate::commands::SessionsCommand;
 use crate::output::{self, OutputFormat};
-use crate::validate::{list_query_from_opts, validate_resource_id};
+use crate::validate::{list_query_from_page_args, validate_resource_id};
 
 pub async fn handle_sessions(
     client: &ApiClient<DefaultHttpClient>,
@@ -12,8 +12,8 @@ pub async fn handle_sessions(
     cmd: &SessionsCommand,
 ) -> Result<(), Box<dyn std::error::Error>> {
     match cmd {
-        SessionsCommand::ListMine { page, page_size } => {
-            let query = list_query_from_opts(*page, *page_size);
+        SessionsCommand::ListMine { page } => {
+            let query = list_query_from_page_args(page)?;
             let sessions = client.list_my_sessions(query).await?;
             match output::effective_output_format(&output) {
                 OutputFormat::Ndjson => output::print_ndjson_list(&sessions),
@@ -65,13 +65,9 @@ pub async fn handle_sessions(
             let session = client.create_session_for_user(user_id).await?;
             output::print_json(&session, &output)
         }
-        SessionsCommand::ListForUser {
-            user_id,
-            page,
-            page_size,
-        } => {
+        SessionsCommand::ListForUser { user_id, page } => {
             validate_resource_id(user_id)?;
-            let query = list_query_from_opts(*page, *page_size);
+            let query = list_query_from_page_args(page)?;
             let sessions = client.list_sessions_for_user(user_id, query).await?;
             match output::effective_output_format(&output) {
                 OutputFormat::Ndjson => output::print_ndjson_list(&sessions),

--- a/cli/src/handlers/setlists.rs
+++ b/cli/src/handlers/setlists.rs
@@ -1,45 +1,45 @@
-use shared::api::ApiClient;
 use shared::move_owner::MoveOwner;
-use shared::net::DefaultHttpClient;
 use shared::setlist::{CreateSetlist, UpdateSetlist};
 
 use crate::commands::SetlistsCommand;
+use crate::list_output::print_list;
 use crate::output::{self, OutputFormat};
-use crate::validate::{list_query_from_opts, validate_resource_id};
+use crate::session::CliSession;
+use crate::validate::{list_query_from_hub_args, list_query_from_page_args, validate_resource_id};
 
 pub async fn handle_setlists(
-    client: &ApiClient<DefaultHttpClient>,
+    session: &CliSession,
     output: OutputFormat,
     dry_run: bool,
-    _effective_base_url: &str,
     cmd: &SetlistsCommand,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let client = session.api();
     match cmd {
-        SetlistsCommand::List { page, page_size } => {
-            let query = list_query_from_opts(*page, *page_size);
-            let setlists = client.list_setlists(query).await?;
-            match output::effective_output_format(&output) {
-                OutputFormat::Ndjson => output::print_ndjson_list(&setlists),
-                _ => output::print_json(&setlists, &output),
-            }
+        SetlistsCommand::List { list } => {
+            let query = list_query_from_hub_args(list)?;
+            print_list(
+                session,
+                "api/v1/setlists",
+                &query.to_query_string(),
+                list.page.with_meta,
+                &output,
+                || async { client.list_setlists(query.clone()).await },
+            )
+            .await
         }
         SetlistsCommand::Get { id } => {
             validate_resource_id(id)?;
             let setlist = client.get_setlist(id).await?;
             output::print_json(&setlist, &output)
         }
-        SetlistsCommand::Songs {
-            id,
-            page,
-            page_size,
-        } => {
+        SetlistsCommand::Songs { id, page } => {
             validate_resource_id(id)?;
-            let query = list_query_from_opts(*page, *page_size);
-            let songs = client.get_setlist_songs(id, query).await?;
-            match output::effective_output_format(&output) {
-                OutputFormat::Ndjson => output::print_ndjson_list(&songs),
-                _ => output::print_json(&songs, &output),
-            }
+            let query = list_query_from_page_args(page)?;
+            let path = format!("api/v1/setlists/{id}/songs{}", query.to_query_string());
+            print_list(session, &path, "", page.with_meta, &output, || async {
+                client.get_setlist_songs(id, query.clone()).await
+            })
+            .await
         }
         SetlistsCommand::Player { id } => {
             validate_resource_id(id)?;

--- a/cli/src/handlers/songs.rs
+++ b/cli/src/handlers/songs.rs
@@ -1,33 +1,31 @@
-use shared::api::{ApiClient, ListQuery};
 use shared::move_owner::MoveOwner;
-use shared::net::DefaultHttpClient;
 use shared::song::{CreateSong, UpdateSong};
 
 use crate::commands::SongsCommand;
+use crate::list_output::print_list;
 use crate::output::{self, OutputFormat};
-use crate::validate::validate_resource_id;
+use crate::session::CliSession;
+use crate::validate::{song_list_query_from_args, validate_resource_id};
 
 pub async fn handle_songs(
-    client: &ApiClient<DefaultHttpClient>,
+    session: &CliSession,
     output: OutputFormat,
     dry_run: bool,
-    _effective_base_url: &str,
     cmd: &SongsCommand,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let client = session.api();
     match cmd {
-        SongsCommand::List { page, page_size } => {
-            let mut query = ListQuery::new();
-            if let Some(p) = *page {
-                query = query.with_page(p);
-            }
-            if let Some(ps) = *page_size {
-                query = query.with_page_size(ps);
-            }
-            let songs = client.get_songs(query.into()).await?;
-            match output::effective_output_format(&output) {
-                OutputFormat::Ndjson => output::print_ndjson_list(&songs),
-                _ => output::print_json(&songs, &output),
-            }
+        SongsCommand::List { list } => {
+            let query = song_list_query_from_args(list)?;
+            print_list(
+                session,
+                "api/v1/songs",
+                &query.to_query_string(),
+                list.page.with_meta,
+                &output,
+                || async { client.get_songs(query.clone()).await },
+            )
+            .await
         }
         SongsCommand::Get { id } => {
             validate_resource_id(id)?;

--- a/cli/src/handlers/teams.rs
+++ b/cli/src/handlers/teams.rs
@@ -1,25 +1,36 @@
-use shared::api::ApiClient;
-use shared::net::DefaultHttpClient;
+use std::fs;
+
 use shared::team::{CreateTeam, UpdateTeam};
 
 use crate::commands::{TeamInvitationsCommand, TeamsCommand};
+use crate::http_extra::upload_team_cover;
+use crate::list_output::print_list;
 use crate::output::{self, OutputFormat};
-use crate::validate::{list_query_from_opts, page_query_from_opts, validate_resource_id};
+use crate::session::CliSession;
+use crate::validate::{
+    image_content_type_for_path, list_query_from_hub_args, page_query_from_page_args,
+    validate_resource_id,
+};
 
 pub async fn handle_teams(
-    client: &ApiClient<DefaultHttpClient>,
+    session: &CliSession,
     output: OutputFormat,
     dry_run: bool,
     cmd: &TeamsCommand,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let client = session.api();
     match cmd {
-        TeamsCommand::List { page, page_size } => {
-            let query = list_query_from_opts(*page, *page_size);
-            let teams = client.list_teams(query).await?;
-            match output::effective_output_format(&output) {
-                OutputFormat::Ndjson => output::print_ndjson_list(&teams),
-                _ => output::print_json(&teams, &output),
-            }
+        TeamsCommand::List { list } => {
+            let query = list_query_from_hub_args(list)?;
+            print_list(
+                session,
+                "api/v1/teams",
+                &query.to_query_string(),
+                list.page.with_meta,
+                &output,
+                || async { client.list_teams(query.clone()).await },
+            )
+            .await
         }
         TeamsCommand::Invitations { command } => {
             handle_team_invitations(client, output.clone(), dry_run, command).await
@@ -86,23 +97,40 @@ pub async fn handle_teams(
             client.delete_team(id).await?;
             output::print_json(&serde_json::json!({"deleted": true}), &output)
         }
+        TeamsCommand::CoverPut {
+            id,
+            file,
+            content_type,
+        } => {
+            validate_resource_id(id)?;
+            let ct = image_content_type_for_path(file, content_type.as_deref())?;
+            let body = fs::read(file)?;
+            if dry_run {
+                let planned = serde_json::json!({
+                    "method": "PUT",
+                    "path": format!("api/v1/teams/{id}/cover"),
+                    "content_type": ct,
+                    "body_len": body.len(),
+                });
+                output::print_json(&planned, &output)?;
+                return Ok(());
+            }
+            let team = upload_team_cover(session.http(), id, &ct, &body).await?;
+            output::print_json(&team, &output)
+        }
     }
 }
 
 async fn handle_team_invitations(
-    client: &ApiClient<DefaultHttpClient>,
+    client: &shared::api::ApiClient<shared::net::DefaultHttpClient>,
     output: OutputFormat,
     dry_run: bool,
     cmd: &TeamInvitationsCommand,
 ) -> Result<(), Box<dyn std::error::Error>> {
     match cmd {
-        TeamInvitationsCommand::List {
-            team_id,
-            page,
-            page_size,
-        } => {
+        TeamInvitationsCommand::List { team_id, page } => {
             validate_resource_id(team_id)?;
-            let query = page_query_from_opts(*page, *page_size);
+            let query = page_query_from_page_args(page)?;
             if dry_run {
                 output::print_json(
                     &serde_json::json!({
@@ -118,7 +146,7 @@ async fn handle_team_invitations(
             }
             let items = client.list_team_invitations(team_id, query).await?;
             match output::effective_output_format(&output) {
-                OutputFormat::Ndjson => output::print_ndjson_list(&items),
+                output::OutputFormat::Ndjson => output::print_ndjson_list(&items),
                 _ => output::print_json(&items, &output),
             }
         }

--- a/cli/src/handlers/users.rs
+++ b/cli/src/handlers/users.rs
@@ -1,27 +1,34 @@
 use std::fs;
 
-use shared::api::ApiClient;
-use shared::net::DefaultHttpClient;
 use shared::user::CreateUser;
 
 use crate::commands::UsersCommand;
+use crate::list_output::print_list;
 use crate::output::{self, OutputFormat};
-use crate::validate::{image_content_type_for_path, list_query_from_opts, validate_resource_id};
+use crate::session::CliSession;
+use crate::validate::{
+    image_content_type_for_path, list_query_from_page_args, validate_resource_id,
+};
 
 pub async fn handle_users(
-    client: &ApiClient<DefaultHttpClient>,
+    session: &CliSession,
     output: OutputFormat,
     dry_run: bool,
     cmd: &UsersCommand,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let client = session.api();
     match cmd {
-        UsersCommand::List { page, page_size } => {
-            let query = list_query_from_opts(*page, *page_size);
-            let users = client.list_users(query).await?;
-            match output::effective_output_format(&output) {
-                OutputFormat::Ndjson => output::print_ndjson_list(&users),
-                _ => output::print_json(&users, &output),
-            }
+        UsersCommand::List { page } => {
+            let query = list_query_from_page_args(page)?;
+            print_list(
+                session,
+                "api/v1/users",
+                &query.to_query_string(),
+                page.with_meta,
+                &output,
+                || async { client.list_users(query.clone()).await },
+            )
+            .await
         }
         UsersCommand::Get { id } => {
             validate_resource_id(id)?;

--- a/cli/src/http_extra.rs
+++ b/cli/src/http_extra.rs
@@ -1,0 +1,34 @@
+use shared::collection::{Collection, TransferCollectionSong, TransferCollectionSongResult};
+use shared::error::NetworkClientError;
+use shared::net::{DefaultHttpClient, HttpClient};
+use shared::team::Team;
+
+pub async fn transfer_collection_song(
+    http: &DefaultHttpClient,
+    collection_id: &str,
+    song_id: &str,
+    payload: TransferCollectionSong,
+) -> Result<TransferCollectionSongResult, NetworkClientError> {
+    let path = format!("api/v1/collections/{collection_id}/songs/{song_id}/transfer");
+    http.post(&path, &payload).await
+}
+
+pub async fn upload_collection_cover(
+    http: &DefaultHttpClient,
+    collection_id: &str,
+    content_type: &str,
+    body: &[u8],
+) -> Result<Collection, NetworkClientError> {
+    let path = format!("api/v1/collections/{collection_id}/cover");
+    http.put_bytes_json(&path, content_type, body).await
+}
+
+pub async fn upload_team_cover(
+    http: &DefaultHttpClient,
+    team_id: &str,
+    content_type: &str,
+    body: &[u8],
+) -> Result<Team, NetworkClientError> {
+    let path = format!("api/v1/teams/{team_id}/cover");
+    http.put_bytes_json(&path, content_type, body).await
+}

--- a/cli/src/list_fetch.rs
+++ b/cli/src/list_fetch.rs
@@ -1,0 +1,58 @@
+use reqwest::Client;
+use serde::de::DeserializeOwned;
+
+use shared::error::NetworkClientError;
+use shared::net::HttpClientConfig;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ListPagination {
+    pub total: Option<u64>,
+    pub link: Option<String>,
+}
+
+pub async fn fetch_json_list<T: DeserializeOwned>(
+    config: &HttpClientConfig,
+    path_with_query: &str,
+) -> Result<(Vec<T>, ListPagination), NetworkClientError> {
+    let base = config.base_url.trim_end_matches('/');
+    let path = path_with_query.trim_start_matches('/');
+    let url = format!("{base}/{path}");
+
+    let mut builder = Client::builder();
+    if let Some(timeout) = config.timeout {
+        builder = builder.timeout(timeout);
+    }
+    let client = builder
+        .build()
+        .map_err(|e| NetworkClientError::Unexpected {
+            message: e.to_string(),
+        })?;
+
+    let mut req = client.get(&url);
+    if let Some(ref cookie) = config.session_cookie {
+        req = req.header(reqwest::header::COOKIE, format!("sso_session={cookie}"));
+    }
+    if let Some(ref token) = config.bearer_token {
+        req = req.bearer_auth(token);
+    }
+    if let Some(ref id) = config.client_ident {
+        req = req.header("X-Worship-Client", id);
+    }
+
+    let resp = req.send().await?;
+    let resp = resp.error_for_status()?;
+
+    let total = resp
+        .headers()
+        .get("x-total-count")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse().ok());
+    let link = resp
+        .headers()
+        .get("link")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
+
+    let items: Vec<T> = resp.json().await?;
+    Ok((items, ListPagination { total, link }))
+}

--- a/cli/src/list_output.rs
+++ b/cli/src/list_output.rs
@@ -1,0 +1,74 @@
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+use shared::error::NetworkClientError;
+
+use crate::list_fetch::{fetch_json_list, ListPagination};
+use crate::output::{self, OutputFormat};
+use crate::session::CliSession;
+use crate::validate::ValidationError;
+
+#[derive(Serialize)]
+struct ListEnvelope<'a, T: Serialize> {
+    items: &'a [T],
+    pagination: ListPaginationView,
+}
+
+#[derive(Serialize)]
+struct ListPaginationView {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    total: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    link: Option<String>,
+}
+
+impl From<ListPagination> for ListPaginationView {
+    fn from(p: ListPagination) -> Self {
+        Self {
+            total: p.total,
+            link: p.link,
+        }
+    }
+}
+
+pub async fn print_list<T, F, Fut>(
+    session: &CliSession,
+    api_path: &str,
+    query_string: &str,
+    with_meta: bool,
+    output: &OutputFormat,
+    fetch_plain: F,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    T: Serialize + DeserializeOwned,
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<Vec<T>, NetworkClientError>>,
+{
+    if with_meta
+        && matches!(
+            output::effective_output_format(output),
+            OutputFormat::Ndjson
+        )
+    {
+        return Err(Box::new(ValidationError::new(
+            "--with-meta cannot be used with --output ndjson; use json or pretty",
+        )));
+    }
+
+    if with_meta {
+        let path = format!("{api_path}{query_string}");
+        let (items, pagination) = fetch_json_list::<T>(session.config(), &path).await?;
+        let envelope = ListEnvelope {
+            items: &items,
+            pagination: pagination.into(),
+        };
+        output::print_json(&envelope, output)?;
+        return Ok(());
+    }
+
+    let items = fetch_plain().await?;
+    match output::effective_output_format(output) {
+        OutputFormat::Ndjson => output::print_ndjson_list(&items),
+        _ => output::print_json(&items, output),
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,15 +1,17 @@
 use clap::Parser;
 
-use shared::api::ApiClient;
-use shared::net::DefaultHttpClient;
-
 mod commands;
 mod config;
 mod handlers;
+mod http_extra;
+mod list_fetch;
+mod list_output;
 mod output;
+mod session;
 mod validate;
 
 use crate::commands::Cli;
+use crate::session::CliSession;
 
 #[tokio::main]
 async fn main() {
@@ -23,8 +25,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
     let options = config::BuildConfigOptions::from_cli(&cli);
-    let (client_config, effective_base_url) = config::build_http_client_config(&options)?;
-    let client = ApiClient::<DefaultHttpClient>::with_default(client_config);
+    let session = CliSession::new(&options)?;
 
-    handlers::dispatch(&client, &cli, &effective_base_url).await
+    handlers::dispatch(&session, &cli).await
 }

--- a/cli/src/session.rs
+++ b/cli/src/session.rs
@@ -1,0 +1,37 @@
+use shared::api::ApiClient;
+use shared::net::{DefaultHttpClient, HttpClientConfig};
+
+use crate::config::{self, BuildConfigOptions};
+
+/// Shared HTTP session: API wrapper plus a clone of the underlying client for
+/// endpoints not yet exposed on [`ApiClient`].
+pub struct CliSession {
+    config: HttpClientConfig,
+    api: ApiClient<DefaultHttpClient>,
+    http: DefaultHttpClient,
+}
+
+impl CliSession {
+    pub fn new(options: &BuildConfigOptions) -> Result<Self, Box<dyn std::error::Error>> {
+        let (config, _) = config::build_http_client_config(options)?;
+        let http = DefaultHttpClient::new(config.clone());
+        let api = ApiClient::new(http.clone());
+        Ok(Self { config, api, http })
+    }
+
+    pub fn api(&self) -> &ApiClient<DefaultHttpClient> {
+        &self.api
+    }
+
+    pub fn http(&self) -> &DefaultHttpClient {
+        &self.http
+    }
+
+    pub fn config(&self) -> &HttpClientConfig {
+        &self.config
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.config.base_url
+    }
+}

--- a/cli/src/validate.rs
+++ b/cli/src/validate.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 
-use shared::api::{ListQuery, PageQuery};
+use shared::api::{ListQuery, PageQuery, SongListQuery};
+
+use crate::commands::{HubListArgs, PageArgs, SongListArgs};
 
 #[derive(Debug)]
 pub struct ValidationError {
@@ -40,19 +42,65 @@ pub fn validate_resource_id(id: &str) -> Result<&str, ValidationError> {
     Ok(id)
 }
 
-pub fn list_query_from_opts(page: Option<u32>, page_size: Option<u32>) -> ListQuery {
+pub fn list_query_from_page_args(page: &PageArgs) -> Result<ListQuery, ValidationError> {
     let mut q = ListQuery::new();
-    if let Some(p) = page {
+    if let Some(p) = page.page {
         q = q.with_page(p);
     }
-    if let Some(ps) = page_size {
+    if let Some(ps) = page.page_size {
         q = q.with_page_size(ps);
     }
-    q
+    q.validate().map_err(ValidationError::new)
 }
 
-pub fn page_query_from_opts(page: Option<u32>, page_size: Option<u32>) -> PageQuery {
-    PageQuery { page, page_size }
+pub fn list_query_from_hub_args(args: &HubListArgs) -> Result<ListQuery, ValidationError> {
+    let mut q = list_query_from_page_args(&args.page)?;
+    if let Some(ref search) = args.filter.q {
+        let trimmed = search.trim();
+        if !trimmed.is_empty() {
+            q = q.with_q(trimmed);
+        }
+    }
+    if let Some(ref team) = args.filter.team {
+        validate_resource_id(team)?;
+        q = q.with_team(team.clone());
+    }
+    q.validate().map_err(ValidationError::new)
+}
+
+pub fn song_list_query_from_args(args: &SongListArgs) -> Result<SongListQuery, ValidationError> {
+    let hub = HubListArgs {
+        page: args.page.clone(),
+        filter: args.filter.clone(),
+    };
+    let list = list_query_from_hub_args(&hub)?;
+    let mut query = SongListQuery {
+        page: list.page,
+        page_size: list.page_size,
+        q: list.q,
+        team: list.team,
+        sort: args.sort.clone(),
+        lang: args.lang.clone(),
+        tag: args.tag.clone(),
+    };
+    if let Some(ref lang) = query.lang {
+        if lang.trim().is_empty() {
+            query.lang = None;
+        }
+    }
+    if let Some(ref tag) = query.tag {
+        if tag.trim().is_empty() {
+            query.tag = None;
+        }
+    }
+    query.validate().map_err(ValidationError::new)
+}
+
+pub fn page_query_from_page_args(page: &PageArgs) -> Result<PageQuery, ValidationError> {
+    list_query_from_page_args(page).map(|lq| PageQuery {
+        page: lq.page,
+        page_size: lq.page_size,
+    })
 }
 
 fn guess_content_type(path: &std::path::Path) -> Option<&'static str> {
@@ -81,4 +129,65 @@ pub fn image_content_type_for_path(
     guess_content_type(path).map(str::to_string).ok_or_else(|| {
         ValidationError::new("could not infer content-type; pass --content-type (e.g. image/png)")
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::{HubFilterArgs, HubListArgs, PageArgs, SongListArgs};
+
+    #[test]
+    fn hub_list_query_includes_search_and_team() {
+        let args = HubListArgs {
+            page: PageArgs {
+                page: Some(1),
+                page_size: Some(25),
+                with_meta: false,
+            },
+            filter: HubFilterArgs {
+                q: Some("grace".into()),
+                team: Some("team_abc".into()),
+            },
+        };
+        let q = list_query_from_hub_args(&args).expect("valid");
+        assert_eq!(q.page, Some(1));
+        assert_eq!(q.page_size, Some(25));
+        assert_eq!(q.q.as_deref(), Some("grace"));
+        assert_eq!(q.team.as_deref(), Some("team_abc"));
+        assert!(q.to_query_string().contains("q=grace"));
+    }
+
+    #[test]
+    fn song_list_query_rejects_relevance_without_q() {
+        let args = SongListArgs {
+            page: PageArgs::default(),
+            filter: HubFilterArgs::default(),
+            sort: Some("relevance".into()),
+            lang: None,
+            tag: None,
+        };
+        let err = song_list_query_from_args(&args).unwrap_err();
+        assert!(err.to_string().contains("relevance"));
+    }
+
+    #[test]
+    fn song_list_query_includes_lang_and_tag() {
+        let args = SongListArgs {
+            page: PageArgs::default(),
+            filter: HubFilterArgs::default(),
+            sort: Some("-id".into()),
+            lang: Some("de".into()),
+            tag: Some("worship".into()),
+        };
+        let q = song_list_query_from_args(&args).expect("valid");
+        let qs = q.to_query_string();
+        assert!(qs.contains("lang=de"));
+        assert!(qs.contains("tag=worship"));
+        assert!(qs.contains("sort=-id"));
+    }
+
+    #[test]
+    fn validate_resource_id_rejects_colon() {
+        assert!(validate_resource_id("bad:id").is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- Add hub-style list filters (`--q`, `--team`, and song-specific `--sort`, `--lang`, `--tag`) to list commands
- Add missing API commands: `collections transfer-song`, `collections cover-put`, `teams cover-put`
- Add `--with-meta` on list commands to surface `X-Total-Count` and `Link` headers for pagination scripts
- Improve CLI help text and add unit tests for query validation

## Test plan
- [x] `cargo fmt`, `cargo clippy -- -D warnings`, `cargo test` in `cli/`
- [ ] `cargo install --path cli --force` and verify `worshipviewer collections --help` shows new subcommands
- [ ] `worshipviewer songs list --q grace --sort relevance --lang de` against local backend
- [ ] `worshipviewer collections transfer-song <src> <song> --json '{"target":"<dst>"}'`
- [ ] `worshipviewer collections list --with-meta --output json` returns pagination wrapper