### PR TITLE
E1.4: Apply per-item language selection to AV

### DIFF
--- a/frontend/app/src/components/player/av/PlayerAv.test.tsx
+++ b/frontend/app/src/components/player/av/PlayerAv.test.tsx
@@ -1,0 +1,279 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { components } from '@/api/schema'
+import { PlayerAv } from '@/components/player/av/PlayerAv'
+
+const navigate = vi.fn()
+const broadcast = vi.fn()
+const closeSync = vi.fn()
+const writeSessionState = vi.fn()
+const writePreferences = vi.fn()
+const setIndexSearchSync = vi.fn()
+const setEvictionWatch = vi.fn()
+const readSessionState = vi.fn()
+const readPreferences = vi.fn()
+const readViewState = vi.fn()
+const writeViewState = vi.fn()
+
+let viewState = { transposeByItem: {}, languageByItem: { 0: 1 } }
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children?: ReactNode } & Record<string, unknown>) => (
+    <a {...props}>{children}</a>
+  ),
+  useNavigate: () => navigate,
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('@/hooks/useMediaQuery', () => ({
+  useMediaQuery: () => false,
+}))
+
+vi.mock('@/hooks/usePlayerIndexSearchSync', () => ({
+  usePlayerIndexSearchSync: (...args: unknown[]) => setIndexSearchSync(...args),
+}))
+
+vi.mock('@/hooks/useSetlistEvictionWatch', () => ({
+  useSetlistEvictionWatch: () => {
+    setEvictionWatch()
+    return false
+  },
+}))
+
+vi.mock('@/hooks/useTocMultilingualPreference', () => ({
+  useTocMultilingualPreference: () => true,
+}))
+
+vi.mock('@/lib/player/av-projection-sync', () => ({
+  AV_PROJECTION_SHARED_SESSION_ID: 'shared',
+  createAvProjectionSync: () => ({
+    broadcast,
+    close: closeSync,
+    readLatest: vi.fn(),
+  }),
+  getAvProjectionSessionId: () => 'shared',
+}))
+
+vi.mock('@/lib/player/av-preferences', () => ({
+  DEFAULT_AV_PREFERENCES: {
+    contentLayer: {
+      maxLinesPerSlide: 2,
+      balanceSlideLines: true,
+      fontSize: 60,
+      textAlign: 'center',
+      verticalAlign: 'center',
+      horizontalAlign: 'center',
+      textShadow: 'none',
+      textTransform: 'uppercase',
+    },
+    backgroundLayer: { preset: 2 },
+    transition: { style: 'none', durationMs: 0 },
+    projection: { outputFullscreenOnDblClick: true },
+  },
+  buildAvProjectionPayload: (input: unknown) => input,
+  readAvPreferences: () => readPreferences(),
+  writeAvPreferences: (...args: unknown[]) => writePreferences(...args),
+}))
+
+vi.mock('@/lib/player/av-session-state', () => ({
+  readAvSessionState: (...args: unknown[]) => readSessionState(...args),
+  writeAvSessionState: (...args: unknown[]) => writeSessionState(...args),
+}))
+
+vi.mock('@/lib/player/player-view-state', () => ({
+  readPlayerViewState: (...args: unknown[]) => readViewState(...args),
+  writePlayerViewState: (...args: unknown[]) => writeViewState(...args),
+  setLanguageForItem: (state: unknown, itemIndex: number, languageIndex: number) => {
+    const next = state as { languageByItem?: Record<number, number> }
+    return {
+      ...(next ?? {}),
+      languageByItem: { ...(next?.languageByItem ?? {}), [itemIndex]: languageIndex },
+    }
+  },
+}))
+
+vi.mock('@/components/player/PlayerEditMenu', () => ({
+  PlayerEditMenu: () => null,
+}))
+
+vi.mock('@/components/player/av/AvOutlinePanel', () => ({
+  AvOutlinePanel: ({ rows }: { rows: Array<{ label: string; slideIndex: number }> }) => (
+    <div data-testid="outline-rows">{rows.map((row) => row.label).join('|')}</div>
+  ),
+}))
+
+vi.mock('@/components/player/av/AvSectionShortcuts', () => ({
+  AvSectionShortcuts: () => null,
+}))
+
+vi.mock('@/components/player/av/AvSlideView', () => ({
+  AvSlideView: ({ contentText }: { contentText: string }) => (
+    <div data-testid="preview-text">{contentText}</div>
+  ),
+}))
+
+vi.mock('@/components/player/av/AvSlidesPanel', () => ({
+  AvSlidesPanel: ({
+    entries,
+    currentSlideIndex,
+  }: {
+    entries: Array<{ text: string; slideIndex: number }>
+    currentSlideIndex: number | null
+  }) => (
+    <div>
+      <div data-testid="slide-entry-texts">{entries.map((entry) => entry.text).join('|')}</div>
+      <div data-testid="selected-slide-index">{String(currentSlideIndex)}</div>
+    </div>
+  ),
+}))
+
+vi.mock('@/components/player/PlayerTocSidebar', () => ({
+  PlayerTocSidebar: ({
+    currentLanguageIndex,
+    onSelect,
+  }: {
+    currentLanguageIndex: number | null
+    onSelect: (sourceIdx: number, languageIndex: number | null) => void
+  }) => (
+    <div>
+      <div data-testid="toc-current-language">{String(currentLanguageIndex)}</div>
+      <button type="button" onClick={() => onSelect(0, 1)}>
+        German row
+      </button>
+      <button type="button" onClick={() => onSelect(0, 0)}>
+        English row
+      </button>
+    </div>
+  ),
+}))
+
+type Player = components['schemas']['Player']
+
+const player = {
+  index: 0,
+  toc: [
+    {
+      idx: 0,
+      nr: '1',
+      title: 'Anchor',
+      id: 'song-1',
+      liked: false,
+    },
+  ],
+  items: [
+    {
+      type: 'chords',
+      language: 'de',
+      song: {
+        id: 'song-1',
+        blobs: [],
+        not_a_song: false,
+        owner: 'user:test',
+        user_specific_addons: { liked: false },
+        data: {
+          sections: [
+            {
+              title: 'Verse 1',
+              lines: [
+                {
+                  parts: [{ comment: false, languages: ['Hello', 'Hallo'] }],
+                },
+              ],
+            },
+            {
+              title: 'Chorus',
+              lines: [
+                {
+                  parts: [{ comment: false, languages: ['Goodbye', 'Tschuess'] }],
+                },
+              ],
+            },
+          ],
+          languages: ['en', 'de'],
+          titles: ['Anchor', 'Anker'],
+        },
+      },
+    },
+  ] as Player['items'],
+} as Player
+
+beforeEach(() => {
+  navigate.mockReset()
+  broadcast.mockReset()
+  closeSync.mockReset()
+  writeSessionState.mockReset()
+  writePreferences.mockReset()
+  setIndexSearchSync.mockReset()
+  setEvictionWatch.mockReset()
+  readSessionState.mockReset().mockReturnValue({
+    itemIndex: 0,
+    slideIndex: 0,
+    screenState: 'live',
+  })
+  readPreferences.mockReset().mockReturnValue({
+    contentLayer: {
+      maxLinesPerSlide: 2,
+      balanceSlideLines: true,
+      fontSize: 60,
+      textAlign: 'center',
+      verticalAlign: 'center',
+      horizontalAlign: 'center',
+      textShadow: 'none',
+      textTransform: 'uppercase',
+    },
+    backgroundLayer: { preset: 2 },
+    transition: { style: 'none', durationMs: 0 },
+    projection: { outputFullscreenOnDblClick: true },
+  })
+  viewState = { transposeByItem: {}, languageByItem: { 0: 1 } }
+  readViewState.mockReset().mockReturnValue(viewState)
+  writeViewState.mockReset().mockImplementation((...args: unknown[]) => {
+    const next = args[2] as typeof viewState
+    viewState = next
+  })
+})
+
+describe('PlayerAv', () => {
+  it('reads the stored per-item language and updates AV content from the TOC selection', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <PlayerAv
+        type="setlist"
+        id="setlist-1"
+        player={player}
+        allowNetworkFetch={false}
+      />,
+    )
+
+    expect(screen.getByTestId('toc-current-language')).toHaveTextContent('1')
+    expect(screen.getByText('Anker')).toBeInTheDocument()
+    expect(screen.getByTestId('preview-text')).toHaveTextContent('Hallo')
+    expect(screen.getByTestId('slide-entry-texts')).toHaveTextContent('Hallo|Tschuess')
+
+    await user.click(screen.getByRole('button', { name: 'English row' }))
+
+    expect(screen.getByTestId('toc-current-language')).toHaveTextContent('0')
+    expect(screen.getByText('Anchor')).toBeInTheDocument()
+    expect(screen.getByTestId('preview-text')).toHaveTextContent('Hello')
+    expect(screen.getByTestId('slide-entry-texts')).toHaveTextContent('Hello|Goodbye')
+
+    await waitFor(() => {
+      expect(writeViewState).toHaveBeenCalledWith(
+        'setlist',
+        'setlist-1',
+        expect.objectContaining({
+          languageByItem: { 0: 0 },
+        }),
+      )
+    })
+  })
+})

--- a/frontend/app/src/components/player/av/PlayerAv.tsx
+++ b/frontend/app/src/components/player/av/PlayerAv.tsx
@@ -15,6 +15,7 @@ import { SettingsIcon } from '@/components/icons/lucide-animated/settings-icon'
 import { Button } from '@/components/ui/button'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { usePlayerIndexSearchSync } from '@/hooks/usePlayerIndexSearchSync'
+import { useTocMultilingualPreference } from '@/hooks/useTocMultilingualPreference'
 import { useSetlistEvictionWatch } from '@/hooks/useSetlistEvictionWatch'
 import {
   avItemTitle,
@@ -22,6 +23,7 @@ import {
   avNextSlideInItem,
   avPrevItemIndex,
   avPrevSlideInItem,
+  resolveAvItemLanguageIndex,
   avSlidesForPlayerItem,
 } from '@/lib/player/av-nav'
 import {
@@ -55,6 +57,12 @@ import {
   type AvSessionState,
 } from '@/lib/player/av-session-state'
 import {
+  readPlayerViewState,
+  setLanguageForItem,
+  writePlayerViewState,
+  type PlayerViewState,
+} from '@/lib/player/player-view-state'
+import {
   PLAYER_HEADER_ICON_SIZE,
   PLAYER_TOC_WIDTH_CLASS,
   playerHeaderIconButtonClass,
@@ -64,7 +72,6 @@ import { buildSongEditorReturnSearch } from '@/lib/player/player-editor-return'
 import { tocEntryForIndex } from '@/lib/player/player-helpers'
 import type { PlayerEntityType } from '@/lib/player-route'
 import { buildSettingsSearch } from '@/lib/settings-route'
-import { languageIndexForSongLink } from '@/lib/setlist-song-links'
 import { cn } from '@/lib/utils'
 
 import './player-av.css'
@@ -123,7 +130,9 @@ export function PlayerAv({
   const { t } = useTranslation()
   const navigate = useNavigate()
   const reduceMotion = useMediaQuery('(prefers-reduced-motion: reduce)')
+  const tocMultilingualEnabled = useTocMultilingualPreference()
   const [prefs, setPrefs] = useState<AvPreferences>(() => readAvPreferences())
+  const [viewState, setViewState] = useState<PlayerViewState>(() => readPlayerViewState(type, id))
   const [session, setSession] = useState<AvSessionState>(() => {
     const saved = readAvSessionState(type, id)
     const startItem = initialIndex ?? saved.itemIndex ?? player.index
@@ -138,6 +147,10 @@ export function PlayerAv({
     return { ...saved, itemIndex: startItem, slideIndex: startSlide }
   })
   const [tocVisible] = useState(true)
+  const resolveLanguageIndexForItem = useCallback(
+    (itemIndex: number) => viewState.languageByItem?.[itemIndex],
+    [viewState.languageByItem],
+  )
 
   const sessionIdRef = useRef(getAvProjectionSessionId())
   const syncRef = useRef<AvProjectionSync | null>(null)
@@ -146,13 +159,22 @@ export function PlayerAv({
 
   const itemsLen = player.items.length
   const tocRow = tocEntryForIndex(player.toc, session.itemIndex)
-  const title = resourceTitle || tocRow?.title || avItemTitle(player.items, session.itemIndex, tocRow?.title)
+  const title = avItemTitle(
+    player.items,
+    session.itemIndex,
+    resourceTitle || tocRow?.title,
+    resolveLanguageIndexForItem,
+  )
   const showToc = player.toc.length > 0
   const evicted = useSetlistEvictionWatch(type === 'setlist' ? id : undefined, type === 'setlist')
   const navBlocked = evicted
   const backTo = hubPathForPlayerType(type)
 
   usePlayerIndexSearchSync(type, id, session.itemIndex, 'av')
+
+  useEffect(() => {
+    writePlayerViewState(type, id, viewState)
+  }, [type, id, viewState])
 
   const collapseLyricWhitespace = readLyricCollapseWhitespacePreference()
 
@@ -162,12 +184,13 @@ export function PlayerAv({
         maxLinesPerSlide: prefs.contentLayer.maxLinesPerSlide,
         balanceSlideLines: prefs.contentLayer.balanceSlideLines,
         collapseLyricWhitespace,
-      }),
+      }, resolveLanguageIndexForItem),
     [
       player.items,
       prefs.contentLayer.maxLinesPerSlide,
       prefs.contentLayer.balanceSlideLines,
       collapseLyricWhitespace,
+      resolveLanguageIndexForItem,
       session.itemIndex,
     ],
   )
@@ -178,21 +201,24 @@ export function PlayerAv({
         maxLinesPerSlide: prefs.contentLayer.maxLinesPerSlide,
         balanceSlideLines: prefs.contentLayer.balanceSlideLines,
         collapseLyricWhitespace,
-      }),
+      }, resolveLanguageIndexForItem),
     [
       player.items,
       prefs.contentLayer.maxLinesPerSlide,
       prefs.contentLayer.balanceSlideLines,
       collapseLyricWhitespace,
+      resolveLanguageIndexForItem,
       projected.itemIndex,
     ],
   )
 
   const projectedTocRow = tocEntryForIndex(player.toc, projected.itemIndex)
-  const projectedTitle =
-    resourceTitle ||
-    projectedTocRow?.title ||
-    avItemTitle(player.items, projected.itemIndex, projectedTocRow?.title)
+  const projectedTitle = avItemTitle(
+    player.items,
+    projected.itemIndex,
+    resourceTitle || projectedTocRow?.title,
+    resolveLanguageIndexForItem,
+  )
 
   const slideCount = currentItem.slides.length
   const announcement = useMemo(() => {
@@ -249,7 +275,7 @@ export function PlayerAv({
   const rawItem = player.items[session.itemIndex]
   const currentLanguageIndex =
     rawItem?.type === 'chords'
-      ? languageIndexForSongLink(rawItem.song.data as Record<string, unknown>, rawItem.language) ?? 0
+      ? resolveAvItemLanguageIndex(rawItem, session.itemIndex, resolveLanguageIndexForItem)
       : null
 
   const navigateToSongEditor = useCallback(() => {
@@ -589,7 +615,12 @@ export function PlayerAv({
               items={player.items}
               currentSourceIdx={session.itemIndex}
               currentLanguageIndex={currentLanguageIndex}
-              onSelect={(idx) => goToItem(idx)}
+              onSelect={(idx, languageIndex) => {
+                if (tocMultilingualEnabled && languageIndex != null) {
+                  setViewState((state) => setLanguageForItem(state, idx, languageIndex))
+                }
+                goToItem(idx)
+              }}
             />
           </div>
         ) : null}

--- a/frontend/app/src/lib/player/av-nav.test.ts
+++ b/frontend/app/src/lib/player/av-nav.test.ts
@@ -1,0 +1,132 @@
+import type { components } from '@/api/schema'
+import { describe, expect, it } from 'vitest'
+
+import {
+  avItemTitle,
+  avSlidesForItem,
+  avSlidesForPlayerItem,
+  buildAvFlatSlides,
+  resolveAvItemLanguageIndex,
+} from '@/lib/player/av-nav'
+import {
+  buildAvOutlineRows,
+  buildAvPresentationSlides,
+} from '@/lib/player/av-lyric-slides'
+
+type PlayerItem = components['schemas']['PlayerItem']
+
+const split = {
+  maxLinesPerSlide: 2,
+  balanceSlideLines: true,
+  collapseLyricWhitespace: true,
+}
+
+const songData = {
+  sections: [
+    {
+      title: 'Verse 1',
+      lines: [
+        {
+          parts: [{ comment: false, languages: ['Hello', 'Hallo'] }],
+        },
+      ],
+    },
+    {
+      title: 'Chorus',
+      lines: [
+        {
+          parts: [{ comment: false, languages: ['Goodbye', 'Tschuess'] }],
+        },
+      ],
+    },
+  ],
+  languages: ['en', 'de'],
+  titles: ['Anchor', 'Anker'],
+}
+
+function chordItem(language: string | null): PlayerItem {
+  return {
+    type: 'chords',
+    song: {
+      id: 'song-1',
+      blobs: [],
+      not_a_song: false,
+      owner: 'user:test',
+      user_specific_addons: { liked: false },
+      data: songData,
+    },
+    language,
+  } as PlayerItem
+}
+
+describe('resolveAvItemLanguageIndex', () => {
+  it('prefers a valid override and falls back to the saved slot language', () => {
+    const item = chordItem('de')
+
+    expect(resolveAvItemLanguageIndex(item, 0, () => 0)).toBe(0)
+    expect(resolveAvItemLanguageIndex(item, 0, () => 99)).toBe(1)
+  })
+
+  it('falls back to track 0 when both override and saved slot are invalid', () => {
+    const item = chordItem('it')
+
+    expect(resolveAvItemLanguageIndex(item, 0, () => 99)).toBe(0)
+    expect(resolveAvItemLanguageIndex(item, 0)).toBe(0)
+  })
+})
+
+describe('avSlidesForItem', () => {
+  it('uses the effective language for slide text and title', () => {
+    const item = chordItem('de')
+
+    const english = avSlidesForItem(item, 0, split, 'Setlist title', () => 0)
+    const german = avSlidesForItem(item, 0, split, 'Setlist title', () => 1)
+
+    expect(english.slides).toEqual(['Hello', 'Goodbye'])
+    expect(german.slides).toEqual(['Hallo', 'Tschuess'])
+    expect(english.sourceSlides).toEqual(english.slides)
+    expect(german.sourceSlides).toEqual(german.slides)
+    expect(avItemTitle([item], 0, 'Setlist title', () => 0)).toBe('Anchor')
+    expect(avItemTitle([item], 0, 'Setlist title', () => 1)).toBe('Anker')
+  })
+})
+
+describe('av flat slides', () => {
+  it('keeps two occurrences of the same song independent', () => {
+    const items: PlayerItem[] = [chordItem('de'), chordItem('de')]
+    const resolveLanguageIndex = (itemIndex: number) => (itemIndex === 0 ? 0 : 1)
+
+    const first = avSlidesForPlayerItem(items, 0, split, resolveLanguageIndex)
+    const second = avSlidesForPlayerItem(items, 1, split, resolveLanguageIndex)
+    const flat = buildAvFlatSlides(items, split, [], resolveLanguageIndex)
+
+    expect(first.slides).toEqual(['Hello', 'Goodbye'])
+    expect(second.slides).toEqual(['Hallo', 'Tschuess'])
+    expect(avItemTitle(items, 0, undefined, resolveLanguageIndex)).toBe('Anchor')
+    expect(avItemTitle(items, 1, undefined, resolveLanguageIndex)).toBe('Anker')
+    expect(flat.filter((row) => row.itemIndex === 0).map((row) => row.text)).toEqual([
+      'Hello',
+      'Goodbye',
+    ])
+    expect(flat.filter((row) => row.itemIndex === 1).map((row) => row.text)).toEqual([
+      'Hallo',
+      'Tschuess',
+    ])
+  })
+
+  it('keeps outline and deck indices aligned after switching language', () => {
+    const item = chordItem('de')
+
+    const english = avSlidesForItem(item, 0, split, 'Setlist title', () => 0)
+    const german = avSlidesForItem(item, 0, split, 'Setlist title', () => 1)
+
+    expect(english.outline.map((row) => row.title)).toEqual(['Verse 1', 'Chorus'])
+    expect(german.outline.map((row) => row.title)).toEqual(['Verse 1', 'Chorus'])
+    expect(english.outline.map((row) => row.len)).toEqual([1, 1])
+    expect(german.outline.map((row) => row.len)).toEqual([1, 1])
+    expect(buildAvPresentationSlides(english.outline, english.sourceSlides)).toEqual(english.slides)
+    expect(buildAvPresentationSlides(german.outline, german.sourceSlides)).toEqual(german.slides)
+    expect(buildAvOutlineRows(english.outline, 0).map((row) => row.slideIndex)).toEqual([0, 1])
+    expect(buildAvOutlineRows(german.outline, 0).map((row) => row.slideIndex)).toEqual([0, 1])
+  })
+})

--- a/frontend/app/src/lib/player/av-nav.ts
+++ b/frontend/app/src/lib/player/av-nav.ts
@@ -8,10 +8,12 @@ import {
 } from '@/lib/player/av-lyric-slides'
 import type { AvLyricSplitPrefs } from '@/lib/player/av-preferences'
 import { itemTypeAt, tocEntryForIndex } from '@/lib/player/player-helpers'
-import { languageIndexForSongLink, songTitleForLanguage } from '@/lib/setlist-song-links'
+import { languageIndexForSongLink, songLanguageOptions } from '@/lib/setlist-song-links'
 
 type Player = components['schemas']['Player']
 type PlayerItem = components['schemas']['PlayerItem']
+
+export type AvLanguageIndexResolver = (itemIndex: number) => number | undefined
 
 export type AvItemSlides = {
   slides: string[]
@@ -20,10 +22,52 @@ export type AvItemSlides = {
   kind: 'lyrics' | 'blob'
 }
 
+function songTitleAtLanguageIndex(
+  data: Record<string, unknown> | undefined | null,
+  languageIndex: number,
+  fallback = '',
+): string {
+  const titles = Array.isArray(data?.titles) ? data.titles : []
+  const value = titles[languageIndex]
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (trimmed.length > 0) return trimmed
+  }
+  const fallbackTitle = fallback.trim()
+  return fallbackTitle.length > 0 ? fallbackTitle : 'Untitled'
+}
+
+export function resolveAvItemLanguageIndex(
+  item: PlayerItem | undefined,
+  itemIndex: number,
+  resolveLanguageIndex?: AvLanguageIndexResolver,
+): number {
+  if (!item || item.type !== 'chords') return 0
+
+  const options = songLanguageOptions(item.song.data as Record<string, unknown>)
+  const slotLanguageIndex = languageIndexForSongLink(
+    item.song.data as Record<string, unknown>,
+    item.language,
+  )
+  const overrideLanguageIndex = resolveLanguageIndex?.(itemIndex)
+
+  const isValidIndex = (value: number | undefined): value is number =>
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    value >= 0 &&
+    value < options.length
+
+  if (isValidIndex(overrideLanguageIndex)) return overrideLanguageIndex
+  if (isValidIndex(slotLanguageIndex)) return slotLanguageIndex
+  return 0
+}
+
 export function avSlidesForItem(
   item: PlayerItem | undefined,
+  itemIndex: number,
   split: AvLyricSplitPrefs,
   fallbackTitle?: string,
+  resolveLanguageIndex?: AvLanguageIndexResolver,
 ): AvItemSlides {
   if (!item) return { slides: [''], sourceSlides: [''], outline: [], kind: 'blob' }
   if (item.type === 'blob') {
@@ -36,8 +80,7 @@ export function avSlidesForItem(
     }
   }
   const songData = item.song.data
-  const title = songTitleForLanguage(songData as Record<string, unknown>, item.language)
-  const languageIndex = languageIndexForSongLink(songData as Record<string, unknown>, item.language) ?? 0
+  const languageIndex = resolveAvItemLanguageIndex(item, itemIndex, resolveLanguageIndex)
   const lyricData = buildAvLyricSlides(
     songData.sections,
     split.maxLinesPerSlide,
@@ -46,12 +89,23 @@ export function avSlidesForItem(
     split.collapseLyricWhitespace,
   )
   if (lyricData.outline.length === 0 && lyricData.slides.length === 0) {
+    const title = songTitleAtLanguageIndex(
+      songData as Record<string, unknown>,
+      languageIndex,
+      fallbackTitle,
+    )
     return { slides: [title], sourceSlides: [title], outline: [], kind: 'lyrics' }
   }
   const slides = buildAvPresentationSlides(lyricData.outline, lyricData.slides)
   if (slides.length === 0) {
     return {
-      slides: [title],
+      slides: [
+        songTitleAtLanguageIndex(
+          songData as Record<string, unknown>,
+          languageIndex,
+          fallbackTitle,
+        ),
+      ],
       sourceSlides: lyricData.slides,
       outline: lyricData.outline,
       kind: 'lyrics',
@@ -69,8 +123,15 @@ export function avSlidesForPlayerItem(
   items: PlayerItem[],
   itemIndex: number,
   split: AvLyricSplitPrefs,
+  resolveLanguageIndex?: AvLanguageIndexResolver,
 ): AvItemSlides {
-  return avSlidesForItem(items[itemIndex], split)
+  return avSlidesForItem(
+    items[itemIndex],
+    itemIndex,
+    split,
+    undefined,
+    resolveLanguageIndex,
+  )
 }
 
 export type AvFlatSlide = {
@@ -83,11 +144,18 @@ export function buildAvFlatSlides(
   items: PlayerItem[],
   split: AvLyricSplitPrefs,
   toc: Player['toc'] = [],
+  resolveLanguageIndex?: AvLanguageIndexResolver,
 ): AvFlatSlide[] {
   const flat: AvFlatSlide[] = []
   for (let itemIndex = 0; itemIndex < items.length; itemIndex += 1) {
     const tocTitle = tocEntryForIndex(toc, itemIndex)?.title
-    const { slides } = avSlidesForItem(items[itemIndex], split, tocTitle)
+    const { slides } = avSlidesForItem(
+      items[itemIndex],
+      itemIndex,
+      split,
+      tocTitle,
+      resolveLanguageIndex,
+    )
     for (let slideIndex = 0; slideIndex < slides.length; slideIndex += 1) {
       flat.push({ itemIndex, slideIndex, text: slides[slideIndex] ?? '' })
     }
@@ -164,13 +232,19 @@ export function avItemTitle(
   items: PlayerItem[],
   itemIndex: number,
   tocTitle?: string,
+  resolveLanguageIndex?: AvLanguageIndexResolver,
 ): string {
   const item = items[itemIndex]
-  if (tocTitle?.trim()) return tocTitle.trim()
   if (!item) return ''
   if (item.type === 'chords') {
-    return songTitleForLanguage(item.song.data as Record<string, unknown>, item.language, '')
+    const languageIndex = resolveAvItemLanguageIndex(item, itemIndex, resolveLanguageIndex)
+    return songTitleAtLanguageIndex(
+      item.song.data as Record<string, unknown>,
+      languageIndex,
+      tocTitle,
+    )
   }
+  if (tocTitle?.trim()) return tocTitle.trim()
   return ''
 }
 
@@ -178,15 +252,20 @@ export function avItemHasLyrics(items: PlayerItem[], itemIndex: number): boolean
   return itemTypeAt(items, itemIndex) === 'chords'
 }
 
-export function avTotalSlides(items: PlayerItem[], split: AvLyricSplitPrefs): number {
-  return buildAvFlatSlides(items, split).length
+export function avTotalSlides(
+  items: PlayerItem[],
+  split: AvLyricSplitPrefs,
+  resolveLanguageIndex?: AvLanguageIndexResolver,
+): number {
+  return buildAvFlatSlides(items, split, [], resolveLanguageIndex).length
 }
 
 export type AvPlayerContext = {
   player: Player
   split: AvLyricSplitPrefs
+  resolveLanguageIndex?: AvLanguageIndexResolver
 }
 
 export function rebuildAvFlat(ctx: AvPlayerContext): AvFlatSlide[] {
-  return buildAvFlatSlides(ctx.player.items, ctx.split, ctx.player.toc)
+  return buildAvFlatSlides(ctx.player.items, ctx.split, ctx.player.toc, ctx.resolveLanguageIndex)
 }


### PR DESCRIPTION
Implements E1.4 from the multi-language epic.

### What changed
- AV now resolves language per item from player view state first, then the saved slot language, then track 0.
- `PlayerAv` persists `languageByItem` and uses it to rebuild titles, slide text, outline, and preview state.
- Added focused unit coverage for AV language fallback and per-item selection behavior.

### Validation
- `pnpm --filter app exec eslint . --fix`
- `pnpm -C frontend lint`
- `pnpm -C frontend typecheck`
- `pnpm -C frontend test`
- `pnpm -C frontend build`