### PR TITLE
fix(frontend): keep AV thumbnail text visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ All notable changes to Worship Viewer are documented here. The format follows [K
 - Backend CI `cargo audit` runs per-crate (`cd … && cargo audit`) — compatible with cargo-audit 0.22+.
 - OpenAPI Problem type documentation references [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) (successor to RFC 7807).
 
+### Fixed
+
+- Dark and light AV lyrics remain visible over checkerboard slide-selector previews.
+
 ## Release process
 
 1. Move `[Unreleased]` items into a dated version section (`## [x.y.z] - YYYY-MM-DD`).

--- a/frontend/app/src/components/player/av/AvSlideView.test.tsx
+++ b/frontend/app/src/components/player/av/AvSlideView.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { AvSlideView } from '@/components/player/av/AvSlideView'
+import { DEFAULT_AV_PREFERENCES } from '@/lib/player/av-preferences'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('motion/react', () => ({
+  useReducedMotion: () => false,
+}))
+
+describe('AvSlideView', () => {
+  it('adds opposite-contrast treatment only when the background is omitted', () => {
+    const contentLayer = {
+      ...DEFAULT_AV_PREFERENCES.contentLayer,
+      primaryTextLightness: 0,
+      secondaryTextLightness: 100,
+      textShadow: 'none' as const,
+    }
+    const view = (showBackground: boolean) => (
+      <AvSlideView
+        contentLines={[{ primary: 'Black lyrics', secondary: 'White translation' }]}
+        contentLayer={contentLayer}
+        backgroundLayer={DEFAULT_AV_PREFERENCES.backgroundLayer}
+        transition={DEFAULT_AV_PREFERENCES.transition}
+        screenState="live"
+        compact
+        showBackground={showBackground}
+      />
+    )
+    const { container, rerender } = render(view(false))
+
+    expect(container.firstElementChild).toHaveClass(
+      'av-slide-view--transparent-preview',
+    )
+    expect(screen.getByText('Black lyrics')).toHaveClass(
+      'av-slide-content__line--shadow-white',
+    )
+    expect(screen.getByText('White translation')).toHaveClass(
+      'av-slide-content__line--shadow-black',
+    )
+
+    rerender(view(true))
+
+    expect(container.firstElementChild).not.toHaveClass(
+      'av-slide-view--transparent-preview',
+    )
+  })
+})

--- a/frontend/app/src/components/player/av/AvSlideView.tsx
+++ b/frontend/app/src/components/player/av/AvSlideView.tsx
@@ -119,11 +119,28 @@ export function AvSlideView({
   )
 
   if (compact) {
-    return <div className={cn('av-slide-view', className)}>{slideBody}</div>
+    return (
+      <div
+        className={cn(
+          'av-slide-view',
+          !showBackground && 'av-slide-view--transparent-preview',
+          className,
+        )}
+      >
+        {slideBody}
+      </div>
+    )
   }
 
   return (
-    <div className={cn('av-slide-view', preview && 'av-slide-view--preview', className)}>
+    <div
+      className={cn(
+        'av-slide-view',
+        preview && 'av-slide-view--preview',
+        !showBackground && 'av-slide-view--transparent-preview',
+        className,
+      )}
+    >
       <AvSlideScaledStage>
         {preview ? (
           slideBody

--- a/frontend/app/src/components/player/av/player-av.css
+++ b/frontend/app/src/components/player/av/player-av.css
@@ -429,6 +429,25 @@
   min-height: 6rem;
 }
 
+.av-slide-view--transparent-preview .av-slide-content__line--shadow-black,
+.av-slide-view--transparent-preview .av-slide-content__line--shadow-white {
+  text-shadow:
+    -4px 0 2px rgb(var(--av-slide-shadow-rgb) / 90%),
+    4px 0 2px rgb(var(--av-slide-shadow-rgb) / 90%),
+    0 -4px 2px rgb(var(--av-slide-shadow-rgb) / 90%),
+    0 4px 2px rgb(var(--av-slide-shadow-rgb) / 90%);
+}
+
+.av-slide-view--transparent-preview
+  .av-slide-content--compact
+  .av-slide-content__line {
+  text-shadow:
+    -1px 0 1px rgb(var(--av-slide-shadow-rgb) / 90%),
+    1px 0 1px rgb(var(--av-slide-shadow-rgb) / 90%),
+    0 -1px 1px rgb(var(--av-slide-shadow-rgb) / 90%),
+    0 1px 1px rgb(var(--av-slide-shadow-rgb) / 90%);
+}
+
 .av-slide-view--compact {
   container-type: normal;
 }


### PR DESCRIPTION
## Summary

- add an opposite-color outline to lyrics only when an AV slide view omits its projection background
- use a smaller outline for compact selector rows and a stronger scaled outline for full 16:9 thumbnails
- keep projection windows, player rooms, live output, and the right-side preview unchanged
- document the fix in the unreleased changelog

## Root cause

Slide-selector thumbnails intentionally render the real lyric color over a checkerboard without the selected AV background. When text was black and projection shadows were disabled, it could disappear against the checkerboard's dark squares.

## Validation

- `pnpm --filter app exec eslint . --fix`
- `pnpm -C frontend lint`
- `pnpm -C frontend typecheck`
- `pnpm --filter app lint:flows`
- `pnpm -C frontend test` — 666 passed, 9 skipped
- `pnpm -C frontend build`
- `pnpm -C frontend audit` — no known vulnerabilities
- `./scripts/verify-ci.sh` — all CI-equivalent checks passed