### PR TITLE
feat(frontend): bilingual AV operator slides and output projection (E1.5–E1.6)

### DIFF
--- a/frontend/app/src/components/player/av/AvOutputPage.test.tsx
+++ b/frontend/app/src/components/player/av/AvOutputPage.test.tsx
@@ -1,0 +1,95 @@
+import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AvOutputPage } from '@/components/player/av/AvOutputPage'
+import { DEFAULT_AV_PREFERENCES } from '@/lib/player/av-preferences'
+
+let slideViewProps: Record<string, unknown> | null = null
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('@/components/player/av/AvSlideView', () => ({
+  AvSlideView: (props: Record<string, unknown>) => {
+    slideViewProps = props
+    return <div data-testid="slide-view" />
+  },
+}))
+
+const subscribeAvProjectionSync = vi.fn()
+
+vi.mock('@/lib/player/av-projection-sync', () => ({
+  subscribeAvProjectionSync: (...args: unknown[]) => subscribeAvProjectionSync(...args),
+}))
+
+beforeEach(() => {
+  slideViewProps = null
+  subscribeAvProjectionSync.mockReset()
+  subscribeAvProjectionSync.mockImplementation((_sessionId: string, onPayload: (payload: unknown) => void) => {
+    onPayload({
+      contentText: 'Hello',
+      contentLayer: DEFAULT_AV_PREFERENCES.contentLayer,
+      backgroundLayer: DEFAULT_AV_PREFERENCES.backgroundLayer,
+      transition: DEFAULT_AV_PREFERENCES.transition,
+      screenState: 'live',
+      itemTitle: 'Song',
+      nextPreview: null,
+    })
+    return { close: vi.fn() }
+  })
+})
+
+describe('AvOutputPage', () => {
+  it('renders structured content lines when the payload includes them', () => {
+    subscribeAvProjectionSync.mockImplementation((_sessionId: string, onPayload: (payload: unknown) => void) => {
+      onPayload({
+        contentText: 'Hello',
+        contentLines: [{ primary: 'Hello', secondary: 'Hallo' }],
+        contentLayer: DEFAULT_AV_PREFERENCES.contentLayer,
+        backgroundLayer: DEFAULT_AV_PREFERENCES.backgroundLayer,
+        transition: DEFAULT_AV_PREFERENCES.transition,
+        screenState: 'live',
+        itemTitle: 'Song',
+        nextPreview: null,
+      })
+      return { close: vi.fn() }
+    })
+
+    render(<AvOutputPage sessionId="shared" />)
+
+    expect(slideViewProps?.contentLines).toEqual([{ primary: 'Hello', secondary: 'Hallo' }])
+    expect(slideViewProps?.contentText).toBeUndefined()
+    expect(slideViewProps?.screenState).toBe('live')
+  })
+
+  it('falls back to contentText when structured lines are absent', () => {
+    render(<AvOutputPage sessionId="shared" />)
+
+    expect(slideViewProps?.contentText).toBe('Hello')
+    expect(slideViewProps?.contentLines).toBeUndefined()
+  })
+
+  it('passes blank screen state without structured lines leaking through the view props', () => {
+    subscribeAvProjectionSync.mockImplementation((_sessionId: string, onPayload: (payload: unknown) => void) => {
+      onPayload({
+        contentText: '',
+        contentLayer: DEFAULT_AV_PREFERENCES.contentLayer,
+        backgroundLayer: DEFAULT_AV_PREFERENCES.backgroundLayer,
+        transition: DEFAULT_AV_PREFERENCES.transition,
+        screenState: 'blank',
+        itemTitle: 'Song',
+        nextPreview: null,
+      })
+      return { close: vi.fn() }
+    })
+
+    render(<AvOutputPage sessionId="shared" />)
+
+    expect(slideViewProps?.screenState).toBe('blank')
+    expect(slideViewProps?.contentText).toBe('')
+    expect(slideViewProps?.contentLines).toBeUndefined()
+  })
+})

--- a/frontend/app/src/components/player/av/AvOutputPage.tsx
+++ b/frontend/app/src/components/player/av/AvOutputPage.tsx
@@ -49,7 +49,8 @@ export function AvOutputPage({
       aria-label={t('player.av.outputAria')}
     >
       <AvSlideView
-        contentText={viewPayload.contentText}
+        contentText={viewPayload.contentLines?.length ? undefined : viewPayload.contentText}
+        contentLines={viewPayload.contentLines}
         contentLayer={viewPayload.contentLayer}
         backgroundLayer={viewPayload.backgroundLayer}
         transition={viewPayload.transition}

--- a/frontend/app/src/components/player/av/AvSlideContent.test.tsx
+++ b/frontend/app/src/components/player/av/AvSlideContent.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { AvSlideContent } from '@/components/player/av/AvSlideContent'
+import { DEFAULT_AV_PREFERENCES } from '@/lib/player/av-preferences'
+
+describe('AvSlideContent', () => {
+  it('renders primary and secondary rows with secondary styling', () => {
+    const { container } = render(
+      <AvSlideContent
+        lines={[
+          { primary: 'Hello', secondary: 'Hallo' },
+          { primary: 'World' },
+        ]}
+        contentLayer={DEFAULT_AV_PREFERENCES.contentLayer}
+      />,
+    )
+
+    expect(screen.getByText('Hello')).toBeInTheDocument()
+    expect(screen.getByText('Hallo')).toBeInTheDocument()
+    expect(screen.getByText('World')).toBeInTheDocument()
+    expect(screen.queryByText('Welt')).not.toBeInTheDocument()
+    expect(container.querySelector('.av-slide-content__line--secondary')).toBeTruthy()
+    expect(container.querySelectorAll('.av-slide-content__line-group')).toHaveLength(2)
+  })
+
+  it('renders plain text lines when structured lines are not provided', () => {
+    render(
+      <AvSlideContent
+        text={'Line one\nLine two'}
+        contentLayer={DEFAULT_AV_PREFERENCES.contentLayer}
+      />,
+    )
+
+    expect(screen.getByText('Line one')).toBeInTheDocument()
+    expect(screen.getByText('Line two')).toBeInTheDocument()
+  })
+
+  it('shows only the first structured line group in compact mode', () => {
+    render(
+      <AvSlideContent
+        lines={[
+          { primary: 'Hello', secondary: 'Hallo' },
+          { primary: 'World', secondary: 'Welt' },
+        ]}
+        contentLayer={DEFAULT_AV_PREFERENCES.contentLayer}
+        compact
+      />,
+    )
+
+    expect(screen.getByText('Hello')).toBeInTheDocument()
+    expect(screen.getByText('Hallo')).toBeInTheDocument()
+    expect(screen.queryByText('World')).not.toBeInTheDocument()
+    expect(screen.queryByText('Welt')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/app/src/components/player/av/AvSlideContent.tsx
+++ b/frontend/app/src/components/player/av/AvSlideContent.tsx
@@ -1,4 +1,5 @@
 import type { AvContentLayer } from '@/lib/player/av-preferences'
+import type { AvLyricLine } from '@/lib/player/av-lyric-slides'
 import {
   AV_SLIDE_EDGE_PADDING_PX,
   avSlideInnerPaddingPx,
@@ -9,20 +10,61 @@ import { cn } from '@/lib/utils'
 import './player-av.css'
 
 type AvSlideContentProps = {
-  text: string
+  text?: string
+  lines?: AvLyricLine[]
   contentLayer: AvContentLayer
   className?: string
   compact?: boolean
 }
 
+function renderLine(
+  line: string,
+  contentLayer: AvContentLayer,
+  designFontSizePx: number,
+  compact: boolean,
+  className?: string,
+) {
+  return (
+    <div
+      className={cn(
+        'av-slide-content__line',
+        `av-slide-content__line--align-${contentLayer.textAlign}`,
+        `av-slide-content__line--shadow-${contentLayer.textShadow}`,
+        `av-slide-content__line--transform-${contentLayer.textTransform}`,
+        className,
+      )}
+      style={
+        compact
+          ? undefined
+          : {
+              fontSize: `${designFontSizePx}px`,
+              lineHeight: `${avSlideLineHeightPx(designFontSizePx)}px`,
+            }
+      }
+    >
+      {line || '\u00a0'}
+    </div>
+  )
+}
+
 export function AvSlideContent({
   text,
+  lines,
   contentLayer,
   className,
   compact = false,
 }: AvSlideContentProps) {
-  const lines = compact ? [text.split('\n')[0] ?? ''] : text.split('\n')
   const designFontSizePx = contentLayer.fontSize
+  const structuredLines = lines
+    ? compact
+      ? lines.slice(0, 1)
+      : lines
+    : undefined
+  const plainLines = structuredLines
+    ? undefined
+    : compact
+      ? [text?.split('\n')[0] ?? '']
+      : (text?.split('\n') ?? [''])
 
   return (
     <div
@@ -43,27 +85,29 @@ export function AvSlideContent({
             : { padding: `${avSlideInnerPaddingPx(designFontSizePx)}px` }
         }
       >
-        {lines.map((line, index) => (
-          <div
-            key={`${index}-${line.slice(0, 12)}`}
-            className={cn(
-              'av-slide-content__line',
-              `av-slide-content__line--align-${contentLayer.textAlign}`,
-              `av-slide-content__line--shadow-${contentLayer.textShadow}`,
-              `av-slide-content__line--transform-${contentLayer.textTransform}`,
-            )}
-            style={
-              compact
-                ? undefined
-                : {
-                    fontSize: `${designFontSizePx}px`,
-                    lineHeight: `${avSlideLineHeightPx(designFontSizePx)}px`,
-                  }
-            }
-          >
-            {line || '\u00a0'}
-          </div>
-        ))}
+        {structuredLines
+          ? structuredLines.map((line, index) => (
+              <div
+                key={`${index}-${line.primary.slice(0, 12)}`}
+                className="av-slide-content__line-group"
+              >
+                {renderLine(line.primary, contentLayer, designFontSizePx, compact)}
+                {line.secondary
+                  ? renderLine(
+                      line.secondary,
+                      contentLayer,
+                      designFontSizePx * 0.75,
+                      compact,
+                      'av-slide-content__line--secondary',
+                    )
+                  : null}
+              </div>
+            ))
+          : plainLines?.map((line, index) => (
+              <div key={`${index}-${line.slice(0, 12)}`}>
+                {renderLine(line, contentLayer, designFontSizePx, compact)}
+              </div>
+            ))}
       </div>
     </div>
   )

--- a/frontend/app/src/components/player/av/AvSlideView.tsx
+++ b/frontend/app/src/components/player/av/AvSlideView.tsx
@@ -7,6 +7,7 @@ import type {
   AvScreenState,
   AvTransition,
 } from '@/lib/player/av-preferences'
+import type { AvLyricLine } from '@/lib/player/av-lyric-slides'
 import { effectiveAvTransition } from '@/lib/player/av-preferences'
 import { AvBackgroundLayer } from '@/components/player/av/AvBackgroundLayer'
 import { AvSlideContent } from '@/components/player/av/AvSlideContent'
@@ -16,7 +17,8 @@ import { cn } from '@/lib/utils'
 import './player-av.css'
 
 type AvSlideViewProps = {
-  contentText: string
+  contentText?: string
+  contentLines?: AvLyricLine[]
   contentLayer: AvContentLayer
   backgroundLayer: AvBackgroundLayerPrefs
   transition: AvTransition
@@ -31,13 +33,19 @@ type AvSlideViewProps = {
 
 function AvSlideCanvas({
   contentText,
+  contentLines,
   contentLayer,
   backgroundLayer,
   compact,
   showBackground,
 }: Pick<
   AvSlideViewProps,
-  'contentText' | 'contentLayer' | 'backgroundLayer' | 'compact' | 'showBackground'
+  | 'contentText'
+  | 'contentLines'
+  | 'contentLayer'
+  | 'backgroundLayer'
+  | 'compact'
+  | 'showBackground'
 >) {
   return (
     <>
@@ -46,7 +54,8 @@ function AvSlideCanvas({
       ) : null}
       <div className="av-slide-view__content">
         <AvSlideContent
-          text={contentText}
+          text={contentLines ? undefined : contentText}
+          lines={contentLines}
           contentLayer={contentLayer}
           compact={compact}
         />
@@ -57,6 +66,7 @@ function AvSlideCanvas({
 
 export function AvSlideView({
   contentText,
+  contentLines,
   contentLayer,
   backgroundLayer,
   transition,
@@ -100,6 +110,7 @@ export function AvSlideView({
   const slideBody = (
     <AvSlideCanvas
       contentText={contentText}
+      contentLines={contentLines}
       contentLayer={contentLayer}
       backgroundLayer={backgroundLayer}
       compact={compact}
@@ -119,7 +130,7 @@ export function AvSlideView({
         ) : (
           <AnimatePresence mode="wait" initial={false}>
             <motion.div
-              key={contentText}
+              key={contentText ?? contentLines?.map((line) => line.primary).join('\n') ?? ''}
               initial={
                 effectiveTransition.style === 'none'
                   ? false

--- a/frontend/app/src/components/player/av/AvSlidesPanel.tsx
+++ b/frontend/app/src/components/player/av/AvSlidesPanel.tsx
@@ -23,6 +23,19 @@ function firstSlideLine(text: string): string {
   return line || text.trim()
 }
 
+function previewContent(entry: AvSlideDeckEntry, multiColumn: boolean): {
+  contentText?: string
+  contentLines?: AvSlideDeckEntry['lines']
+} {
+  if (entry.lines?.length) {
+    return {
+      contentLines: multiColumn ? entry.lines : entry.lines.slice(0, 1),
+    }
+  }
+  const text = multiColumn ? entry.text : firstSlideLine(entry.text)
+  return { contentText: text }
+}
+
 function slidePanelColumnCount(width: number): number {
   return Math.floor((width + SLIDE_COL_GAP_PX) / (SLIDE_COL_MIN_PX + SLIDE_COL_GAP_PX))
 }
@@ -108,7 +121,7 @@ export function AvSlidesPanel({
       >
       {entries.map((entry) => {
         const selected = entry.slideIndex === currentSlideIndex
-        const previewText = multiColumn ? entry.text : firstSlideLine(entry.text)
+        const preview = previewContent(entry, multiColumn)
         return (
           <button
             key={entry.slideIndex}
@@ -137,7 +150,8 @@ export function AvSlidesPanel({
               )}
             >
               <AvSlideView
-                contentText={previewText}
+                contentText={preview.contentText}
+                contentLines={preview.contentLines}
                 contentLayer={contentLayer}
                 backgroundLayer={backgroundLayer}
                 transition={transition}

--- a/frontend/app/src/components/player/av/PlayerAv.test.tsx
+++ b/frontend/app/src/components/player/av/PlayerAv.test.tsx
@@ -48,8 +48,14 @@ vi.mock('@/hooks/useSetlistEvictionWatch', () => ({
   },
 }))
 
+let bilingualEnabled = false
+
 vi.mock('@/hooks/useTocMultilingualPreference', () => ({
   useTocMultilingualPreference: () => true,
+}))
+
+vi.mock('@/hooks/useAvBilingualPreference', () => ({
+  useAvBilingualPreference: () => bilingualEnabled,
 }))
 
 vi.mock('@/lib/player/av-projection-sync', () => ({
@@ -115,8 +121,22 @@ vi.mock('@/components/player/av/AvSectionShortcuts', () => ({
 }))
 
 vi.mock('@/components/player/av/AvSlideView', () => ({
-  AvSlideView: ({ contentText }: { contentText: string }) => (
-    <div data-testid="preview-text">{contentText}</div>
+  AvSlideView: ({
+    contentText,
+    contentLines,
+  }: {
+    contentText?: string
+    contentLines?: Array<{ primary: string; secondary?: string }>
+  }) => (
+    <div data-testid="preview-text">
+      {contentLines
+        ? contentLines
+            .map((line) =>
+              line.secondary ? `${line.primary}|${line.secondary}` : line.primary,
+            )
+            .join('//')
+        : contentText}
+    </div>
   ),
 }))
 
@@ -206,6 +226,7 @@ const player = {
 } as Player
 
 beforeEach(() => {
+  bilingualEnabled = false
   navigate.mockReset()
   broadcast.mockReset()
   closeSync.mockReset()
@@ -275,5 +296,47 @@ describe('PlayerAv', () => {
         }),
       )
     })
+  })
+
+  it('shows bilingual structured preview content when the preference is enabled', () => {
+    bilingualEnabled = true
+
+    render(
+      <PlayerAv
+        type="setlist"
+        id="setlist-1"
+        player={player}
+        allowNetworkFetch={false}
+      />,
+    )
+
+    expect(screen.getByTestId('preview-text')).toHaveTextContent('Hallo|Hello')
+  })
+
+  it('broadcasts structured contentLines when bilingual AV is enabled', async () => {
+    bilingualEnabled = true
+    const user = userEvent.setup()
+
+    render(
+      <PlayerAv
+        type="setlist"
+        id="setlist-1"
+        player={player}
+        allowNetworkFetch={false}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'English row' }))
+
+    await waitFor(() => {
+      expect(broadcast).toHaveBeenCalled()
+    })
+
+    const lastPayload = broadcast.mock.calls.at(-1)?.[0] as {
+      contentText?: string
+      contentLines?: Array<{ primary: string; secondary?: string }>
+    }
+    expect(lastPayload.contentText).toBe('Hello')
+    expect(lastPayload.contentLines).toEqual([{ primary: 'Hello', secondary: 'Hallo' }])
   })
 })

--- a/frontend/app/src/components/player/av/PlayerAv.tsx
+++ b/frontend/app/src/components/player/av/PlayerAv.tsx
@@ -16,6 +16,7 @@ import { Button } from '@/components/ui/button'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { usePlayerIndexSearchSync } from '@/hooks/usePlayerIndexSearchSync'
 import { useTocMultilingualPreference } from '@/hooks/useTocMultilingualPreference'
+import { useAvBilingualPreference } from '@/hooks/useAvBilingualPreference'
 import { useSetlistEvictionWatch } from '@/hooks/useSetlistEvictionWatch'
 import {
   avItemTitle,
@@ -131,6 +132,7 @@ export function PlayerAv({
   const navigate = useNavigate()
   const reduceMotion = useMediaQuery('(prefers-reduced-motion: reduce)')
   const tocMultilingualEnabled = useTocMultilingualPreference()
+  const bilingualEnabled = useAvBilingualPreference()
   const [prefs, setPrefs] = useState<AvPreferences>(() => readAvPreferences())
   const [viewState, setViewState] = useState<PlayerViewState>(() => readPlayerViewState(type, id))
   const [session, setSession] = useState<AvSessionState>(() => {
@@ -184,7 +186,7 @@ export function PlayerAv({
         maxLinesPerSlide: prefs.contentLayer.maxLinesPerSlide,
         balanceSlideLines: prefs.contentLayer.balanceSlideLines,
         collapseLyricWhitespace,
-      }, resolveLanguageIndexForItem),
+      }, resolveLanguageIndexForItem, bilingualEnabled),
     [
       player.items,
       prefs.contentLayer.maxLinesPerSlide,
@@ -192,6 +194,7 @@ export function PlayerAv({
       collapseLyricWhitespace,
       resolveLanguageIndexForItem,
       session.itemIndex,
+      bilingualEnabled,
     ],
   )
 
@@ -201,7 +204,7 @@ export function PlayerAv({
         maxLinesPerSlide: prefs.contentLayer.maxLinesPerSlide,
         balanceSlideLines: prefs.contentLayer.balanceSlideLines,
         collapseLyricWhitespace,
-      }, resolveLanguageIndexForItem),
+      }, resolveLanguageIndexForItem, bilingualEnabled),
     [
       player.items,
       prefs.contentLayer.maxLinesPerSlide,
@@ -209,6 +212,7 @@ export function PlayerAv({
       collapseLyricWhitespace,
       resolveLanguageIndexForItem,
       projected.itemIndex,
+      bilingualEnabled,
     ],
   )
 
@@ -231,8 +235,13 @@ export function PlayerAv({
     })
   }, [session.screenState, session.slideIndex, slideCount, t, title])
   const slideDeckEntries = useMemo(
-    () => buildAvSlideDeckEntries(currentItem.outline, currentItem.sourceSlides),
-    [currentItem.outline, currentItem.sourceSlides],
+    () =>
+      buildAvSlideDeckEntries(
+        currentItem.outline,
+        currentItem.sourceSlides,
+        currentItem.structuredSourceSlides,
+      ),
+    [currentItem.outline, currentItem.sourceSlides, currentItem.structuredSourceSlides],
   )
   const outlineRows = useMemo(
     () => buildAvOutlineRows(currentItem.outline, session.slideIndex),
@@ -248,6 +257,11 @@ export function PlayerAv({
     return currentItem.slides[session.slideIndex] ?? currentItem.slides[0] ?? ''
   }, [currentItem.slides, session.screenState, session.slideIndex])
 
+  const currentLines = useMemo(() => {
+    if (session.screenState !== 'live') return undefined
+    return currentItem.structuredSlides?.[session.slideIndex] ?? currentItem.structuredSlides?.[0]
+  }, [currentItem.structuredSlides, session.screenState, session.slideIndex])
+
   const projectedSlideCount = projectedItem.slides.length
   const projectedText = useMemo(() => {
     if (projected.screenState !== 'live') return ''
@@ -261,6 +275,14 @@ export function PlayerAv({
     if (nextIndex == null) return null
     return projectedItem.slides[nextIndex] ?? null
   }, [projected.slideIndex, projectedItem.slides, projectedSlideCount])
+
+  const projectedLines = useMemo(() => {
+    if (projected.screenState !== 'live') return undefined
+    return (
+      projectedItem.structuredSlides?.[projected.slideIndex]
+      ?? projectedItem.structuredSlides?.[0]
+    )
+  }, [projected.screenState, projected.slideIndex, projectedItem.structuredSlides])
 
   const playerReturnContext = useMemo(
     () => ({
@@ -339,6 +361,7 @@ export function PlayerAv({
     }
     const payload = buildAvProjectionPayload({
       contentText: projectedText,
+      contentLines: projectedLines,
       contentLayer: prefs.contentLayer,
       backgroundLayer: prefs.backgroundLayer,
       transition: prefs.transition,
@@ -350,6 +373,7 @@ export function PlayerAv({
     syncRef.current?.broadcast(payload)
   }, [
     projectedText,
+    projectedLines,
     projectedNextText,
     projected.screenState,
     projectedTitle,
@@ -652,7 +676,8 @@ export function PlayerAv({
           <div className="player-av__preview">
             <AvSlideView
               preview
-              contentText={currentText}
+              contentText={currentLines ? undefined : currentText}
+              contentLines={currentLines}
               contentLayer={prefs.contentLayer}
               backgroundLayer={prefs.backgroundLayer}
               transition={prefs.transition}

--- a/frontend/app/src/components/player/av/player-av.css
+++ b/frontend/app/src/components/player/av/player-av.css
@@ -93,6 +93,15 @@
   word-break: break-word;
 }
 
+.av-slide-content__line--secondary {
+  color: var(--color-muted-foreground);
+}
+
+.av-slide-content__line-group {
+  display: flex;
+  flex-direction: column;
+}
+
 .av-slide-content__line--align-left {
   text-align: left;
 }

--- a/frontend/app/src/components/settings/SettingsView.tsx
+++ b/frontend/app/src/components/settings/SettingsView.tsx
@@ -61,6 +61,10 @@ import {
   writeSheetImageInvertPreference,
 } from '@/lib/sheet-image-invert-preference'
 import {
+  readAvBilingualPreference,
+  writeAvBilingualPreference,
+} from '@/lib/av-bilingual-preference'
+import {
   readTocMultilingualPreference,
   writeTocMultilingualPreference,
 } from '@/lib/toc-multilingual-preference'
@@ -317,6 +321,7 @@ export function SettingsView({
   const [chordFormatPreference, setChordFormatPreference] = useState(readChordFormatPreference)
   const [hideChords, setHideChordsState] = useState(readHideChordsPreference)
   const [tocMultilingual, setTocMultilingualState] = useState(readTocMultilingualPreference)
+  const [avBilingual, setAvBilingualState] = useState(readAvBilingualPreference)
   const [sheetBackgroundPreference, setSheetBackgroundPreference] = useState(readSheetBackgroundPreference)
   const [invertSheetImages, setInvertSheetImagesState] = useState(readSheetImageInvertPreference)
   const [layoutPreferences, setLayoutPreferences] = useState(readPlayerLayoutPreferences)
@@ -561,6 +566,11 @@ export function SettingsView({
   function setTocMultilingual(enabled: boolean) {
     setTocMultilingualState(enabled)
     writeTocMultilingualPreference(enabled)
+  }
+
+  function setAvBilingual(enabled: boolean) {
+    setAvBilingualState(enabled)
+    writeAvBilingualPreference(enabled)
   }
 
   function setSheetBackground(next: SheetBackgroundPreference) {
@@ -1012,6 +1022,21 @@ export function SettingsView({
                   <span>{t('settings.playerRoles.content.balanceSlideLines')}</span>
                   <span className="text-xs text-[var(--color-muted-foreground)]">
                     {t('settings.playerRoles.content.balanceSlideLinesDescription')}
+                  </span>
+                </span>
+              </label>
+              <label className="flex items-start gap-3 text-sm">
+                <input
+                  type="checkbox"
+                  className="mt-0.5 size-4 shrink-0 accent-[var(--color-primary)]"
+                  aria-label={t('settings.avBilingual.label')}
+                  checked={avBilingual}
+                  onChange={(e) => setAvBilingual(e.target.checked)}
+                />
+                <span className="flex flex-col gap-0.5">
+                  <span>{t('settings.avBilingual.label')}</span>
+                  <span className="text-xs text-[var(--color-muted-foreground)]">
+                    {t('settings.avBilingual.description')}
                   </span>
                 </span>
               </label>

--- a/frontend/app/src/components/settings/settings-view.test.tsx
+++ b/frontend/app/src/components/settings/settings-view.test.tsx
@@ -107,4 +107,27 @@ describe('SettingsView', () => {
       screen.getByRole('checkbox', { name: 'settings.tocMultilingual.label' }),
     ).toBeChecked()
   })
+
+  it('renders the AV bilingual control in Player AV and restores it from storage', async () => {
+    const user = userEvent.setup()
+
+    const { unmount } = render(<SettingsView activeTab="playerRoles" />)
+    const toggle = screen.getByRole('checkbox', {
+      name: 'settings.avBilingual.label',
+    })
+
+    expect(toggle).not.toBeChecked()
+
+    await user.click(toggle)
+
+    expect(toggle).toBeChecked()
+    expect(window.localStorage.getItem('wv_av_bilingual')).toBe('true')
+
+    unmount()
+
+    render(<SettingsView activeTab="playerRoles" />)
+    expect(
+      screen.getByRole('checkbox', { name: 'settings.avBilingual.label' }),
+    ).toBeChecked()
+  })
 })

--- a/frontend/app/src/hooks/useAvBilingualPreference.ts
+++ b/frontend/app/src/hooks/useAvBilingualPreference.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react'
+
+import {
+  AV_BILINGUAL_CHANGE_EVENT,
+  readAvBilingualPreference,
+} from '@/lib/av-bilingual-preference'
+
+export function useAvBilingualPreference(): boolean {
+  const [enabled, setEnabled] = useState(readAvBilingualPreference)
+
+  useEffect(() => {
+    const onChange = (event: Event) => {
+      const detail = (event as CustomEvent<boolean>).detail
+      setEnabled(detail ?? readAvBilingualPreference())
+    }
+
+    globalThis.window.addEventListener(AV_BILINGUAL_CHANGE_EVENT, onChange)
+    return () => globalThis.window.removeEventListener(AV_BILINGUAL_CHANGE_EVENT, onChange)
+  }, [])
+
+  return enabled
+}

--- a/frontend/app/src/i18n/de.json
+++ b/frontend/app/src/i18n/de.json
@@ -497,6 +497,10 @@
       "label": "Mehrsprachige Liedtitel im Inhaltsverzeichnis erweitern",
       "description": "Zeigt im Inhaltsverzeichnis bei aktivem Sprachfilter den passenden übersetzten Titel. Die Erweiterung für A–Z und Favoriten folgt später."
     },
+    "avBilingual": {
+      "label": "Zweisprachige AV-Texte",
+      "description": "Zeigt unter jeder primären Textzeile im AV-Modus eine kleinere Übersetzung. Das externe Ausgabefenster bleibt vorerst einsprachig."
+    },
     "hideChords": {
       "label": "Akkorde im Player und Export ausblenden",
       "description": "Zeigt im Player und beim Export von PDF- oder Textdateien nur Songtext. Der Song-Editor bleibt unverändert."

--- a/frontend/app/src/i18n/en.json
+++ b/frontend/app/src/i18n/en.json
@@ -497,6 +497,10 @@
       "label": "Expand multilingual song titles in the TOC",
       "description": "Use the matching translated title in the table of contents when a language filter is active. Alphabetical and liked expansion will come later."
     },
+    "avBilingual": {
+      "label": "Bilingual AV lyrics",
+      "description": "Show a smaller translation beneath each primary lyric line in AV mode. The external output window stays primary-only until projection support is enabled separately."
+    },
     "hideChords": {
       "label": "Hide chords in player and exports",
       "description": "Show only song lyrics in the player and when exporting PDF or text files. The song editor is not affected."

--- a/frontend/app/src/lib/av-bilingual-preference.test.ts
+++ b/frontend/app/src/lib/av-bilingual-preference.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  AV_BILINGUAL_STORAGE_KEY,
+  readAvBilingualPreference,
+  writeAvBilingualPreference,
+} from '@/lib/av-bilingual-preference'
+
+describe('readAvBilingualPreference', () => {
+  it('defaults to false when unset', () => {
+    expect(readAvBilingualPreference({ getItem: () => null })).toBe(false)
+  })
+
+  it('reads stored boolean strings', () => {
+    expect(readAvBilingualPreference({ getItem: () => 'true' })).toBe(true)
+    expect(readAvBilingualPreference({ getItem: () => 'false' })).toBe(false)
+  })
+
+  it('falls back to false for malformed storage', () => {
+    expect(readAvBilingualPreference({ getItem: () => 'yes' })).toBe(false)
+  })
+})
+
+describe('writeAvBilingualPreference', () => {
+  it('stores and clears the preference', () => {
+    const storage = new Map<string, string>()
+    const mockStorage = {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        storage.set(key, value)
+      },
+      removeItem: (key: string) => {
+        storage.delete(key)
+      },
+    }
+
+    writeAvBilingualPreference(true, mockStorage)
+    expect(storage.get(AV_BILINGUAL_STORAGE_KEY)).toBe('true')
+    writeAvBilingualPreference(false, mockStorage)
+    expect(storage.has(AV_BILINGUAL_STORAGE_KEY)).toBe(false)
+  })
+
+  it('notifies listeners when window is available', () => {
+    const dispatchEvent = vi.fn()
+    vi.stubGlobal('window', { dispatchEvent })
+
+    writeAvBilingualPreference(true, { setItem: vi.fn(), removeItem: vi.fn() })
+
+    expect(dispatchEvent).toHaveBeenCalledOnce()
+    vi.unstubAllGlobals()
+  })
+})

--- a/frontend/app/src/lib/av-bilingual-preference.ts
+++ b/frontend/app/src/lib/av-bilingual-preference.ts
@@ -1,0 +1,28 @@
+import { getLocalStorage, safeGetItem, safeRemoveItem, safeSetItem } from '@/lib/browser-storage'
+
+export const AV_BILINGUAL_STORAGE_KEY = 'wv_av_bilingual'
+
+export const AV_BILINGUAL_CHANGE_EVENT = 'wv-av-bilingual-change'
+
+export function readAvBilingualPreference(
+  storage: Pick<Storage, 'getItem'> | null = getLocalStorage(),
+): boolean {
+  return safeGetItem(AV_BILINGUAL_STORAGE_KEY, storage) === 'true'
+}
+
+export function writeAvBilingualPreference(
+  enabled: boolean,
+  storage: Pick<Storage, 'setItem' | 'removeItem'> | null = getLocalStorage(),
+): void {
+  if (enabled) {
+    safeSetItem(AV_BILINGUAL_STORAGE_KEY, 'true', storage)
+  } else {
+    safeRemoveItem(AV_BILINGUAL_STORAGE_KEY, storage)
+  }
+
+  if (typeof globalThis.window !== 'undefined') {
+    globalThis.window.dispatchEvent(
+      new CustomEvent(AV_BILINGUAL_CHANGE_EVENT, { detail: enabled }),
+    )
+  }
+}

--- a/frontend/app/src/lib/player/av-lyric-slides.test.ts
+++ b/frontend/app/src/lib/player/av-lyric-slides.test.ts
@@ -1,13 +1,19 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  avLyricLinesToSlideText,
   avSlideDeckEntrySlideIndex,
+  buildAvBilingualLyricSlides,
   buildAvLyricSlides,
   buildAvOutlineRows,
   buildAvPresentationSlides,
+  buildAvPresentationStructuredSlides,
   buildAvSlideDeckEntries,
   distributeSlideLineCounts,
+  resolveAvEffectivePrimaryLanguageIndex,
   resolveAvOutlineSlideText,
+  resolveAvSecondaryLanguageIndex,
+  songHasUsableLyricsAtIndex,
 } from '@/lib/player/av-lyric-slides'
 
 describe('distributeSlideLineCounts', () => {
@@ -397,5 +403,162 @@ describe('buildAvPresentationSlides', () => {
     ]
 
     expect(buildAvPresentationSlides(outline, [])).toEqual([''])
+  })
+})
+
+const bilingualSections = [
+  {
+    title: 'Verse 1',
+    lines: [
+      { parts: [{ comment: false, languages: ['Hello', 'Hallo', 'Bonjour'] }] },
+      { parts: [{ comment: false, languages: ['World', 'Welt', ''] }] },
+    ],
+  },
+  {
+    title: 'Chorus',
+    lines: [
+      { parts: [{ comment: false, languages: ['Sing', 'Singt', 'Chante'] }] },
+    ],
+  },
+]
+
+describe('bilingual track selection', () => {
+  it('detects usable lyrics per language index', () => {
+    expect(songHasUsableLyricsAtIndex(bilingualSections, 0)).toBe(true)
+    expect(songHasUsableLyricsAtIndex(bilingualSections, 2)).toBe(true)
+    expect(songHasUsableLyricsAtIndex(bilingualSections, 99)).toBe(false)
+  })
+
+  it('falls back to track 0 when the requested primary has no lyrics', () => {
+    const sparsePrimary = [
+      {
+        title: 'Verse 1',
+        lines: [{ parts: [{ comment: false, languages: ['Hello', '', 'Bonjour'] }] }],
+      },
+    ]
+
+    expect(resolveAvEffectivePrimaryLanguageIndex(sparsePrimary, 1)).toBe(0)
+    expect(resolveAvEffectivePrimaryLanguageIndex(sparsePrimary, 0)).toBe(0)
+  })
+
+  it('picks the first other language track for secondary in two-language songs', () => {
+    const twoLang = [
+      {
+        title: 'Verse 1',
+        lines: [{ parts: [{ comment: false, languages: ['Hello', 'Hallo'] }] }],
+      },
+    ]
+
+    expect(resolveAvSecondaryLanguageIndex(twoLang, 0)).toBe(1)
+    expect(resolveAvSecondaryLanguageIndex(twoLang, 1)).toBe(0)
+  })
+
+  it('picks the first other usable track for three or more languages', () => {
+    expect(resolveAvSecondaryLanguageIndex(bilingualSections, 1)).toBe(0)
+    expect(resolveAvSecondaryLanguageIndex(bilingualSections, 0)).toBe(1)
+    expect(resolveAvSecondaryLanguageIndex(bilingualSections, 2)).toBe(0)
+  })
+
+  it('returns null when no secondary track has lyrics', () => {
+    const singleLang = [
+      {
+        title: 'Verse 1',
+        lines: [{ parts: [{ comment: false, languages: ['Hello'] }] }],
+      },
+    ]
+
+    expect(resolveAvSecondaryLanguageIndex(singleLang, 0)).toBeNull()
+  })
+})
+
+describe('buildAvBilingualLyricSlides', () => {
+  it('pairs primary and secondary lines and omits empty secondary rows', () => {
+    const result = buildAvBilingualLyricSlides(bilingualSections, 2, 0, 1)
+
+    expect(result.slides).toEqual(['Hello\nWorld', 'Sing'])
+    expect(result.structuredSlides).toEqual([
+      [
+        { primary: 'Hello', secondary: 'Hallo' },
+        { primary: 'World', secondary: 'Welt' },
+      ],
+      [{ primary: 'Sing', secondary: 'Singt' }],
+    ])
+    expect(avLyricLinesToSlideText(result.structuredSlides![0]!)).toBe('Hello\nWorld')
+  })
+
+  it('keeps the same slide count as single-language mode', () => {
+    const mono = buildAvLyricSlides(bilingualSections, 2, 0, true, true)
+    const bilingual = buildAvBilingualLyricSlides(bilingualSections, 2, 0, 1, true, true)
+
+    expect(bilingual.slides).toEqual(mono.slides)
+    expect(bilingual.slides.length).toBe(mono.slides.length)
+    expect(bilingual.outline).toEqual(mono.outline)
+  })
+
+  it('falls back to single-language output when no secondary track exists', () => {
+    const singleLang = [
+      {
+        title: 'Verse 1',
+        lines: [{ parts: [{ comment: false, languages: ['Hello'] }] }],
+      },
+    ]
+    const mono = buildAvLyricSlides(singleLang, 2, 0)
+    const bilingual = buildAvBilingualLyricSlides(singleLang, 2, 0, null)
+
+    expect(bilingual).toEqual(mono)
+    expect(bilingual.structuredSlides).toBeUndefined()
+  })
+
+  it('preserves balancing and whitespace behavior in structured slides', () => {
+    const sections = [
+      {
+        title: 'Verse 1',
+        lines: [
+          { parts: [{ comment: false, languages: ['Line one', 'Zeile eins'] }] },
+          { parts: [{ comment: false, languages: ['Line two', 'Zeile zwei'] }] },
+          { parts: [{ comment: false, languages: ['Line three', 'Zeile drei'] }] },
+          { parts: [{ comment: false, languages: ['Line four', 'Zeile vier'] }] },
+          { parts: [{ comment: false, languages: ['Line five', 'Zeile fuenf'] }] },
+        ],
+      },
+    ]
+
+    const mono = buildAvLyricSlides(sections, 2, 0, true, true)
+    const bilingual = buildAvBilingualLyricSlides(sections, 2, 0, 1, true, true)
+
+    expect(bilingual.slides).toEqual(mono.slides)
+    expect(bilingual.structuredSlides?.map((slide) => slide.length)).toEqual(
+      mono.slides.map((slide) => slide.split('\n').length),
+    )
+  })
+
+  it('builds structured deck entries and repeated-section donors', () => {
+    const repeated = [
+      {
+        title: 'Chorus',
+        lines: [{ parts: [{ comment: false, languages: ['Sing', 'Singt'] }] }],
+      },
+      {
+        title: 'Verse 1',
+        lines: [{ parts: [{ comment: false, languages: ['Verse', 'Strophe'] }] }],
+      },
+      {
+        title: 'Chorus',
+        lines: [],
+      },
+    ]
+    const result = buildAvBilingualLyricSlides(repeated, 2, 0, 1)
+    const entries = buildAvSlideDeckEntries(
+      result.outline,
+      result.slides,
+      result.structuredSlides,
+    )
+
+    expect(entries).toHaveLength(2)
+    expect(entries[0]?.lines).toEqual([{ primary: 'Sing', secondary: 'Singt' }])
+    expect(entries[1]?.lines).toEqual([{ primary: 'Verse', secondary: 'Strophe' }])
+    expect(
+      buildAvPresentationStructuredSlides(result.outline, result.structuredSlides!),
+    ).toHaveLength(buildAvPresentationSlides(result.outline, result.slides).length)
   })
 })

--- a/frontend/app/src/lib/player/av-lyric-slides.ts
+++ b/frontend/app/src/lib/player/av-lyric-slides.ts
@@ -19,6 +19,77 @@ export type AvLyricSlidesResult = {
   outline: AvSectionOutline[]
 }
 
+export type AvLyricLine = {
+  primary: string
+  secondary?: string
+}
+
+export type AvBilingualLyricSlidesResult = AvLyricSlidesResult & {
+  structuredSlides?: AvLyricLine[][]
+}
+
+function maxLanguageCount(sections: Section[]): number {
+  let max = 0
+  for (const section of sections) {
+    for (const line of section.lines) {
+      for (const part of line.parts) {
+        if (part.comment) continue
+        if (Array.isArray(part.languages)) {
+          max = Math.max(max, part.languages.length)
+        }
+      }
+    }
+  }
+  return max
+}
+
+export function songHasUsableLyricsAtIndex(
+  sections: Section[] | undefined | null,
+  languageIndex: number,
+  collapseLyricWhitespace = true,
+): boolean {
+  if (!sections?.length) return false
+  if (languageIndex < 0 || languageIndex >= maxLanguageCount(sections)) return false
+  for (const section of sections) {
+    for (const line of section.lines) {
+      const text = lyricFromLine(line, languageIndex, collapseLyricWhitespace)
+      if (text.trim()) return true
+    }
+  }
+  return false
+}
+
+export function resolveAvEffectivePrimaryLanguageIndex(
+  sections: Section[] | undefined | null,
+  requestedIndex: number,
+  collapseLyricWhitespace = true,
+): number {
+  if (songHasUsableLyricsAtIndex(sections, requestedIndex, collapseLyricWhitespace)) {
+    return requestedIndex
+  }
+  return 0
+}
+
+export function resolveAvSecondaryLanguageIndex(
+  sections: Section[] | undefined | null,
+  primaryIndex: number,
+  collapseLyricWhitespace = true,
+): number | null {
+  if (!sections?.length) return null
+  const languageCount = maxLanguageCount(sections)
+  for (let index = 0; index < languageCount; index += 1) {
+    if (index === primaryIndex) continue
+    if (songHasUsableLyricsAtIndex(sections, index, collapseLyricWhitespace)) {
+      return index
+    }
+  }
+  return null
+}
+
+export function avLyricLinesToSlideText(lines: AvLyricLine[]): string {
+  return lines.map((line) => line.primary).join('\n')
+}
+
 function lyricFromPart(part: Part, languageIndex: number): string {
   if (part.comment) return ''
   const languages = part.languages
@@ -70,6 +141,71 @@ export function distributeSlideLineCounts(
     ]
   }
   return [...Array.from({ length: slideCount - 1 }, () => maxPerSlide), remainder]
+}
+
+function chunkStructuredLines(
+  lines: AvLyricLine[],
+  maxLinesPerSlide: number,
+  balanceSlideLines: boolean,
+): AvLyricLine[][] {
+  const counts = distributeSlideLineCounts(lines.length, maxLinesPerSlide, balanceSlideLines)
+  const slides: AvLyricLine[][] = []
+  let offset = 0
+  for (const count of counts) {
+    slides.push(lines.slice(offset, offset + count))
+    offset += count
+  }
+  return slides
+}
+
+function buildBilingualSlidesFromSections(
+  sections: Section[],
+  maxLinesPerSlide: number,
+  primaryLanguageIndex: number,
+  secondaryLanguageIndex: number,
+  balanceSlideLines: boolean,
+  collapseLyricWhitespace: boolean,
+): {
+  slides: string[]
+  structuredSlides: AvLyricLine[][]
+  sectionMap: Map<string, { textIdx: number; len: number }>
+} {
+  const slides: string[] = []
+  const structuredSlides: AvLyricLine[][] = []
+  const sectionMap = new Map<string, { textIdx: number; len: number }>()
+  let slideIdxCounter = 0
+
+  for (const section of sections) {
+    const currentIdx = slideIdxCounter
+    const sectionLines: AvLyricLine[] = []
+
+    for (const line of section.lines) {
+      const primaryText = lyricFromLine(line, primaryLanguageIndex, collapseLyricWhitespace)
+      if (!primaryText.trim()) continue
+      const secondaryText = lyricFromLine(line, secondaryLanguageIndex, collapseLyricWhitespace)
+      const lyricLine: AvLyricLine = secondaryText.trim()
+        ? { primary: primaryText, secondary: secondaryText }
+        : { primary: primaryText }
+      sectionLines.push(lyricLine)
+    }
+
+    const sectionStructuredSlides = chunkStructuredLines(
+      sectionLines,
+      maxLinesPerSlide,
+      balanceSlideLines,
+    )
+    for (const structuredSlide of sectionStructuredSlides) {
+      structuredSlides.push(structuredSlide)
+      slides.push(avLyricLinesToSlideText(structuredSlide))
+      slideIdxCounter += 1
+    }
+
+    if (sectionStructuredSlides.length > 0 && !sectionMap.has(section.title)) {
+      sectionMap.set(section.title, { textIdx: currentIdx, len: sectionStructuredSlides.length })
+    }
+  }
+
+  return { slides, structuredSlides, sectionMap }
 }
 
 function chunkLines(
@@ -169,6 +305,41 @@ export function buildAvLyricSlides(
   return { slides, outline: buildOutline(sections, sectionMap) }
 }
 
+export function buildAvBilingualLyricSlides(
+  sections: Section[] | undefined | null,
+  maxLinesPerSlide: number,
+  primaryLanguageIndex: number,
+  secondaryLanguageIndex: number | null,
+  balanceSlideLines = true,
+  collapseLyricWhitespace = true,
+): AvBilingualLyricSlidesResult {
+  if (!sections?.length) {
+    return { slides: [], outline: [] }
+  }
+  if (secondaryLanguageIndex == null) {
+    return buildAvLyricSlides(
+      sections,
+      maxLinesPerSlide,
+      primaryLanguageIndex,
+      balanceSlideLines,
+      collapseLyricWhitespace,
+    )
+  }
+  const { slides, structuredSlides, sectionMap } = buildBilingualSlidesFromSections(
+    sections,
+    maxLinesPerSlide,
+    primaryLanguageIndex,
+    secondaryLanguageIndex,
+    balanceSlideLines,
+    collapseLyricWhitespace,
+  )
+  return {
+    slides,
+    structuredSlides,
+    outline: buildOutline(sections, sectionMap),
+  }
+}
+
 export function findAvSectionOutline(
   outline: AvSectionOutline[],
   title: string,
@@ -204,6 +375,21 @@ export function resolveAvOutlineSlideText(
   return slides[donor.textIdx + donorOffset] ?? ''
 }
 
+export function resolveAvOutlineStructuredSlideText(
+  outline: AvSectionOutline[],
+  slides: AvLyricLine[][],
+  row: AvSectionOutline,
+  offset = 0,
+): AvLyricLine[] {
+  if (row.hasText) {
+    return slides[row.textIdx + offset] ?? []
+  }
+  const donor = findAvTextDonor(outline, row.title)
+  if (!donor) return []
+  const donorOffset = Math.min(offset, donor.len - 1)
+  return slides[donor.textIdx + donorOffset] ?? []
+}
+
 /** Full navigable slide list aligned with the outline (includes empty/borrowed slides). */
 export function buildAvPresentationSlides(
   outline: AvSectionOutline[],
@@ -216,6 +402,23 @@ export function buildAvPresentationSlides(
   for (const row of outline) {
     for (let offset = 0; offset < row.len; offset += 1) {
       presentation.push(resolveAvOutlineSlideText(outline, slides, row, offset))
+    }
+  }
+  return presentation
+}
+
+/** Full navigable structured slide list aligned with the outline. */
+export function buildAvPresentationStructuredSlides(
+  outline: AvSectionOutline[],
+  slides: AvLyricLine[][],
+): AvLyricLine[][] {
+  if (outline.length === 0) {
+    return slides
+  }
+  const presentation: AvLyricLine[][] = []
+  for (const row of outline) {
+    for (let offset = 0; offset < row.len; offset += 1) {
+      presentation.push(resolveAvOutlineStructuredSlideText(outline, slides, row, offset))
     }
   }
   return presentation
@@ -269,6 +472,7 @@ export type AvSlideDeckEntry = {
   slideIndex: number
   label: string
   text: string
+  lines?: AvLyricLine[]
   isSubSlide: boolean
   hasText: boolean
 }
@@ -277,6 +481,7 @@ export type AvSlideDeckEntry = {
 export function buildAvSlideDeckEntries(
   outline: AvSectionOutline[],
   sourceSlides: string[],
+  structuredSourceSlides?: AvLyricLine[][],
 ): AvSlideDeckEntry[] {
   const entries: AvSlideDeckEntry[] = []
   let presentationIndex = 0
@@ -287,10 +492,14 @@ export function buildAvSlideDeckEntries(
     }
     for (let offset = 0; offset < row.len; offset += 1) {
       if (row.hasText) {
+        const lines = structuredSourceSlides
+          ? resolveAvOutlineStructuredSlideText(outline, structuredSourceSlides, row, offset)
+          : undefined
         entries.push({
           slideIndex: presentationIndex,
           label: offset === 0 ? row.title : `${row.title} (${offset + 1})`,
           text: resolveAvOutlineSlideText(outline, sourceSlides, row, offset),
+          lines: lines && lines.length > 0 ? lines : undefined,
           isSubSlide: offset > 0,
           hasText: true,
         })
@@ -300,10 +509,12 @@ export function buildAvSlideDeckEntries(
   }
   if (entries.length === 0) {
     for (let slideIndex = 0; slideIndex < sourceSlides.length; slideIndex += 1) {
+      const lines = structuredSourceSlides?.[slideIndex]
       entries.push({
         slideIndex,
         label: `Slide ${slideIndex + 1}`,
         text: sourceSlides[slideIndex] ?? '',
+        lines: lines && lines.length > 0 ? lines : undefined,
         isSubSlide: false,
         hasText: true,
       })

--- a/frontend/app/src/lib/player/av-nav.test.ts
+++ b/frontend/app/src/lib/player/av-nav.test.ts
@@ -130,3 +130,40 @@ describe('av flat slides', () => {
     expect(buildAvOutlineRows(german.outline, 0).map((row) => row.slideIndex)).toEqual([0, 1])
   })
 })
+
+describe('avSlidesForItem bilingual mode', () => {
+  it('produces structured lines while keeping primary-only string slides', () => {
+    const item = chordItem('de')
+    const bilingual = avSlidesForItem(item, 0, split, 'Setlist title', () => 0, true)
+
+    expect(bilingual.slides).toEqual(['Hello', 'Goodbye'])
+    expect(bilingual.structuredSlides).toEqual([
+      [{ primary: 'Hello', secondary: 'Hallo' }],
+      [{ primary: 'Goodbye', secondary: 'Tschuess' }],
+    ])
+  })
+
+  it('swaps tracks when the primary override changes', () => {
+    const item = chordItem('de')
+    const english = avSlidesForItem(item, 0, split, 'Setlist title', () => 0, true)
+    const german = avSlidesForItem(item, 0, split, 'Setlist title', () => 1, true)
+
+    expect(english.structuredSlides?.[0]?.[0]).toEqual({
+      primary: 'Hello',
+      secondary: 'Hallo',
+    })
+    expect(german.structuredSlides?.[0]?.[0]).toEqual({
+      primary: 'Hallo',
+      secondary: 'Hello',
+    })
+  })
+
+  it('matches monolingual slide counts when bilingual is disabled', () => {
+    const item = chordItem('de')
+    const mono = avSlidesForItem(item, 0, split, 'Setlist title', () => 0, false)
+    const bilingual = avSlidesForItem(item, 0, split, 'Setlist title', () => 0, true)
+
+    expect(bilingual.slides).toEqual(mono.slides)
+    expect(bilingual.slides.length).toBe(mono.slides.length)
+  })
+})

--- a/frontend/app/src/lib/player/av-nav.ts
+++ b/frontend/app/src/lib/player/av-nav.ts
@@ -1,10 +1,16 @@
 import type { components } from '@/api/schema'
 
 import {
+  type AvLyricLine,
+  type AvBilingualLyricSlidesResult,
   type AvSectionOutline,
   blobItemSlideText,
+  buildAvBilingualLyricSlides,
   buildAvLyricSlides,
   buildAvPresentationSlides,
+  buildAvPresentationStructuredSlides,
+  resolveAvEffectivePrimaryLanguageIndex,
+  resolveAvSecondaryLanguageIndex,
 } from '@/lib/player/av-lyric-slides'
 import type { AvLyricSplitPrefs } from '@/lib/player/av-preferences'
 import { itemTypeAt, tocEntryForIndex } from '@/lib/player/player-helpers'
@@ -18,6 +24,8 @@ export type AvLanguageIndexResolver = (itemIndex: number) => number | undefined
 export type AvItemSlides = {
   slides: string[]
   sourceSlides: string[]
+  structuredSlides?: AvLyricLine[][]
+  structuredSourceSlides?: AvLyricLine[][]
   outline: AvSectionOutline[]
   kind: 'lyrics' | 'blob'
 }
@@ -68,6 +76,7 @@ export function avSlidesForItem(
   split: AvLyricSplitPrefs,
   fallbackTitle?: string,
   resolveLanguageIndex?: AvLanguageIndexResolver,
+  bilingualEnabled = false,
 ): AvItemSlides {
   if (!item) return { slides: [''], sourceSlides: [''], outline: [], kind: 'blob' }
   if (item.type === 'blob') {
@@ -80,33 +89,60 @@ export function avSlidesForItem(
     }
   }
   const songData = item.song.data
-  const languageIndex = resolveAvItemLanguageIndex(item, itemIndex, resolveLanguageIndex)
-  const lyricData = buildAvLyricSlides(
-    songData.sections,
-    split.maxLinesPerSlide,
-    languageIndex,
-    split.balanceSlideLines,
-    split.collapseLyricWhitespace,
-  )
+  const requestedPrimary = resolveAvItemLanguageIndex(item, itemIndex, resolveLanguageIndex)
+  const effectivePrimary = bilingualEnabled
+    ? resolveAvEffectivePrimaryLanguageIndex(
+        songData.sections,
+        requestedPrimary,
+        split.collapseLyricWhitespace,
+      )
+    : requestedPrimary
+  const lyricData: AvBilingualLyricSlidesResult = bilingualEnabled
+    ? buildAvBilingualLyricSlides(
+        songData.sections,
+        split.maxLinesPerSlide,
+        effectivePrimary,
+        resolveAvSecondaryLanguageIndex(
+          songData.sections,
+          effectivePrimary,
+          split.collapseLyricWhitespace,
+        ),
+        split.balanceSlideLines,
+        split.collapseLyricWhitespace,
+      )
+    : buildAvLyricSlides(
+        songData.sections,
+        split.maxLinesPerSlide,
+        requestedPrimary,
+        split.balanceSlideLines,
+        split.collapseLyricWhitespace,
+      )
   if (lyricData.outline.length === 0 && lyricData.slides.length === 0) {
     const title = songTitleAtLanguageIndex(
       songData as Record<string, unknown>,
-      languageIndex,
+      requestedPrimary,
       fallbackTitle,
     )
     return { slides: [title], sourceSlides: [title], outline: [], kind: 'lyrics' }
   }
   const slides = buildAvPresentationSlides(lyricData.outline, lyricData.slides)
+  const structuredSourceSlides = lyricData.structuredSlides
+  const structuredSlides =
+    structuredSourceSlides && lyricData.outline.length > 0
+      ? buildAvPresentationStructuredSlides(lyricData.outline, structuredSourceSlides)
+      : structuredSourceSlides
   if (slides.length === 0) {
     return {
       slides: [
         songTitleAtLanguageIndex(
           songData as Record<string, unknown>,
-          languageIndex,
+          requestedPrimary,
           fallbackTitle,
         ),
       ],
       sourceSlides: lyricData.slides,
+      structuredSlides,
+      structuredSourceSlides,
       outline: lyricData.outline,
       kind: 'lyrics',
     }
@@ -114,6 +150,8 @@ export function avSlidesForItem(
   return {
     slides,
     sourceSlides: lyricData.slides,
+    structuredSlides,
+    structuredSourceSlides,
     outline: lyricData.outline,
     kind: 'lyrics',
   }
@@ -124,6 +162,7 @@ export function avSlidesForPlayerItem(
   itemIndex: number,
   split: AvLyricSplitPrefs,
   resolveLanguageIndex?: AvLanguageIndexResolver,
+  bilingualEnabled = false,
 ): AvItemSlides {
   return avSlidesForItem(
     items[itemIndex],
@@ -131,6 +170,7 @@ export function avSlidesForPlayerItem(
     split,
     undefined,
     resolveLanguageIndex,
+    bilingualEnabled,
   )
 }
 
@@ -145,6 +185,7 @@ export function buildAvFlatSlides(
   split: AvLyricSplitPrefs,
   toc: Player['toc'] = [],
   resolveLanguageIndex?: AvLanguageIndexResolver,
+  bilingualEnabled = false,
 ): AvFlatSlide[] {
   const flat: AvFlatSlide[] = []
   for (let itemIndex = 0; itemIndex < items.length; itemIndex += 1) {
@@ -155,6 +196,7 @@ export function buildAvFlatSlides(
       split,
       tocTitle,
       resolveLanguageIndex,
+      bilingualEnabled,
     )
     for (let slideIndex = 0; slideIndex < slides.length; slideIndex += 1) {
       flat.push({ itemIndex, slideIndex, text: slides[slideIndex] ?? '' })
@@ -264,8 +306,15 @@ export type AvPlayerContext = {
   player: Player
   split: AvLyricSplitPrefs
   resolveLanguageIndex?: AvLanguageIndexResolver
+  bilingualEnabled?: boolean
 }
 
 export function rebuildAvFlat(ctx: AvPlayerContext): AvFlatSlide[] {
-  return buildAvFlatSlides(ctx.player.items, ctx.split, ctx.player.toc, ctx.resolveLanguageIndex)
+  return buildAvFlatSlides(
+    ctx.player.items,
+    ctx.split,
+    ctx.player.toc,
+    ctx.resolveLanguageIndex,
+    ctx.bilingualEnabled,
+  )
 }

--- a/frontend/app/src/lib/player/av-preferences.test.ts
+++ b/frontend/app/src/lib/player/av-preferences.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_AV_PREFERENCES,
+  buildAvProjectionPayload,
+} from '@/lib/player/av-preferences'
+
+const baseInput = {
+  contentText: 'Hello',
+  contentLayer: DEFAULT_AV_PREFERENCES.contentLayer,
+  backgroundLayer: DEFAULT_AV_PREFERENCES.backgroundLayer,
+  transition: DEFAULT_AV_PREFERENCES.transition,
+  itemTitle: 'Song',
+  nextPreview: 'Next',
+}
+
+describe('buildAvProjectionPayload', () => {
+  it('includes structured lines and primary fallback text when live', () => {
+    const contentLines = [
+      { primary: 'Hello', secondary: 'Hallo' },
+      { primary: 'World' },
+    ]
+
+    const payload = buildAvProjectionPayload({
+      ...baseInput,
+      contentLines,
+      screenState: 'live',
+    })
+
+    expect(payload.contentText).toBe('Hello')
+    expect(payload.contentLines).toEqual(contentLines)
+    expect(payload.screenState).toBe('live')
+  })
+
+  it('returns a legacy primary-only payload when contentLines are absent', () => {
+    const payload = buildAvProjectionPayload({
+      ...baseInput,
+      screenState: 'live',
+    })
+
+    expect(payload.contentText).toBe('Hello')
+    expect(payload.contentLines).toBeUndefined()
+  })
+
+  it('omits contentLines for blank and blackout screen states', () => {
+    const contentLines = [{ primary: 'Hello', secondary: 'Hallo' }]
+
+    expect(
+      buildAvProjectionPayload({
+        ...baseInput,
+        contentLines,
+        screenState: 'blank',
+      }).contentLines,
+    ).toBeUndefined()
+    expect(
+      buildAvProjectionPayload({
+        ...baseInput,
+        contentLines,
+        screenState: 'blackout',
+      }).contentLines,
+    ).toBeUndefined()
+  })
+})

--- a/frontend/app/src/lib/player/av-preferences.ts
+++ b/frontend/app/src/lib/player/av-preferences.ts
@@ -1,3 +1,4 @@
+import type { AvLyricLine } from '@/lib/player/av-lyric-slides'
 import { getLocalStorage, safeGetItem, safeSetItem } from '@/lib/browser-storage'
 import type { PlayerMode } from '@/lib/player/player-mode'
 
@@ -186,6 +187,7 @@ export function effectiveAvTransition(
 
 export type AvProjectionPayload = {
   contentText: string
+  contentLines?: AvLyricLine[]
   contentLayer: AvContentLayer
   backgroundLayer: AvBackgroundLayer
   transition: AvTransition
@@ -196,6 +198,7 @@ export type AvProjectionPayload = {
 
 export function buildAvProjectionPayload(input: {
   contentText: string
+  contentLines?: AvLyricLine[]
   contentLayer: AvContentLayer
   backgroundLayer: AvBackgroundLayer
   transition: AvTransition
@@ -208,8 +211,13 @@ export function buildAvProjectionPayload(input: {
 }): AvProjectionPayload {
   const screenState =
     input.screenState ?? (input.blackout ? 'blackout' : 'live')
+  const contentLines =
+    screenState === 'live' && input.contentLines && input.contentLines.length > 0
+      ? input.contentLines
+      : undefined
   return {
     contentText: input.contentText,
+    ...(contentLines ? { contentLines } : {}),
     contentLayer: input.contentLayer,
     backgroundLayer: input.backgroundLayer,
     transition: effectiveAvTransition(

--- a/frontend/app/src/lib/player/av-projection-sync.test.ts
+++ b/frontend/app/src/lib/player/av-projection-sync.test.ts
@@ -38,6 +38,56 @@ describe('av-projection-sync', () => {
     expect(readAvProjectionSnapshot('session-1', storage)).toEqual(payload)
   })
 
+  it('round-trips structured contentLines through snapshot storage', () => {
+    const map = new Map<string, string>()
+    const storage = {
+      getItem: (key: string) => map.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        map.set(key, value)
+      },
+    }
+    const payload: AvProjectionPayload = {
+      contentText: 'Hello',
+      contentLines: [
+        { primary: 'Hello', secondary: 'Hallo' },
+        { primary: 'World' },
+      ],
+      contentLayer: DEFAULT_AV_PREFERENCES.contentLayer,
+      backgroundLayer: DEFAULT_AV_PREFERENCES.backgroundLayer,
+      transition: DEFAULT_AV_PREFERENCES.transition,
+      screenState: 'live',
+      itemTitle: 'Song',
+      nextPreview: null,
+    }
+
+    writeAvProjectionSnapshot('session-bilingual', payload, storage)
+    expect(readAvProjectionSnapshot('session-bilingual', storage)).toEqual(payload)
+  })
+
+  it('broadcast persists structured contentLines in latest snapshot', () => {
+    const map = new Map<string, string>()
+    const storage = {
+      getItem: (key: string) => map.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        map.set(key, value)
+      },
+    }
+    const sync = createAvProjectionSync('session-bilingual-broadcast', storage)
+    const payload: AvProjectionPayload = {
+      contentText: 'Hallo',
+      contentLines: [{ primary: 'Hallo', secondary: 'Hello' }],
+      contentLayer: DEFAULT_AV_PREFERENCES.contentLayer,
+      backgroundLayer: DEFAULT_AV_PREFERENCES.backgroundLayer,
+      transition: DEFAULT_AV_PREFERENCES.transition,
+      screenState: 'live',
+      itemTitle: 'Anker',
+      nextPreview: 'Tschuess',
+    }
+    sync.broadcast(payload)
+    sync.close()
+    expect(readAvProjectionSnapshot('session-bilingual-broadcast', storage)).toEqual(payload)
+  })
+
   it('broadcast persists latest snapshot', () => {
     const map = new Map<string, string>()
     const storage = {


### PR DESCRIPTION
## Summary
- Add a global `wv_av_bilingual` setting and structured primary/secondary AV lyric lines in the operator UI (E1.5).
- Extend the AV projection payload with optional `contentLines` so the external output window renders the same bilingual rows as the operator view (E1.6).
- Keep `contentText` primary-only for backward compatibility; blank/blackout omit structured lines to avoid stale lyrics.

## Test plan
- [x] `pnpm --filter app exec eslint . --fix`
- [x] `pnpm -C frontend lint`
- [x] `pnpm -C frontend typecheck`
- [x] `pnpm -C frontend test`
- [x] `pnpm -C frontend build`
- [ ] Enable bilingual AV in Settings → Player AV and confirm operator preview + slide panel show muted translations under primary lines
- [ ] Open AV output window and confirm it matches operator bilingual rows; refresh restores latest slide
- [ ] Toggle blank/blackout and confirm no stale lyrics appear
- [ ] Disable bilingual AV and confirm both operator and output return to primary-only rendering