### PR TITLE
Fix player room song event delivery

### DIFF
--- a/frontend/app/src/lib/player-room-connection.test.tsx
+++ b/frontend/app/src/lib/player-room-connection.test.tsx
@@ -1,0 +1,150 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { usePlayerRoom } from '@/lib/player-room'
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+describe('player room connection', () => {
+  it('ignores a close event from a disposed socket generation', () => {
+    vi.useFakeTimers()
+    class MockWebSocket {
+      static readonly OPEN = 1
+      static instances: MockWebSocket[] = []
+
+      readyState = 0
+      onopen: (() => void) | null = null
+      onmessage: ((event: MessageEvent) => void) | null = null
+      onerror: (() => void) | null = null
+      onclose: ((event: CloseEvent) => void) | null = null
+      send = vi.fn()
+      close = vi.fn()
+
+      constructor() {
+        MockWebSocket.instances.push(this)
+      }
+    }
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    const firstCredentials = {
+      room_id: 'r1',
+      participant_id: 'p1',
+      mode: 'sheet' as const,
+      resume_credential: 'resume-1',
+      connection_ticket: 'ticket-1',
+    }
+    const { rerender, unmount } = renderHook(
+      ({ value }) => usePlayerRoom(value),
+      { initialProps: { value: firstCredentials } },
+    )
+    const disposedSocket = MockWebSocket.instances[0]
+
+    rerender({
+      value: {
+        ...firstCredentials,
+        room_id: 'r2',
+        resume_credential: 'resume-2',
+        connection_ticket: 'ticket-2',
+      },
+    })
+    disposedSocket.onclose?.({
+      code: 1006,
+      reason: '',
+      wasClean: false,
+    } as CloseEvent)
+
+    expect(MockWebSocket.instances).toHaveLength(2)
+    expect(vi.getTimerCount()).toBe(0)
+    unmount()
+  })
+
+  it('keeps the socket open when equivalent credentials are recreated', () => {
+    vi.useFakeTimers()
+    class MockWebSocket {
+      static readonly OPEN = 1
+      static instances: MockWebSocket[] = []
+
+      readyState = 0
+      onopen: (() => void) | null = null
+      onmessage: ((event: MessageEvent) => void) | null = null
+      onerror: (() => void) | null = null
+      onclose: ((event: CloseEvent) => void) | null = null
+      send = vi.fn()
+      close = vi.fn()
+
+      constructor() {
+        MockWebSocket.instances.push(this)
+      }
+    }
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    const credentials = {
+      room_id: 'r1',
+      participant_id: 'p1',
+      mode: 'sheet' as const,
+      resume_credential: 'resume',
+      connection_ticket: 'ticket',
+    }
+    const { rerender, unmount } = renderHook(
+      ({ value }) => usePlayerRoom(value),
+      { initialProps: { value: credentials } },
+    )
+    const socket = MockWebSocket.instances[0]
+
+    rerender({ value: { ...credentials } })
+
+    expect(MockWebSocket.instances).toHaveLength(1)
+    expect(socket.close).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('sends the latest queued musical state after the room socket opens', () => {
+    vi.useFakeTimers()
+    class MockWebSocket {
+      static readonly OPEN = 1
+      static instances: MockWebSocket[] = []
+
+      readyState = 0
+      onopen: (() => void) | null = null
+      onmessage: ((event: MessageEvent) => void) | null = null
+      onerror: (() => void) | null = null
+      onclose: ((event: CloseEvent) => void) | null = null
+      send = vi.fn()
+      close = vi.fn()
+
+      constructor() {
+        MockWebSocket.instances.push(this)
+      }
+    }
+    vi.stubGlobal('WebSocket', MockWebSocket)
+
+    const credentials = {
+      room_id: 'r1',
+      participant_id: 'p1',
+      mode: 'sheet' as const,
+      resume_credential: 'resume',
+      connection_ticket: 'ticket',
+    }
+    const { result, unmount } = renderHook(() => usePlayerRoom(credentials))
+    const socket = MockWebSocket.instances[0]
+
+    act(() => {
+      result.current.sendMusicalState({ item_index: 1, language: null, transposition: null })
+      result.current.sendMusicalState({ item_index: 2, language: null, transposition: null })
+      socket.readyState = MockWebSocket.OPEN
+      socket.onopen?.()
+    })
+
+    expect(socket.send).toHaveBeenCalledTimes(2)
+    expect(JSON.parse(socket.send.mock.calls[0][0] as string)).toEqual({
+      type: 'authenticate',
+      ticket: 'ticket',
+    })
+    expect(JSON.parse(socket.send.mock.calls[1][0] as string)).toMatchObject({
+      type: 'update_musical_state',
+      musical_state: { item_index: 2, language: null, transposition: null },
+    })
+    unmount()
+  })
+})

--- a/frontend/app/src/lib/player-room.ts
+++ b/frontend/app/src/lib/player-room.ts
@@ -166,27 +166,46 @@ export function applyPlayerRoomServerMessage(
 export function usePlayerRoom(credentials: PlayerRoomCredentials | null): RoomConnection {
   const [snapshot, setSnapshot] = useState<PlayerRoomSnapshot | null>(null)
   const [status, setStatus] = useState<RoomConnection['status']>('connecting')
+  const roomId = credentials?.room_id
+  const participantId = credentials?.participant_id
+  const mode = credentials?.mode
+  const resumeCredential = credentials?.resume_credential
+  const connectionTicket = credentials?.connection_ticket
   const socketRef = useRef<WebSocket | null>(null); const retryRef = useRef(0); const closedRef = useRef(false); const snapshotRef = useRef<PlayerRoomSnapshot | null>(null)
+  const pendingCommandsRef = useRef(new Map<string, object>())
   const send = useCallback((message: object) => {
-    if (credentials && socketRef.current?.readyState === WebSocket.OPEN) {
-      sendPlayerRoomEvent(credentials.room_id, socketRef.current, message)
+    if (roomId && socketRef.current?.readyState === WebSocket.OPEN) {
+      sendPlayerRoomEvent(roomId, socketRef.current, message)
+      return
     }
-  }, [credentials])
+    if ('type' in message && typeof message.type === 'string' && message.type.startsWith('update_')) {
+      pendingCommandsRef.current.set(message.type, message)
+    }
+  }, [roomId])
   useEffect(() => {
-    if (!credentials) return
+    if (!roomId || !participantId || !mode || !resumeCredential || !connectionTicket) return
+    const connectionCredentials: PlayerRoomCredentials = {
+      room_id: roomId,
+      participant_id: participantId,
+      mode,
+      resume_credential: resumeCredential,
+      connection_ticket: connectionTicket,
+    }
+    const pendingCommands = pendingCommandsRef.current
     closedRef.current = false; let disposed = false; let retryTimer: number | undefined; let heartbeat: number | undefined
     const connect = async () => {
+      if (disposed) return
       setStatus(retryRef.current ? 'reconnecting' : 'connecting')
-      console.log(`[PlayerRoom ${credentials.room_id}] connecting`, { attempt: retryRef.current + 1 })
-      let activeCredentials = credentials
+      console.log(`[PlayerRoom ${roomId}] connecting`, { attempt: retryRef.current + 1 })
+      let activeCredentials = connectionCredentials
       if (retryRef.current > 0) {
-        const reconnected = await reconnectPlayerRoom(credentials).catch(() => null)
+        const reconnected = await reconnectPlayerRoom(connectionCredentials).catch(() => null)
         if (disposed) return
         if (!reconnected) {
-          console.warn(`[PlayerRoom ${credentials.room_id}] credential exchange failed`)
+          console.warn(`[PlayerRoom ${roomId}] credential exchange failed`)
           setStatus('reconnecting')
           const delay = Math.min(10_000, 500 * 2 ** retryRef.current++)
-          console.log(`[PlayerRoom ${credentials.room_id}] reconnect scheduled`, { delayMs: delay })
+          console.log(`[PlayerRoom ${roomId}] reconnect scheduled`, { delayMs: delay })
           retryTimer = window.setTimeout(connect, delay)
           return
         }
@@ -195,48 +214,60 @@ export function usePlayerRoom(credentials: PlayerRoomCredentials | null): RoomCo
       const base = apiBase || window.location.origin; const url = new URL('/api/v1/player-rooms/ws', base); url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
       const ws = new WebSocket(url); socketRef.current = ws
       ws.onopen = () => {
-        console.log(`[PlayerRoom ${credentials.room_id}] socket open`)
-        sendPlayerRoomEvent(credentials.room_id, ws, { type: 'authenticate', ticket: activeCredentials.connection_ticket })
+        if (disposed) {
+          ws.close()
+          return
+        }
+        console.log(`[PlayerRoom ${roomId}] socket open`)
+        sendPlayerRoomEvent(roomId, ws, { type: 'authenticate', ticket: activeCredentials.connection_ticket })
+        for (const command of pendingCommands.values()) {
+          sendPlayerRoomEvent(roomId, ws, command)
+        }
+        pendingCommands.clear()
         heartbeat = window.setInterval(() => {
-          if (ws.readyState === WebSocket.OPEN) sendPlayerRoomEvent(credentials.room_id, ws, { type: 'heartbeat', revision: snapshotRef.current?.revision ?? null })
+          if (ws.readyState === WebSocket.OPEN) sendPlayerRoomEvent(roomId, ws, { type: 'heartbeat', revision: snapshotRef.current?.revision ?? null })
         }, 10_000)
       }
       ws.onmessage = (event) => {
+        if (disposed) return
         let message: PlayerRoomServerMessage
         try {
           message = JSON.parse(String(event.data)) as typeof message
         } catch (error) {
-          console.warn(`[PlayerRoom ${credentials.room_id}] invalid incoming event`, {
+          console.warn(`[PlayerRoom ${roomId}] invalid incoming event`, {
             dataType: typeof event.data,
             dataLength: typeof event.data === 'string' ? event.data.length : undefined,
             error,
           })
           return
         }
-        logPlayerRoomEvent(credentials.room_id, 'incoming', message)
+        logPlayerRoomEvent(roomId, 'incoming', message)
         if (message.type === 'room_ended') { closedRef.current = true; setStatus('ended'); ws.close(); return }
         setSnapshot((current) => {
           const result = applyPlayerRoomServerMessage(current, message)
-          if (result.needsSnapshot) sendPlayerRoomEvent(credentials.room_id, ws, { type: 'request_snapshot' })
+          if (result.needsSnapshot) sendPlayerRoomEvent(roomId, ws, { type: 'request_snapshot' })
           snapshotRef.current = result.snapshot
           return result.snapshot
         })
         setStatus('connected')
         retryRef.current = 0
       }
-      ws.onerror = () => console.warn(`[PlayerRoom ${credentials.room_id}] socket error`)
+      ws.onerror = () => {
+        if (!disposed) console.warn(`[PlayerRoom ${roomId}] socket error`)
+      }
       ws.onclose = (event) => {
-        console.log(`[PlayerRoom ${credentials.room_id}] socket closed`, { code: event.code, reason: event.reason, wasClean: event.wasClean })
+        if (disposed) return
+        console.log(`[PlayerRoom ${roomId}] socket closed`, { code: event.code, reason: event.reason, wasClean: event.wasClean })
         if (heartbeat) window.clearInterval(heartbeat)
         if (closedRef.current) return
         setStatus('reconnecting')
         const delay = Math.min(10_000, 500 * 2 ** retryRef.current++)
-        console.log(`[PlayerRoom ${credentials.room_id}] reconnect scheduled`, { delayMs: delay })
+        console.log(`[PlayerRoom ${roomId}] reconnect scheduled`, { delayMs: delay })
         retryTimer = window.setTimeout(connect, delay)
       }
     }
-    void connect(); return () => { disposed = true; closedRef.current = true; snapshotRef.current = null; if (retryTimer) window.clearTimeout(retryTimer); if (heartbeat) window.clearInterval(heartbeat); socketRef.current?.close() }
-  }, [credentials])
+    void connect(); return () => { disposed = true; closedRef.current = true; snapshotRef.current = null; pendingCommands.clear(); if (retryTimer) window.clearTimeout(retryTimer); if (heartbeat) window.clearInterval(heartbeat); socketRef.current?.close() }
+  }, [connectionTicket, mode, participantId, resumeCredential, roomId])
   const sendMusicalState = useCallback(
     (musical_state: PlayerRoomMusicalState) =>
       send({ type: 'update_musical_state', command_id: crypto.randomUUID(), musical_state }),


### PR DESCRIPTION
## What changed

- keep the player-room WebSocket stable when equivalent credentials are recreated during route rerenders
- queue the latest desired room update while the socket is connecting or reconnecting
- ignore delayed callbacks from disposed WebSocket generations
- add regression coverage for credential rerenders, queued musical state, and React Strict Mode-style stale close events

## Why

Hosts could switch songs without sending an outgoing `update_musical_state` event. In development, React Strict Mode disposed the first socket, but its delayed close callback could still schedule a reconnect. That stale reconnect overwrote the active socket reference with a dead socket while the healthy connection continued heartbeating. Route rerenders could also restart the connection because credentials were compared by object identity.

## Impact

Host song, language, and transposition changes now continue to reach player-room participants across route rerenders and connection transitions.

## Validation

- `pnpm --filter app exec eslint . --fix`
- `pnpm -C frontend lint`
- `pnpm -C frontend typecheck`
- `pnpm -C frontend test` — 642 passed, 9 skipped
