### PR TITLE
Fix Player Room slide and AV behavior

### DIFF
--- a/frontend/app/src/components/player-room/PlayerRoomLivePage.test.tsx
+++ b/frontend/app/src/components/player-room/PlayerRoomLivePage.test.tsx
@@ -1,0 +1,150 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { PlayerRoomCredentials, PlayerRoomSnapshot } from '@/lib/player-room'
+import { PlayerRoomLivePage } from '@/components/player-room/PlayerRoomLivePage'
+
+const usePlayerRoom = vi.fn()
+const registerPlayerRoomMedia = vi.fn()
+let slideViewProps: Record<string, unknown> | null = null
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('@/lib/player-room', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/player-room')>()
+  return { ...actual, usePlayerRoom: (...args: unknown[]) => usePlayerRoom(...args) }
+})
+
+vi.mock('@/lib/player-room-media', () => ({
+  registerPlayerRoomMedia: (...args: unknown[]) => registerPlayerRoomMedia(...args),
+}))
+
+vi.mock('@/components/player-room/PlayerRoomSidebar', () => ({
+  PlayerRoomSidebar: () => <aside data-testid="room-sidebar" />,
+}))
+
+vi.mock('@/components/player/PlayerBook', () => ({
+  PlayerBook: () => <div data-testid="player-book" />,
+}))
+
+vi.mock('@/components/player/av/PlayerAv', () => ({
+  PlayerAv: () => <div data-testid="player-av" />,
+}))
+
+vi.mock('@/components/player/av/AvSlideView', () => ({
+  AvSlideView: (props: Record<string, unknown>) => {
+    slideViewProps = props
+    return <div data-testid="slide-view" />
+  },
+}))
+
+const credentials: PlayerRoomCredentials = {
+  room_id: 'room-1',
+  participant_id: 'participant-1',
+  mode: 'slide',
+  resume_credential: 'resume',
+  connection_ticket: 'ticket',
+}
+
+const projection = {
+  content_text: 'Projected lyric',
+  content_layer: { fontSize: 60 },
+  background_layer: { preset: 2 },
+  transition: { style: 'none', durationMs: 0 },
+  screen_state: 'live' as const,
+  item_title: 'Song',
+  next_preview: null,
+}
+
+function snapshotWithProjection(
+  nextProjection: PlayerRoomSnapshot['projection'],
+): PlayerRoomSnapshot {
+  return {
+    id: 'room-1',
+    name: 'Room',
+    team_id: 'team-1',
+    source_type: 'song',
+    source_id: 'song-1',
+    source_title: 'Song',
+    host_email: 'host@example.com',
+    participant_count: 1,
+    av_occupied: true,
+    created_at: new Date().toISOString(),
+    content: { items: [{ type: 'blob', blob_id: 'blob-1' }], toc: [] },
+    musical_state: { item_index: 0, language: null, transposition: null },
+    projection: nextProjection,
+    participants: [
+      {
+        id: 'participant-1',
+        mode: 'slide',
+        display_name: 'Projection',
+        avatar_url: null,
+        anonymous: false,
+        connected: true,
+        is_host: false,
+        is_av_host: false,
+      },
+    ],
+    revision: 1,
+    host_lease_expires_at: new Date(Date.now() + 30_000).toISOString(),
+  }
+}
+
+function mockRoom(snapshot: PlayerRoomSnapshot) {
+  usePlayerRoom.mockReturnValue({
+    snapshot,
+    status: 'connected',
+    sendMusicalState: vi.fn(),
+    sendProjection: vi.fn(),
+    sendGuestsAllowed: vi.fn(),
+    leave: vi.fn(),
+  })
+}
+
+beforeEach(() => {
+  slideViewProps = null
+  usePlayerRoom.mockReset()
+  registerPlayerRoomMedia.mockReset().mockReturnValue(vi.fn())
+})
+
+describe('PlayerRoomLivePage slide mode', () => {
+  it('renders a clean black canvas before the first projection event', () => {
+    mockRoom(snapshotWithProjection(null))
+
+    const { container } = render(<PlayerRoomLivePage credentials={credentials} />)
+
+    expect(container.firstElementChild).toHaveClass('bg-black', 'h-dvh', 'w-dvw')
+    expect(screen.queryByText('common.load')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('room-sidebar')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('slide-view')).not.toBeInTheDocument()
+  })
+
+  it('renders projection content without the room sidebar', () => {
+    mockRoom(snapshotWithProjection(projection))
+
+    render(<PlayerRoomLivePage credentials={credentials} />)
+
+    expect(screen.getByTestId('slide-view')).toBeInTheDocument()
+    expect(screen.queryByTestId('room-sidebar')).not.toBeInTheDocument()
+    expect(slideViewProps).toMatchObject({
+      contentText: 'Projected lyric',
+      screenState: 'live',
+    })
+  })
+
+  it('requests fullscreen when the canvas is double-clicked', () => {
+    mockRoom(snapshotWithProjection(null))
+    const requestFullscreen = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(document.documentElement, 'requestFullscreen', {
+      configurable: true,
+      value: requestFullscreen,
+    })
+    const { container } = render(<PlayerRoomLivePage credentials={credentials} />)
+
+    fireEvent.doubleClick(container.firstElementChild as Element)
+
+    expect(requestFullscreen).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/app/src/components/player-room/PlayerRoomLivePage.tsx
+++ b/frontend/app/src/components/player-room/PlayerRoomLivePage.tsx
@@ -1,5 +1,4 @@
-import { motion, useReducedMotion } from 'motion/react'
-import { useCallback, useEffect, useMemo, type ReactNode } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { PlayerBook } from '@/components/player/PlayerBook'
@@ -31,33 +30,24 @@ function projectionToWire(payload: AvProjectionPayload): PlayerRoomProjection {
   }
 }
 
-function SlideModeShell({
-  projection,
-  roomSidebar,
-}: {
-  projection: PlayerRoomProjection
-  roomSidebar: ReactNode
-}) {
-  const reduceMotion = useReducedMotion()
-
+function SlideModeShell({ projection }: { projection: PlayerRoomProjection | null }) {
   return (
-    <div className="relative h-dvh w-dvw overflow-hidden bg-black">
-      <AvSlideView
-        contentText={projection.content_text}
-        contentLines={projection.content_lines as never}
-        contentLayer={projection.content_layer as never}
-        backgroundLayer={projection.background_layer as never}
-        transition={projection.transition as never}
-        screenState={projection.screen_state}
-      />
-      <motion.div
-        className="absolute inset-y-0 right-0 z-[60] flex overflow-hidden"
-        initial={reduceMotion ? false : { x: '100%' }}
-        animate={{ x: 0 }}
-        transition={{ type: 'spring', stiffness: 420, damping: 36 }}
-      >
-        {roomSidebar}
-      </motion.div>
+    <div
+      className="h-dvh w-dvw overflow-hidden bg-black"
+      onDoubleClick={() => {
+        void document.documentElement.requestFullscreen?.()
+      }}
+    >
+      {projection ? (
+        <AvSlideView
+          contentText={projection.content_text}
+          contentLines={projection.content_lines as never}
+          contentLayer={projection.content_layer as never}
+          backgroundLayer={projection.background_layer as never}
+          transition={projection.transition as never}
+          screenState={projection.screen_state}
+        />
+      ) : null}
     </div>
   )
 }
@@ -97,6 +87,10 @@ export function PlayerRoomLivePage({ credentials }: { credentials: PlayerRoomCre
     )
   }
 
+  if (credentials.mode === 'slide') {
+    return <SlideModeShell projection={snapshot.projection} />
+  }
+
   const roomSidebar = (
     <PlayerRoomSidebar
       name={playerRoomShortName(snapshot)}
@@ -118,18 +112,6 @@ export function PlayerRoomLivePage({ credentials }: { credentials: PlayerRoomCre
   )
 
   const roomPanelProps = { roomSidebar }
-
-  if (credentials.mode === 'slide') {
-    const projection = snapshot.projection
-    if (!projection) {
-      return (
-        <main className="flex min-h-dvh items-center justify-center p-6">{t('common.load')}</main>
-      )
-    }
-    return (
-      <SlideModeShell projection={projection} roomSidebar={roomSidebar} />
-    )
-  }
 
   const shared = {
     type: snapshot.source_type,

--- a/frontend/app/src/components/player/av/PlayerAv.test.tsx
+++ b/frontend/app/src/components/player/av/PlayerAv.test.tsx
@@ -514,4 +514,51 @@ describe('PlayerAv', () => {
     const nextPayload = broadcast.mock.calls.at(-1)?.[0] as { contentText?: string }
     expect(nextPayload.contentText).toBe('Second song line')
   })
+
+  it('lets an AV-only room host navigate slides without changing musical state', async () => {
+    const user = userEvent.setup()
+    const onRoomProjectionChange = vi.fn()
+    const onRoomMusicalStateChange = vi.fn()
+
+    render(
+      <PlayerAv
+        type="setlist"
+        id="setlist-1"
+        player={twoItemPlayer}
+        allowNetworkFetch={false}
+        roomMusicalState={{ item_index: 0, language: 'de', transposition: null }}
+        canControlRoomProjection
+        canControlRoomMusicalState={false}
+        onRoomProjectionChange={onRoomProjectionChange}
+        onRoomMusicalStateChange={onRoomMusicalStateChange}
+      />,
+    )
+
+    await user.keyboard('{ArrowRight}')
+    await waitFor(() => {
+      expect(onRoomProjectionChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ contentText: 'Tschuess' }),
+      )
+    })
+
+    await user.keyboard('{Home}')
+    await waitFor(() => {
+      expect(onRoomProjectionChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ contentText: 'Hallo' }),
+      )
+    })
+
+    await user.keyboard('{End}')
+    await waitFor(() => {
+      expect(onRoomProjectionChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ contentText: 'Tschuess' }),
+      )
+    })
+
+    await user.keyboard('{PageUp}{PageDown}n')
+
+    expect(screen.getByText('Anker')).toBeInTheDocument()
+    expect(screen.queryByText('Second Song')).not.toBeInTheDocument()
+    expect(onRoomMusicalStateChange).not.toHaveBeenCalled()
+  })
 })

--- a/frontend/app/src/components/player/av/PlayerAv.tsx
+++ b/frontend/app/src/components/player/av/PlayerAv.tsx
@@ -576,22 +576,22 @@ export function PlayerAv({
 
       if (action === 'prev') {
         e.preventDefault()
-        if (!navBlocked) goPrev()
+        if (!evicted) goPrev()
         return
       }
       if (action === 'next') {
         e.preventDefault()
-        if (!navBlocked) goNext()
+        if (!evicted) goNext()
         return
       }
       if (action === 'home') {
         e.preventDefault()
-        if (!navBlocked) goToSlide(0)
+        if (!evicted) goToSlide(0)
         return
       }
       if (action === 'end') {
         e.preventDefault()
-        if (!navBlocked) goToSlide(slideCount - 1)
+        if (!evicted) goToSlide(slideCount - 1)
         return
       }
       if (action === 'escape') {
@@ -637,6 +637,7 @@ export function PlayerAv({
     goPrevItem,
     goToSlide,
     jumpToSection,
+    evicted,
     navBlocked,
     navigate,
     openOutputWindow,


### PR DESCRIPTION
## What changed

- remove the room sidebar from Slide-mode participants
- render a clean black projection canvas before the first projection event
- allow Slide-mode fullscreen through a canvas double-click
- let AV-only hosts navigate and publish slides while keeping musical-state controls restricted to the room host
- add regression coverage for Slide rendering/fullscreen and AV-only navigation permissions

## Why

Slide participants were receiving room chrome, could not enter fullscreen, and saw a loading state until the first projection. AV participants who were not also the normal room host inherited the musical-state navigation lock for keyboard slide controls, preventing them from publishing slide changes.

## Impact

Slide devices now behave as projection-only displays. AV hosts can control the projected slide independently, while item, language, and transposition authority remain with the normal room host.

## Validation

- `pnpm --filter app exec eslint . --fix`
- `pnpm -C frontend lint`
- `pnpm -C frontend typecheck`
- `pnpm -C frontend test` — 646 passed, 9 skipped
- flow coverage script — all 48 flows covered
- `git diff --check`