### PR TITLE
fix(frontend): animate hub filter and polish AV player interactions

### DIFF
--- a/frontend/app/src/components/hub/HubShell.tsx
+++ b/frontend/app/src/components/hub/HubShell.tsx
@@ -141,6 +141,7 @@ function HubLibrarySearchField({
   const { t } = useTranslation()
   const { selectedTeamId } = useHubSearch()
   const [filtersOpen, setFiltersOpen] = useState(false)
+  const [filterHovered, setFilterHovered] = useState(false)
   const filterActive = filtersOpen || selectedTeamId != null
 
   return (
@@ -180,6 +181,8 @@ function HubLibrarySearchField({
           aria-label={filtersOpen ? t('hub.filters.closeAria') : t('hub.filters.openAria')}
           aria-pressed={filtersOpen}
           onClick={() => setFiltersOpen((open) => !open)}
+          onMouseEnter={() => setFilterHovered(true)}
+          onMouseLeave={() => setFilterHovered(false)}
           className={cn(
             'mr-1 flex size-10 shrink-0 items-center justify-center rounded-full text-[var(--color-muted-foreground)] outline-none transition-colors',
             'hover:bg-[var(--color-muted)] hover:text-[var(--color-foreground)]',
@@ -187,7 +190,7 @@ function HubLibrarySearchField({
             filterActive && 'bg-[var(--color-muted)] text-[var(--color-foreground)]',
           )}
         >
-          <FilterIcon />
+          <FilterIcon isHovered={filterHovered} size={18} />
         </button>
         {filtersOpen ? (
           <>
@@ -233,6 +236,7 @@ function AdminDateRangeField({
 }) {
   const { t } = useTranslation()
   const [filtersOpen, setFiltersOpen] = useState(false)
+  const [filterHovered, setFilterHovered] = useState(false)
   const filterActive = filtersOpen || activeQuickRange != null
 
   return (
@@ -279,6 +283,8 @@ function AdminDateRangeField({
           aria-label={filtersOpen ? t('hub.filters.closeAria') : t('hub.filters.openAria')}
           aria-pressed={filtersOpen}
           onClick={() => setFiltersOpen((open) => !open)}
+          onMouseEnter={() => setFilterHovered(true)}
+          onMouseLeave={() => setFilterHovered(false)}
           className={cn(
             'mr-1 flex size-10 shrink-0 items-center justify-center rounded-full text-[var(--color-muted-foreground)] outline-none transition-colors',
             'hover:bg-[var(--color-muted)] hover:text-[var(--color-foreground)]',
@@ -286,7 +292,7 @@ function AdminDateRangeField({
             filterActive && 'bg-[var(--color-muted)] text-[var(--color-foreground)]',
           )}
         >
-          <FilterIcon />
+          <FilterIcon isHovered={filterHovered} size={18} />
         </button>
         {filtersOpen ? (
           <>

--- a/frontend/app/src/components/icons/filter-icon.tsx
+++ b/frontend/app/src/components/icons/filter-icon.tsx
@@ -1,26 +1,2 @@
-import type { HTMLAttributes } from 'react'
-
-import { cn } from '@/lib/utils'
-
-export function FilterIcon({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return (
-    <div className={cn(className)} {...props}>
-      <svg
-        aria-hidden
-        width="18"
-        height="18"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path d="M3 5h18" />
-        <path d="M6 12h12" />
-        <path d="M10 19h4" />
-      </svg>
-    </div>
-  )
-}
+export { FilterIcon } from '@/components/icons/lucide-animated/filter-icon'
+export type { FilterIconHandle, FilterIconProps } from '@/components/icons/lucide-animated/filter-icon'

--- a/frontend/app/src/components/icons/lucide-animated/filter-icon.tsx
+++ b/frontend/app/src/components/icons/lucide-animated/filter-icon.tsx
@@ -1,0 +1,130 @@
+import type { Transition } from 'motion/react'
+import { motion, useAnimation } from 'motion/react'
+import type { HTMLAttributes } from 'react'
+import { forwardRef, useCallback, useEffect, useImperativeHandle } from 'react'
+
+import { cn } from '@/lib/utils'
+
+/** Lucide filter paths + Motion — same pattern as Lucide Animated (https://github.com/pqoqubbw/icons). */
+export interface FilterIconHandle {
+  startAnimation: () => void
+  stopAnimation: () => void
+}
+
+export interface FilterIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number
+  isHovered?: boolean
+}
+
+const DEFAULT_TRANSITION: Transition = {
+  type: 'spring',
+  stiffness: 120,
+  damping: 16,
+  mass: 0.9,
+}
+
+export const FilterIcon = forwardRef<FilterIconHandle, FilterIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, isHovered, ...props }, ref) => {
+    const controls = useAnimation()
+    const external = isHovered !== undefined
+
+    useImperativeHandle(ref, () => ({
+      startAnimation: async () => {
+        await controls.start('firstState')
+        await controls.start('secondState')
+      },
+      stopAnimation: () => controls.start('normal'),
+    }))
+
+    useEffect(() => {
+      if (!external) return
+      let cancelled = false
+      async function run() {
+        if (isHovered) {
+          await controls.start('firstState')
+          if (!cancelled) await controls.start('secondState')
+        } else {
+          await controls.start('normal')
+        }
+      }
+      void run()
+      return () => {
+        cancelled = true
+      }
+    }, [external, isHovered, controls])
+
+    const handleMouseEnter = useCallback(
+      async (e: React.MouseEvent<HTMLDivElement>) => {
+        if (external) return
+        onMouseEnter?.(e)
+        await controls.start('firstState')
+        await controls.start('secondState')
+      },
+      [controls, external, onMouseEnter],
+    )
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (external) return
+        void controls.start('normal')
+        onMouseLeave?.(e)
+      },
+      [controls, external, onMouseLeave],
+    )
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden
+        >
+          <motion.path
+            animate={controls}
+            d="M3 5h18"
+            transition={DEFAULT_TRANSITION}
+            variants={{
+              normal: { y: 0 },
+              firstState: { y: 3.5 },
+              secondState: { y: 0 },
+            }}
+          />
+          <motion.path
+            animate={controls}
+            d="M6 12h12"
+            transition={DEFAULT_TRANSITION}
+            variants={{
+              normal: { scaleX: 1, x: 0 },
+              firstState: { scaleX: 0.88, x: 0.72 },
+              secondState: { scaleX: 1, x: 0 },
+            }}
+          />
+          <motion.path
+            animate={controls}
+            d="M10 19h4"
+            transition={DEFAULT_TRANSITION}
+            variants={{
+              normal: { y: 0 },
+              firstState: { y: -3.5 },
+              secondState: { y: 0 },
+            }}
+          />
+        </svg>
+      </div>
+    )
+  },
+)
+
+FilterIcon.displayName = 'FilterIcon'

--- a/frontend/app/src/components/player/PlayerBook.tsx
+++ b/frontend/app/src/components/player/PlayerBook.tsx
@@ -197,7 +197,8 @@ export function PlayerBook({
   const touchMovedRef = useRef(false)
   const suppressClickRef = useRef(false)
   const chromeToggleHandledRef = useRef(false)
-  const lastViewportTapTimeRef = useRef<number | null>(null)
+  const lastMiddleViewportTapTimeRef = useRef<number | null>(null)
+  const pendingChromeOpenRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [likeBurstKey, setLikeBurstKey] = useState(0)
   const [likeBurstActive, setLikeBurstActive] = useState(false)
   const tocMultilingualEnabled = useTocMultilingualPreference()
@@ -335,6 +336,15 @@ export function PlayerBook({
       toast.error(t('player.loadFailed'))
     })
   }, [allowNetworkFetch, currentItem, likedBySongId, online, player, queryClient, t, triggerLikeBurst])
+
+  const cancelPendingChromeOpen = useCallback(() => {
+    if (pendingChromeOpenRef.current != null) {
+      clearTimeout(pendingChromeOpenRef.current)
+      pendingChromeOpenRef.current = null
+    }
+  }, [])
+
+  useEffect(() => () => cancelPendingChromeOpen(), [cancelPendingChromeOpen])
 
   useEffect(() => {
     if (deletedReconciled) {
@@ -515,6 +525,7 @@ export function PlayerBook({
       }
       if (action === 'toggleChrome') {
         e.preventDefault()
+        cancelPendingChromeOpen()
         setKeyPopoverOpen(false)
         setLanguagePopoverOpen(false)
         setChromeVisible((visible) => !visible)
@@ -598,6 +609,7 @@ export function PlayerBook({
     chromeVisible,
     layoutPreferences,
     sheetOrientation,
+    cancelPendingChromeOpen,
     toggleCurrentSongLike,
     type,
     id,
@@ -716,41 +728,62 @@ export function PlayerBook({
     (clientX: number, target: EventTarget | null, rect: DOMRect) => {
       if (isInteractiveTarget(target)) return false
 
+      const zone = viewportPointerZone(clientX, rect)
       const now = performance.now()
       const doubleTap =
-        lastViewportTapTimeRef.current != null &&
-        now - lastViewportTapTimeRef.current < VIEWPORT_DOUBLE_TAP_MS
-      lastViewportTapTimeRef.current = now
+        zone === 'middle' &&
+        lastMiddleViewportTapTimeRef.current != null &&
+        now - lastMiddleViewportTapTimeRef.current < VIEWPORT_DOUBLE_TAP_MS
 
-      const zone = viewportPointerZone(clientX, rect)
+      if (zone === 'middle') {
+        lastMiddleViewportTapTimeRef.current = now
+      }
 
       if (chromeVisible) {
         setKeyPopoverOpen(false)
         setLanguagePopoverOpen(false)
         if (zone !== 'middle') {
+          cancelPendingChromeOpen()
           setChromeVisible(false)
           return true
         }
+        if (doubleTap) {
+          cancelPendingChromeOpen()
+          toggleCurrentSongLike()
+          return true
+        }
+        cancelPendingChromeOpen()
         setChromeVisible(false)
-        if (doubleTap) toggleCurrentSongLike()
         return true
       }
 
       if (zone === 'left') {
+        cancelPendingChromeOpen()
         if (!navBlocked) dispatch({ type: 'prev' })
         return true
       }
       if (zone === 'right') {
+        cancelPendingChromeOpen()
         if (!navBlocked) dispatch({ type: 'next' })
         return true
       }
-      setKeyPopoverOpen(false)
-      setLanguagePopoverOpen(false)
-      setChromeVisible(true)
-      if (doubleTap) toggleCurrentSongLike()
+
+      if (doubleTap) {
+        cancelPendingChromeOpen()
+        toggleCurrentSongLike()
+        return true
+      }
+
+      cancelPendingChromeOpen()
+      pendingChromeOpenRef.current = setTimeout(() => {
+        pendingChromeOpenRef.current = null
+        setKeyPopoverOpen(false)
+        setLanguagePopoverOpen(false)
+        setChromeVisible(true)
+      }, VIEWPORT_DOUBLE_TAP_MS)
       return true
     },
-    [chromeVisible, dispatch, navBlocked, toggleCurrentSongLike],
+    [cancelPendingChromeOpen, chromeVisible, dispatch, navBlocked, toggleCurrentSongLike],
   )
 
   function onTouchEnd(e: React.TouchEvent) {

--- a/frontend/app/src/components/player/av/PlayerAv.test.tsx
+++ b/frontend/app/src/components/player/av/PlayerAv.test.tsx
@@ -104,6 +104,12 @@ vi.mock('@/lib/player/player-view-state', () => ({
       languageByItem: { ...(next?.languageByItem ?? {}), [itemIndex]: languageIndex },
     }
   },
+  clearLanguageForItem: (state: unknown, itemIndex: number) => {
+    const next = state as { languageByItem?: Record<number, number> }
+    const languageByItem = { ...(next?.languageByItem ?? {}) }
+    delete languageByItem[itemIndex]
+    return { ...(next ?? {}), languageByItem }
+  },
 }))
 
 vi.mock('@/components/player/PlayerEditMenu', () => ({
@@ -144,13 +150,24 @@ vi.mock('@/components/player/av/AvSlidesPanel', () => ({
   AvSlidesPanel: ({
     entries,
     currentSlideIndex,
+    onSelectSlide,
   }: {
     entries: Array<{ text: string; slideIndex: number }>
     currentSlideIndex: number | null
+    onSelectSlide: (slideIndex: number) => void
   }) => (
     <div>
       <div data-testid="slide-entry-texts">{entries.map((entry) => entry.text).join('|')}</div>
       <div data-testid="selected-slide-index">{String(currentSlideIndex)}</div>
+      {entries.map((entry) => (
+        <button
+          key={entry.slideIndex}
+          type="button"
+          onClick={() => onSelectSlide(entry.slideIndex)}
+        >
+          Select slide {entry.slideIndex}
+        </button>
+      ))}
     </div>
   ),
 }))
@@ -225,6 +242,53 @@ const player = {
   ] as Player['items'],
 } as Player
 
+const secondSongItem = {
+  type: 'chords',
+  language: 'en',
+  song: {
+    id: 'song-2',
+    blobs: [],
+    not_a_song: false,
+    owner: 'user:test',
+    user_specific_addons: { liked: false },
+    data: {
+      sections: [
+        {
+          title: 'Verse 1',
+          lines: [
+            {
+              parts: [{ comment: false, languages: ['Second song line'] }],
+            },
+          ],
+        },
+      ],
+      languages: ['en'],
+      titles: ['Second Song'],
+    },
+  },
+} as Player['items'][number]
+
+const twoItemPlayer = {
+  index: 0,
+  toc: [
+    {
+      idx: 0,
+      nr: '1',
+      title: 'Anchor',
+      id: 'song-1',
+      liked: false,
+    },
+    {
+      idx: 1,
+      nr: '2',
+      title: 'Second Song',
+      id: 'song-2',
+      liked: false,
+    },
+  ],
+  items: [...player.items, secondSongItem],
+} as Player
+
 beforeEach(() => {
   bilingualEnabled = false
   navigate.mockReset()
@@ -263,6 +327,41 @@ beforeEach(() => {
 })
 
 describe('PlayerAv', () => {
+  it('shows the header language switcher and updates AV content from it', async () => {
+    viewState = { transposeByItem: {}, languageByItem: { 0: 0 } }
+    readViewState.mockReturnValue(viewState)
+    const user = userEvent.setup()
+
+    render(
+      <PlayerAv
+        type="setlist"
+        id="setlist-1"
+        player={player}
+        allowNetworkFetch={false}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'player.language.current' })).toHaveTextContent('en')
+    expect(screen.getByTestId('preview-text')).toHaveTextContent('Hello')
+
+    await user.click(screen.getByRole('button', { name: 'player.language.current' }))
+    await user.click(screen.getByRole('button', { name: 'de' }))
+
+    expect(screen.getByRole('button', { name: 'player.language.current' })).toHaveTextContent('de')
+    expect(screen.getByText('Anker')).toBeInTheDocument()
+    expect(screen.getByTestId('preview-text')).toHaveTextContent('Hallo')
+
+    await waitFor(() => {
+      expect(writeViewState).toHaveBeenCalledWith(
+        'setlist',
+        'setlist-1',
+        expect.objectContaining({
+          languageByItem: { 0: 1 },
+        }),
+      )
+    })
+  })
+
   it('reads the stored per-item language and updates AV content from the TOC selection', async () => {
     const user = userEvent.setup()
 
@@ -338,5 +437,49 @@ describe('PlayerAv', () => {
     }
     expect(lastPayload.contentText).toBe('Hello')
     expect(lastPayload.contentLines).toEqual([{ primary: 'Hello', secondary: 'Hallo' }])
+  })
+
+  it('keeps the projected output on the last selected slide when switching songs', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <PlayerAv
+        type="setlist"
+        id="setlist-1"
+        player={twoItemPlayer}
+        allowNetworkFetch={false}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Select slide 1' }))
+
+    await waitFor(() => {
+      expect(broadcast).toHaveBeenCalled()
+    })
+
+    const projectedPayload = broadcast.mock.calls.at(-1)?.[0] as { contentText?: string }
+    expect(projectedPayload.contentText).toBe('Tschuess')
+
+    broadcast.mockClear()
+
+    await user.keyboard('n')
+
+    expect(screen.getByText('Second Song')).toBeInTheDocument()
+    expect(screen.getByTestId('preview-text')).toHaveTextContent('Tschuess')
+
+    for (const call of broadcast.mock.calls) {
+      const payload = call[0] as { contentText?: string }
+      expect(payload.contentText).not.toBe('Second song line')
+    }
+
+    await user.click(screen.getByRole('button', { name: 'Select slide 0' }))
+
+    await waitFor(() => {
+      expect(broadcast).toHaveBeenCalled()
+    })
+
+    expect(screen.getByTestId('preview-text')).toHaveTextContent('Second song line')
+    const nextPayload = broadcast.mock.calls.at(-1)?.[0] as { contentText?: string }
+    expect(nextPayload.contentText).toBe('Second song line')
   })
 })

--- a/frontend/app/src/components/player/av/PlayerAv.tsx
+++ b/frontend/app/src/components/player/av/PlayerAv.tsx
@@ -13,6 +13,7 @@ import { ChevronLeftIcon } from '@/components/icons/lucide-animated/chevron-left
 import { OutputIcon } from '@/components/icons/lucide-animated/output-icon'
 import { SettingsIcon } from '@/components/icons/lucide-animated/settings-icon'
 import { Button } from '@/components/ui/button'
+import { PopoverContent, PopoverRoot, PopoverTrigger } from '@/components/ui/popover'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { usePlayerIndexSearchSync } from '@/hooks/usePlayerIndexSearchSync'
 import { useTocMultilingualPreference } from '@/hooks/useTocMultilingualPreference'
@@ -58,6 +59,7 @@ import {
   type AvSessionState,
 } from '@/lib/player/av-session-state'
 import {
+  clearLanguageForItem,
   readPlayerViewState,
   setLanguageForItem,
   writePlayerViewState,
@@ -72,6 +74,7 @@ import {
 import { buildSongEditorReturnSearch } from '@/lib/player/player-editor-return'
 import { tocEntryForIndex } from '@/lib/player/player-helpers'
 import type { PlayerEntityType } from '@/lib/player-route'
+import { songLanguageOptions } from '@/lib/player/song-language'
 import { buildSettingsSearch } from '@/lib/settings-route'
 import { cn } from '@/lib/utils'
 
@@ -149,6 +152,7 @@ export function PlayerAv({
     return { ...saved, itemIndex: startItem, slideIndex: startSlide }
   })
   const [tocVisible] = useState(true)
+  const [languagePopoverOpen, setLanguagePopoverOpen] = useState(false)
   const resolveLanguageIndexForItem = useCallback(
     (itemIndex: number) => viewState.languageByItem?.[itemIndex],
     [viewState.languageByItem],
@@ -257,11 +261,6 @@ export function PlayerAv({
     return currentItem.slides[session.slideIndex] ?? currentItem.slides[0] ?? ''
   }, [currentItem.slides, session.screenState, session.slideIndex])
 
-  const currentLines = useMemo(() => {
-    if (session.screenState !== 'live') return undefined
-    return currentItem.structuredSlides?.[session.slideIndex] ?? currentItem.structuredSlides?.[0]
-  }, [currentItem.structuredSlides, session.screenState, session.slideIndex])
-
   const projectedSlideCount = projectedItem.slides.length
   const projectedText = useMemo(() => {
     if (projected.screenState !== 'live') return ''
@@ -299,6 +298,14 @@ export function PlayerAv({
     rawItem?.type === 'chords'
       ? resolveAvItemLanguageIndex(rawItem, session.itemIndex, resolveLanguageIndexForItem)
       : null
+  const currentLanguageOptions =
+    rawItem?.type === 'chords'
+      ? songLanguageOptions(rawItem.song.data as Record<string, unknown>)
+      : []
+  const currentLanguageLabel =
+    currentLanguageOptions[currentLanguageIndex ?? 0]?.label ??
+    `L${(currentLanguageIndex ?? 0) + 1}`
+  const showLanguageSelector = rawItem?.type === 'chords' && currentLanguageOptions.length > 1
 
   const navigateToSongEditor = useCallback(() => {
     const item = player.items[session.itemIndex]
@@ -407,11 +414,12 @@ export function PlayerAv({
   )
 
   const goToItem = useCallback((itemIndex: number) => {
-    setSession((state) => {
-      const next: AvSessionState = { ...state, itemIndex, slideIndex: 0, screenState: 'live' }
-      setProjected(next)
-      return next
-    })
+    setSession((state) => ({
+      ...state,
+      itemIndex,
+      slideIndex: 0,
+      screenState: 'live',
+    }))
   }, [])
 
   const toggleBlank = useCallback(() => {
@@ -503,7 +511,11 @@ export function PlayerAv({
       }
       if (action === 'escape') {
         e.preventDefault()
-        void navigate({ to: backTo })
+        if (languagePopoverOpen) {
+          setLanguagePopoverOpen(false)
+        } else {
+          void navigate({ to: backTo })
+        }
         return
       }
       if (action === 'toggleBlank') {
@@ -547,6 +559,7 @@ export function PlayerAv({
     toggleBlank,
     toggleBlackout,
     tocVisible,
+    languagePopoverOpen,
   ])
 
   if (itemsLen === 0 || slideCount === 0) {
@@ -596,6 +609,49 @@ export function PlayerAv({
           </p>
         </div>
         <div className="flex shrink-0 items-center gap-1">
+          {showLanguageSelector ? (
+            <PopoverRoot open={languagePopoverOpen} onOpenChange={setLanguagePopoverOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  className={playerHeaderIconButtonClass}
+                  aria-label={t('player.language.current', {
+                    language: currentLanguageLabel,
+                  })}
+                >
+                  <span className={cn(playerHeaderIconClass, 'text-xs font-semibold leading-none')}>
+                    {currentLanguageLabel}
+                  </span>
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent align="end" className="w-48 p-2">
+                <div className="grid gap-1">
+                  {currentLanguageOptions.map((option) => (
+                    <Button
+                      key={option.index}
+                      type="button"
+                      size="sm"
+                      variant={currentLanguageIndex === option.index ? 'default' : 'outline'}
+                      onClick={() => {
+                        setViewState((state) =>
+                          option.index === 0
+                            ? clearLanguageForItem(state, session.itemIndex)
+                            : setLanguageForItem(state, session.itemIndex, option.index),
+                        )
+                        setLanguagePopoverOpen(false)
+                      }}
+                    >
+                      {option.index === 0
+                        ? t('player.language.defaultOption', { language: option.label })
+                        : option.label}
+                    </Button>
+                  ))}
+                </div>
+              </PopoverContent>
+            </PopoverRoot>
+          ) : null}
           <Button
             type="button"
             variant="outline"
@@ -676,12 +732,12 @@ export function PlayerAv({
           <div className="player-av__preview">
             <AvSlideView
               preview
-              contentText={currentLines ? undefined : currentText}
-              contentLines={currentLines}
+              contentText={projectedLines ? undefined : projectedText}
+              contentLines={projectedLines}
               contentLayer={prefs.contentLayer}
               backgroundLayer={prefs.backgroundLayer}
               transition={prefs.transition}
-              screenState={session.screenState}
+              screenState={projected.screenState}
             />
           </div>
 


### PR DESCRIPTION
## Summary
- Animate the hub and admin filter icons on hover using the shared Lucide Animated pattern
- Restore double-tap-to-like in the book player by deferring chrome open until the double-tap window passes
- Add an AV header language switcher matching the normal player, with persisted per-item language selection
- Keep AV projected output on the last selected slide when switching songs until a new slide is explicitly chosen

## Test plan
- [x] `pnpm -C frontend lint`
- [x] `pnpm -C frontend typecheck`
- [x] `pnpm -C frontend test`
- [ ] Hover hub filter button and confirm icon animates
- [ ] Double-tap center of book player to like without opening chrome
- [ ] Open AV player for a multilingual song and switch language from header
- [ ] Switch songs in AV mode and confirm output stays on prior slide until a new slide is selected