### PR TITLE
feat(setlist): apply custom flow in export and AV surfaces

### DIFF
--- a/frontend/app/src/components/player/PlayerBook.tsx
+++ b/frontend/app/src/components/player/PlayerBook.tsx
@@ -25,6 +25,7 @@ import { useOnline } from '@/hooks/use-online'
 import { usePlayerIndexSearchSync } from '@/hooks/usePlayerIndexSearchSync'
 import { useTocMultilingualPreference } from '@/hooks/useTocMultilingualPreference'
 import { useSetlistEvictionWatch } from '@/hooks/useSetlistEvictionWatch'
+import { useResolvedSongWithFlow } from '@/lib/player/apply-song-flow'
 import { getChordEngine } from '@/lib/chord-engine'
 import { chordFormatToRepresentation, writeChordFormatPreference } from '@/lib/chord-format'
 import {
@@ -153,53 +154,6 @@ function isInteractiveTarget(target: EventTarget | null): boolean {
   )
 }
 
-function cloneSongForFlow(song: Song): Song {
-  return structuredClone(song) as Song
-}
-
-function cloneFlowItems(flow: SongFlowItem[]): SongFlowItem[] {
-  return flow.map((item) => ({ ...item }))
-}
-
-function useResolvedBookSong(song: Song, flow: SongFlowItem[] | null | undefined): Song {
-  const [resolvedSong, setResolvedSong] = useState(song)
-
-  useEffect(() => {
-    let cancelled = false
-    queueMicrotask(() => {
-      if (!cancelled) setResolvedSong(song)
-    })
-
-    if (flow == null || flow.length === 0) {
-      return () => {
-        cancelled = true
-      }
-    }
-
-    void (async () => {
-      try {
-        const engine = await getChordEngine()
-        const clonedSong = cloneSongForFlow(song)
-        const applied = engine.applyFlow(clonedSong.data, cloneFlowItems(flow))
-        clonedSong.data = applied as Song['data']
-        if (!cancelled) {
-          setResolvedSong(clonedSong)
-        }
-      } catch {
-        if (!cancelled) {
-          setResolvedSong(song)
-        }
-      }
-    })()
-
-    return () => {
-      cancelled = true
-    }
-  }, [flow, song])
-
-  return resolvedSong
-}
-
 type ResolvedBookChordsProps = {
   song: Song
   flow: SongFlowItem[] | null | undefined
@@ -233,8 +187,8 @@ export function ResolvedBookChords({
   overflowStyle,
   expandSections,
 }: ResolvedBookChordsProps) {
-  const resolvedSong = useResolvedBookSong(song, flow)
-  const resolvedNextSong = useResolvedBookSong(nextSong ?? song, nextFlow)
+  const resolvedSong = useResolvedSongWithFlow(song, flow)
+  const resolvedNextSong = useResolvedSongWithFlow(nextSong ?? song, nextFlow)
 
   if (freeColumnCount != null) {
     return (

--- a/frontend/app/src/components/player/av/PlayerAv.tsx
+++ b/frontend/app/src/components/player/av/PlayerAv.tsx
@@ -19,6 +19,7 @@ import { usePlayerIndexSearchSync } from '@/hooks/usePlayerIndexSearchSync'
 import { useTocMultilingualPreference } from '@/hooks/useTocMultilingualPreference'
 import { useAvBilingualPreference } from '@/hooks/useAvBilingualPreference'
 import { useSetlistEvictionWatch } from '@/hooks/useSetlistEvictionWatch'
+import { useResolvedPlayerItemChordData } from '@/lib/player/apply-song-flow'
 import {
   avItemTitle,
   avNextItemIndex,
@@ -184,13 +185,18 @@ export function PlayerAv({
 
   const collapseLyricWhitespace = readLyricCollapseWhitespacePreference()
 
+  const currentPlayerItem = player.items[session.itemIndex]
+  const projectedPlayerItem = player.items[projected.itemIndex]
+  const resolvedCurrentSongData = useResolvedPlayerItemChordData(currentPlayerItem)
+  const resolvedProjectedSongData = useResolvedPlayerItemChordData(projectedPlayerItem)
+
   const currentItem = useMemo(
     () =>
       avSlidesForPlayerItem(player.items, session.itemIndex, {
         maxLinesPerSlide: prefs.contentLayer.maxLinesPerSlide,
         balanceSlideLines: prefs.contentLayer.balanceSlideLines,
         collapseLyricWhitespace,
-      }, resolveLanguageIndexForItem, bilingualEnabled),
+      }, resolveLanguageIndexForItem, bilingualEnabled, resolvedCurrentSongData),
     [
       player.items,
       prefs.contentLayer.maxLinesPerSlide,
@@ -199,6 +205,7 @@ export function PlayerAv({
       resolveLanguageIndexForItem,
       session.itemIndex,
       bilingualEnabled,
+      resolvedCurrentSongData,
     ],
   )
 
@@ -208,7 +215,7 @@ export function PlayerAv({
         maxLinesPerSlide: prefs.contentLayer.maxLinesPerSlide,
         balanceSlideLines: prefs.contentLayer.balanceSlideLines,
         collapseLyricWhitespace,
-      }, resolveLanguageIndexForItem, bilingualEnabled),
+      }, resolveLanguageIndexForItem, bilingualEnabled, resolvedProjectedSongData),
     [
       player.items,
       prefs.contentLayer.maxLinesPerSlide,
@@ -217,6 +224,7 @@ export function PlayerAv({
       resolveLanguageIndexForItem,
       projected.itemIndex,
       bilingualEnabled,
+      resolvedProjectedSongData,
     ],
   )
 

--- a/frontend/app/src/lib/hydrate-hub-song-links.ts
+++ b/frontend/app/src/lib/hydrate-hub-song-links.ts
@@ -3,6 +3,7 @@ import type { QueryClient } from '@tanstack/react-query'
 import { fetchSongForHubSlot } from '@/api/setlists-detail'
 import { getChordEngine } from '@/lib/chord-engine'
 import type { ChordFormatPreference } from '@/lib/chord-format'
+import { applyFlowToSongDataAsync } from '@/lib/player/apply-song-flow'
 import {
   exportOrderedSongsZip,
   exportSetlistPdf,
@@ -14,9 +15,14 @@ import {
   languageIndexForSongLink,
   resolveSongDataKey,
 } from '@/lib/setlist-song-links'
-import type { ChordSongData } from '@/ports/chord-engine'
+import type { ChordSongData, SongFlowItem } from '@/ports/chord-engine'
 
-export type HubExportSongLink = { id: string; key?: unknown; language?: unknown }
+export type HubExportSongLink = {
+  id: string
+  key?: unknown
+  language?: unknown
+  flow?: SongFlowItem[] | null
+}
 
 export async function hydrateSongLinksForHubExport(
   queryClient: QueryClient,
@@ -26,7 +32,8 @@ export async function hydrateSongLinksForHubExport(
     links.map(async (link) => {
       const song = await fetchSongForHubSlot(queryClient, { id: link.id })
       if (!song || song.not_a_song) return null
-      const data = song.data as ChordSongData
+      const rawData = song.data as ChordSongData
+      const data = await applyFlowToSongDataAsync(rawData, link.flow)
       const key =
         coerceMusicalKeyString(link.key) ??
         resolveSongDataKey(data as Record<string, unknown>) ??

--- a/frontend/app/src/lib/player/apply-song-flow.test.tsx
+++ b/frontend/app/src/lib/player/apply-song-flow.test.tsx
@@ -1,0 +1,152 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { components } from '@/api/schema'
+import type { ChordSongData, SongFlowItem } from '@/ports/chord-engine'
+import {
+  applyFlowToSongData,
+  applyFlowToSongDataAsync,
+  hasCustomSongFlow,
+  useResolvedPlayerItemChordData,
+  useResolvedSongWithFlow,
+} from '@/lib/player/apply-song-flow'
+
+const applyFlow = vi.fn()
+const getChordEngine = vi.fn(async () => ({ applyFlow }))
+
+vi.mock('@/lib/chord-engine', () => ({
+  getChordEngine: () => getChordEngine(),
+}))
+
+function songData(sections: Array<{ title: string }>): ChordSongData {
+  return {
+    titles: ['Test'],
+    sections,
+  } as ChordSongData
+}
+
+function song(sections: Array<{ title: string }>): components['schemas']['Song'] {
+  return {
+    id: 'song-1',
+    blobs: [],
+    not_a_song: false,
+    owner: 'team-1',
+    user_specific_addons: { liked: false },
+    data: {
+      titles: ['Test'],
+      sections: sections.map((section) => ({ title: section.title, lines: [] })),
+    },
+  } as components['schemas']['Song']
+}
+
+function flow(title: string, repeats = 1): SongFlowItem {
+  return { title, repeats, occurrence_index: 0 }
+}
+
+beforeEach(() => {
+  applyFlow.mockReset()
+  getChordEngine.mockClear()
+})
+
+describe('hasCustomSongFlow', () => {
+  it('treats null, undefined, and empty arrays as inactive', () => {
+    expect(hasCustomSongFlow(null)).toBe(false)
+    expect(hasCustomSongFlow(undefined)).toBe(false)
+    expect(hasCustomSongFlow([])).toBe(false)
+  })
+
+  it('treats non-empty arrays as active', () => {
+    expect(hasCustomSongFlow([flow('Verse')])).toBe(true)
+  })
+})
+
+describe('applyFlowToSongData', () => {
+  it('returns the original data when flow is inactive', () => {
+    const data = songData([{ title: 'Verse' }])
+    const engine = { applyFlow } as never
+
+    expect(applyFlowToSongData(engine, data, null)).toBe(data)
+    expect(applyFlow).not.toHaveBeenCalled()
+  })
+
+  it('applies flow through the chord engine and falls back on error', () => {
+    const data = songData([{ title: 'Verse' }])
+    const engine = { applyFlow } as never
+    applyFlow.mockReturnValue(songData([{ title: 'Chorus' }]))
+
+    expect(applyFlowToSongData(engine, data, [flow('Chorus')])).toEqual(
+      songData([{ title: 'Chorus' }]),
+    )
+
+    applyFlow.mockImplementation(() => {
+      throw new Error('boom')
+    })
+    expect(applyFlowToSongData(engine, data, [flow('Chorus')])).toBe(data)
+  })
+})
+
+describe('applyFlowToSongDataAsync', () => {
+  it('loads the engine and applies flow', async () => {
+    const data = songData([{ title: 'Verse' }])
+    applyFlow.mockReturnValue(songData([{ title: 'Chorus' }]))
+
+    await expect(applyFlowToSongDataAsync(data, [flow('Chorus')])).resolves.toEqual(
+      songData([{ title: 'Chorus' }]),
+    )
+    expect(getChordEngine).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useResolvedSongWithFlow', () => {
+  it('returns the raw song when flow is inactive', () => {
+    const source = song([{ title: 'Verse' }])
+    const { result } = renderHook(() => useResolvedSongWithFlow(source, null))
+
+    expect(result.current).toBe(source)
+    expect(getChordEngine).not.toHaveBeenCalled()
+  })
+
+  it('applies flow asynchronously', async () => {
+    const source = song([{ title: 'Verse' }])
+    applyFlow.mockReturnValue(songData([{ title: 'Chorus' }]))
+
+    const { result } = renderHook(() => useResolvedSongWithFlow(source, [flow('Chorus')]))
+
+    await waitFor(() =>
+      expect(
+        (result.current.data as { sections: Array<{ title: string }> }).sections.map(
+          (section) => section.title,
+        ),
+      ).toEqual(['Chorus']),
+    )
+  })
+})
+
+describe('useResolvedPlayerItemChordData', () => {
+  it('returns undefined for non-chord items', () => {
+    const { result } = renderHook(() =>
+      useResolvedPlayerItemChordData({ type: 'blob', blob_id: 'blob-1' }),
+    )
+
+    expect(result.current).toBeUndefined()
+  })
+
+  it('applies flow for chord items', async () => {
+    applyFlow.mockReturnValue(songData([{ title: 'Chorus' }]))
+    const item = {
+      type: 'chords',
+      flow: [flow('Chorus')],
+      song: song([{ title: 'Verse' }]),
+    } as components['schemas']['PlayerItem']
+
+    const { result } = renderHook(() => useResolvedPlayerItemChordData(item))
+
+    await waitFor(() =>
+      expect(
+        (result.current?.sections as Array<{ title: string }> | undefined)?.map(
+          (section) => section.title,
+        ),
+      ).toEqual(['Chorus']),
+    )
+  })
+})

--- a/frontend/app/src/lib/player/apply-song-flow.ts
+++ b/frontend/app/src/lib/player/apply-song-flow.ts
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react'
+
+import type { components } from '@/api/schema'
+import { getChordEngine } from '@/lib/chord-engine'
+import type { ChordEngine, ChordSongData, SongFlowItem } from '@/ports/chord-engine'
+
+type Song = components['schemas']['Song']
+type PlayerItem = components['schemas']['PlayerItem']
+
+export function hasCustomSongFlow(flow: SongFlowItem[] | null | undefined): boolean {
+  return flow != null && flow.length > 0
+}
+
+export function cloneFlowItems(flow: SongFlowItem[]): SongFlowItem[] {
+  return flow.map((item) => ({ ...item }))
+}
+
+export function applyFlowToSongData(
+  engine: ChordEngine,
+  data: ChordSongData,
+  flow: SongFlowItem[] | null | undefined,
+): ChordSongData {
+  if (!hasCustomSongFlow(flow)) return data
+  try {
+    const cloned = structuredClone(data) as ChordSongData
+    return engine.applyFlow(cloned, cloneFlowItems(flow!))
+  } catch {
+    return data
+  }
+}
+
+export async function applyFlowToSongDataAsync(
+  data: ChordSongData,
+  flow: SongFlowItem[] | null | undefined,
+): Promise<ChordSongData> {
+  if (!hasCustomSongFlow(flow)) return data
+  const engine = await getChordEngine()
+  return applyFlowToSongData(engine, data, flow)
+}
+
+export function useResolvedSongWithFlow(
+  song: Song,
+  flow: SongFlowItem[] | null | undefined,
+): Song {
+  const [resolvedSong, setResolvedSong] = useState(song)
+
+  useEffect(() => {
+    let cancelled = false
+    queueMicrotask(() => {
+      if (!cancelled) setResolvedSong(song)
+    })
+
+    if (!hasCustomSongFlow(flow)) {
+      return () => {
+        cancelled = true
+      }
+    }
+
+    void (async () => {
+      try {
+        const clonedSong = structuredClone(song) as Song
+        const applied = await applyFlowToSongDataAsync(
+          clonedSong.data as ChordSongData,
+          flow,
+        )
+        clonedSong.data = applied as Song['data']
+        if (!cancelled) {
+          setResolvedSong(clonedSong)
+        }
+      } catch {
+        if (!cancelled) {
+          setResolvedSong(song)
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [flow, song])
+
+  return resolvedSong
+}
+
+export function useResolvedPlayerItemChordData(
+  item: PlayerItem | undefined,
+): ChordSongData | undefined {
+  const rawData =
+    item?.type === 'chords' ? (item.song.data as ChordSongData) : undefined
+  const flow = item?.type === 'chords' ? item.flow : undefined
+  const [resolvedData, setResolvedData] = useState<ChordSongData | undefined>(rawData)
+
+  useEffect(() => {
+    let cancelled = false
+    queueMicrotask(() => {
+      if (!cancelled) setResolvedData(rawData)
+    })
+
+    if (!rawData || !hasCustomSongFlow(flow)) {
+      return () => {
+        cancelled = true
+      }
+    }
+
+    void applyFlowToSongDataAsync(rawData, flow).then((data) => {
+      if (!cancelled) setResolvedData(data)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [flow, rawData])
+
+  return resolvedData
+}

--- a/frontend/app/src/lib/player/av-nav.test.ts
+++ b/frontend/app/src/lib/player/av-nav.test.ts
@@ -12,6 +12,7 @@ import {
   buildAvOutlineRows,
   buildAvPresentationSlides,
 } from '@/lib/player/av-lyric-slides'
+import type { ChordSongData, SongFlowItem } from '@/ports/chord-engine'
 
 type PlayerItem = components['schemas']['PlayerItem']
 
@@ -165,5 +166,36 @@ describe('avSlidesForItem bilingual mode', () => {
 
     expect(bilingual.slides).toEqual(mono.slides)
     expect(bilingual.slides.length).toBe(mono.slides.length)
+  })
+})
+
+describe('avSlidesForItem custom flow', () => {
+  function flow(title: string, repeats = 1): SongFlowItem {
+    return { title, repeats, occurrence_index: 0 }
+  }
+
+  it('uses resolved song data when provided', () => {
+    const item = {
+      ...chordItem('de'),
+      flow: [flow('Chorus'), flow('Verse 1')],
+    } as PlayerItem
+    const resolvedData = {
+      ...songData,
+      sections: [
+        {
+          title: 'Chorus',
+          lines: [{ parts: [{ comment: false, languages: ['Sing'] }] }],
+        },
+        {
+          title: 'Verse 1',
+          lines: [{ parts: [{ comment: false, languages: ['First'] }] }],
+        },
+      ],
+    } as ChordSongData
+
+    const result = avSlidesForItem(item, 0, split, 'Setlist title', () => 0, false, resolvedData)
+
+    expect(result.slides).toEqual(['Sing', 'First'])
+    expect(result.outline.map((row) => row.title)).toEqual(['Chorus', 'Verse 1'])
   })
 })

--- a/frontend/app/src/lib/player/av-nav.ts
+++ b/frontend/app/src/lib/player/av-nav.ts
@@ -15,6 +15,7 @@ import {
 import type { AvLyricSplitPrefs } from '@/lib/player/av-preferences'
 import { itemTypeAt, tocEntryForIndex } from '@/lib/player/player-helpers'
 import { languageIndexForSongLink, songLanguageOptions } from '@/lib/setlist-song-links'
+import type { ChordSongData } from '@/ports/chord-engine'
 
 type Player = components['schemas']['Player']
 type PlayerItem = components['schemas']['PlayerItem']
@@ -77,6 +78,7 @@ export function avSlidesForItem(
   fallbackTitle?: string,
   resolveLanguageIndex?: AvLanguageIndexResolver,
   bilingualEnabled = false,
+  resolvedSongData?: ChordSongData,
 ): AvItemSlides {
   if (!item) return { slides: [''], sourceSlides: [''], outline: [], kind: 'blob' }
   if (item.type === 'blob') {
@@ -88,7 +90,10 @@ export function avSlidesForItem(
       kind: 'blob',
     }
   }
-  const songData = item.song.data
+  const songData =
+    resolvedSongData != null
+      ? ({ ...item.song.data, ...resolvedSongData } as typeof item.song.data)
+      : item.song.data
   const requestedPrimary = resolveAvItemLanguageIndex(item, itemIndex, resolveLanguageIndex)
   const effectivePrimary = bilingualEnabled
     ? resolveAvEffectivePrimaryLanguageIndex(
@@ -163,6 +168,7 @@ export function avSlidesForPlayerItem(
   split: AvLyricSplitPrefs,
   resolveLanguageIndex?: AvLanguageIndexResolver,
   bilingualEnabled = false,
+  resolvedSongData?: ChordSongData,
 ): AvItemSlides {
   return avSlidesForItem(
     items[itemIndex],
@@ -171,6 +177,7 @@ export function avSlidesForPlayerItem(
     undefined,
     resolveLanguageIndex,
     bilingualEnabled,
+    resolvedSongData,
   )
 }
 


### PR DESCRIPTION
## Summary
- Add a shared `apply-song-flow` resolver that wraps chordlib `apply_flow()` with stale-flow fallback.
- Route setlist PDF/ZIP export hydration through the resolver so exported songs honor per-slot custom flows.
- Apply resolved flow song data in AV mode so slides, outline, shortcuts, preview, and projection match Book mode.

## Test plan
- [x] `pnpm -C frontend lint`
- [x] `pnpm -C frontend typecheck`
- [x] `pnpm -C frontend test`
- [ ] Open a setlist song with a custom flow in AV mode and confirm slide order matches Book
- [ ] Export the same setlist to PDF/ZIP and confirm section order matches Book
- [ ] Reset flow to default and confirm export/AV return to source order