### PR TITLE
Add admin sidebar and user directory

### DIFF
--- a/frontend/app/src/api/admin-users.test.ts
+++ b/frontend/app/src/api/admin-users.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { api } from '@/api/client'
+import { fetchAdminUsersPage } from '@/api/admin-users'
+
+vi.mock('@/api/client', () => ({ api: { GET: vi.fn() } }))
+vi.mock('@/lib/api-unauthorized', () => ({ redirectToLoginAfterUnauthorized: vi.fn() }))
+
+const queryClient = {} as never
+const response = (status = 200, headers?: Record<string, string>) =>
+  new Response(null, { status, headers })
+const user = {
+  id: 'user:1',
+  email: 'admin@example.com',
+  role: 'admin' as const,
+  created_at: '2026-08-28T10:00:00Z',
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('Admin users API', () => {
+  it('maps trimmed search, pagination, and total count', async () => {
+    vi.mocked(api.GET).mockResolvedValue({
+      data: [user],
+      response: response(200, { 'X-Total-Count': '73' }),
+    } as never)
+
+    await expect(
+      fetchAdminUsersPage(queryClient, { page: 1, q: ' admin@example.com ' }),
+    ).resolves.toEqual({ items: [user], total: 73 })
+    expect(api.GET).toHaveBeenCalledWith(
+      '/api/v1/users',
+      expect.objectContaining({
+        params: { query: { page: 1, page_size: 50, q: 'admin@example.com' } },
+      }),
+    )
+  })
+
+  it('omits a whitespace-only search and surfaces problem details', async () => {
+    vi.mocked(api.GET)
+      .mockResolvedValueOnce({ data: [], response: response() } as never)
+      .mockResolvedValueOnce({
+        error: { title: 'User list failed', detail: 'Directory unavailable.' },
+        response: response(500),
+      } as never)
+
+    await fetchAdminUsersPage(queryClient, { page: 0, q: '   ' })
+    expect(api.GET).toHaveBeenLastCalledWith(
+      '/api/v1/users',
+      expect.objectContaining({
+        params: { query: { page: 0, page_size: 50, q: undefined } },
+      }),
+    )
+    await expect(fetchAdminUsersPage(queryClient, { page: 0, q: '' })).rejects.toThrow(
+      'Directory unavailable.',
+    )
+  })
+})

--- a/frontend/app/src/api/admin-users.ts
+++ b/frontend/app/src/api/admin-users.ts
@@ -1,0 +1,35 @@
+import type { QueryClient } from '@tanstack/react-query'
+
+import { api } from '@/api/client'
+import { problemMessageFromBody } from '@/api/problem'
+import type { components } from '@/api/schema'
+import { redirectToLoginAfterUnauthorized } from '@/lib/api-unauthorized'
+import { parseTotalCount } from '@/lib/list-pagination'
+
+export type AdminUser = components['schemas']['User']
+export const ADMIN_USERS_PAGE_SIZE = 50
+
+export async function fetchAdminUsersPage(
+  queryClient: QueryClient,
+  args: { page: number; q: string; signal?: AbortSignal },
+): Promise<{ items: AdminUser[]; total: number | undefined }> {
+  const result = await api.GET('/api/v1/users', {
+    params: {
+      query: {
+        page: args.page,
+        page_size: ADMIN_USERS_PAGE_SIZE,
+        q: args.q.trim() || undefined,
+      },
+    },
+    signal: args.signal,
+  })
+
+  if (result.response.status === 401) {
+    await redirectToLoginAfterUnauthorized(queryClient)
+  }
+  if (!result.response.ok || result.data == null) {
+    throw new Error(problemMessageFromBody(result.error, 'Could not load users.'))
+  }
+
+  return { items: result.data, total: parseTotalCount(result.response) }
+}

--- a/frontend/app/src/components/admin/AdminNavigation.test.tsx
+++ b/frontend/app/src/components/admin/AdminNavigation.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { AnchorHTMLAttributes, ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { AdminLayout, AdminMobileNav } from '@/components/admin/AdminNavigation'
+
+vi.mock('@tanstack/react-router', async () => {
+  const { forwardRef } = await import('react')
+  return {
+    Link: forwardRef<
+      HTMLAnchorElement,
+      AnchorHTMLAttributes<HTMLAnchorElement> & {
+        children: ReactNode
+        to: string
+        search?: unknown
+      }
+    >(function MockLink({ children, to, search, onClick, ...props }, ref) {
+      void search
+      return (
+        <a
+          ref={ref}
+          href={to}
+          onClick={(event) => {
+            onClick?.(event)
+            event.preventDefault()
+          }}
+          {...props}
+        >
+          {children}
+        </a>
+      )
+    }),
+    useRouterState: ({
+      select,
+    }: {
+      select: (state: { location: { pathname: string } }) => unknown
+    }) => select({ location: { pathname: '/admin/users' } }),
+  }
+})
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }))
+
+describe('Admin navigation', () => {
+  it('marks the users destination active in the desktop sidebar', () => {
+    render(<AdminLayout><p>Content</p></AdminLayout>)
+    const navLinks = screen.getByRole('navigation', { name: 'adminNav.aria' }).querySelectorAll('a')
+    expect(navLinks[0]).toHaveTextContent('adminNav.users')
+    expect(screen.getByRole('link', { name: 'adminNav.users' })).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByRole('link', { name: 'adminNav.metrics' })).not.toHaveAttribute('aria-current')
+    expect(screen.getByRole('link', { name: 'adminNav.back' })).toHaveAttribute('href', '/collections')
+  })
+
+  it('opens the mobile drawer and closes it after navigation', async () => {
+    const user = userEvent.setup()
+    render(<AdminMobileNav />)
+    await user.click(screen.getByRole('button', { name: 'adminNav.open' }))
+    const usersLink = screen.getByRole('link', { name: 'adminNav.users' })
+    expect(usersLink).toBeVisible()
+    await user.click(usersLink)
+    await vi.waitFor(() => expect(screen.queryByRole('link', { name: 'adminNav.users' })).not.toBeInTheDocument())
+  })
+})

--- a/frontend/app/src/components/admin/AdminNavigation.tsx
+++ b/frontend/app/src/components/admin/AdminNavigation.tsx
@@ -1,0 +1,115 @@
+import { Link, useRouterState } from '@tanstack/react-router'
+import { useTranslation } from 'react-i18next'
+
+import { UsersIcon } from '@/components/icons/lucide-animated/users-icon'
+import { Button } from '@/components/ui/button'
+import { Sheet, SheetClose, SheetContent, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
+import { cn } from '@/lib/utils'
+
+function ChartIcon({ className }: { className?: string }) {
+  return (
+    <svg aria-hidden className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3 3v18h18" />
+      <path d="m7 16 4-5 4 3 5-7" />
+    </svg>
+  )
+}
+
+function MenuIcon() {
+  return (
+    <svg aria-hidden fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <path d="M4 6h16M4 12h16M4 18h16" />
+    </svg>
+  )
+}
+
+function ArrowLeftIcon({ className }: { className?: string }) {
+  return (
+    <svg aria-hidden className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="m15 18-6-6 6-6" />
+    </svg>
+  )
+}
+
+function AdminNavContent({ mobile = false }: { mobile?: boolean }) {
+  const { t } = useTranslation()
+  const pathname = useRouterState({ select: (state) => state.location.pathname })
+  const links = [
+    { to: '/admin/users' as const, label: t('adminNav.users'), icon: UsersIcon },
+    { to: '/admin/metrics' as const, label: t('adminNav.metrics'), icon: ChartIcon },
+  ]
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="border-b border-[var(--color-border)] px-4 py-5">
+        <p className="text-xs font-medium uppercase tracking-[0.18em] text-[var(--color-muted-foreground)]">{t('adminNav.kicker')}</p>
+        <p className="mt-1 text-lg font-semibold">{t('adminNav.title')}</p>
+      </div>
+      <nav className="flex flex-1 flex-col gap-1 p-3" aria-label={t('adminNav.aria')}>
+        {links.map(({ to, label, icon: Icon }) => {
+          const active = pathname === to || pathname.startsWith(`${to}/`)
+          const link = (
+            <Link
+              to={to}
+              search={to === '/admin/metrics' ? undefined : {}}
+              aria-current={active ? 'page' : undefined}
+              className={cn(
+                'flex h-10 items-center gap-3 rounded-md px-3 text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary)]',
+                active
+                  ? 'bg-[var(--color-primary)] text-[var(--color-primary-foreground)]'
+                  : 'text-[var(--color-muted-foreground)] hover:bg-[var(--color-muted)] hover:text-[var(--color-foreground)]',
+              )}
+            >
+              <Icon className="size-4" size={16} />
+              {label}
+            </Link>
+          )
+          return mobile ? <SheetClose asChild key={to}>{link}</SheetClose> : <div key={to}>{link}</div>
+        })}
+      </nav>
+      <div className="border-t border-[var(--color-border)] p-3">
+        {mobile ? (
+          <SheetClose asChild>
+            <Link to="/collections" className="flex h-10 items-center gap-3 rounded-md px-3 text-sm font-medium text-[var(--color-muted-foreground)] hover:bg-[var(--color-muted)] hover:text-[var(--color-foreground)]">
+              <ArrowLeftIcon className="size-4" />
+              {t('adminNav.back')}
+            </Link>
+          </SheetClose>
+        ) : (
+          <Link to="/collections" className="flex h-10 items-center gap-3 rounded-md px-3 text-sm font-medium text-[var(--color-muted-foreground)] hover:bg-[var(--color-muted)] hover:text-[var(--color-foreground)]">
+            <ArrowLeftIcon className="size-4" />
+            {t('adminNav.back')}
+          </Link>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function AdminMobileNav() {
+  const { t } = useTranslation()
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button type="button" size="icon" variant="outline" className="my-[0.36rem] size-[3.6rem] shrink-0 rounded-full shadow-[var(--shadow-elevated)] lg:hidden" aria-label={t('adminNav.open')}>
+          <MenuIcon />
+        </Button>
+      </SheetTrigger>
+      <SheetContent aria-describedby={undefined}>
+        <SheetTitle className="sr-only">{t('adminNav.title')}</SheetTitle>
+        <AdminNavContent mobile />
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+export function AdminLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mx-auto flex w-full max-w-[96rem] min-w-0 items-start gap-4">
+      <aside className="sticky top-0 hidden h-[calc(100dvh-6.6rem)] w-60 shrink-0 overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] shadow-sm lg:block">
+        <AdminNavContent />
+      </aside>
+      <section className="min-w-0 flex-1">{children}</section>
+    </div>
+  )
+}

--- a/frontend/app/src/components/admin/AdminUsersView.test.tsx
+++ b/frontend/app/src/components/admin/AdminUsersView.test.tsx
@@ -1,0 +1,85 @@
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AdminUsersView } from '@/components/admin/AdminUsersView'
+import { renderWithProviders } from '@/test/renderWithProviders'
+
+const mocks = vi.hoisted(() => ({
+  fetchPage: vi.fn(),
+  q: '',
+  setQInput: vi.fn(),
+}))
+
+vi.mock('@/api/admin-users', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/api/admin-users')>()
+  return { ...original, fetchAdminUsersPage: mocks.fetchPage }
+})
+vi.mock('@/hooks/useHubSearch', () => ({
+  useHubSearch: () => ({ debouncedQ: mocks.q, setQInput: mocks.setQInput }),
+}))
+
+const admin = {
+  id: 'user:admin',
+  email: 'admin@example.com',
+  role: 'admin' as const,
+  created_at: '2026-08-28T10:00:00Z',
+}
+
+beforeEach(() => {
+  mocks.q = ''
+  mocks.setQInput.mockReset()
+  mocks.fetchPage.mockReset().mockResolvedValue({ items: [admin], total: 51 })
+})
+
+describe('AdminUsersView', () => {
+  it('renders user fields and moves between server pages', async () => {
+    const user = userEvent.setup()
+    const view = renderWithProviders(<AdminUsersView />)
+
+    expect(await screen.findAllByText('admin@example.com')).toHaveLength(2)
+    expect(screen.getAllByText('user:admin')).toHaveLength(2)
+    expect(screen.getAllByText('Admin')).toHaveLength(2)
+    expect(screen.getByText('Showing 1–1 of 51 users')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Previous' })).toBeDisabled()
+
+    await user.click(screen.getByRole('button', { name: 'Next' }))
+    await waitFor(() =>
+      expect(mocks.fetchPage).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.objectContaining({ page: 1, q: '' }),
+      ),
+    )
+
+    mocks.q = 'singer'
+    view.rerender(<AdminUsersView />)
+    await waitFor(() =>
+      expect(mocks.fetchPage).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.objectContaining({ page: 0, q: 'singer' }),
+      ),
+    )
+  })
+
+  it('shows search-specific empty state and clears the shared search', async () => {
+    const user = userEvent.setup()
+    mocks.q = 'missing'
+    mocks.fetchPage.mockResolvedValue({ items: [], total: 0 })
+    renderWithProviders(<AdminUsersView />)
+
+    expect(await screen.findByText('No matching users')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Clear search' }))
+    expect(mocks.setQInput).toHaveBeenCalledWith('')
+  })
+
+  it('offers retry after a failed request', async () => {
+    const user = userEvent.setup()
+    mocks.fetchPage.mockRejectedValueOnce(new Error('Directory unavailable.'))
+    renderWithProviders(<AdminUsersView />)
+
+    expect(await screen.findByText('Directory unavailable.')).toBeInTheDocument()
+    mocks.fetchPage.mockResolvedValue({ items: [admin], total: 1 })
+    await user.click(screen.getByRole('button', { name: 'Try again' }))
+    expect(await screen.findAllByText('admin@example.com')).toHaveLength(2)
+  })
+})

--- a/frontend/app/src/components/admin/AdminUsersView.tsx
+++ b/frontend/app/src/components/admin/AdminUsersView.tsx
@@ -1,0 +1,151 @@
+import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import {
+  ADMIN_USERS_PAGE_SIZE,
+  fetchAdminUsersPage,
+  type AdminUser,
+} from '@/api/admin-users'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { useHubSearch } from '@/hooks/useHubSearch'
+
+function formatCreatedAt(value: string, language: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return new Intl.DateTimeFormat(language, { dateStyle: 'medium' }).format(date)
+}
+
+function RoleBadge({ role }: { role: AdminUser['role'] }) {
+  const { t } = useTranslation()
+  return (
+    <span className="inline-flex rounded-full border border-[var(--color-border)] bg-[var(--color-muted)] px-2.5 py-1 text-xs font-medium text-[var(--color-foreground)]">
+      {t(`adminUsers.roles.${role}`)}
+    </span>
+  )
+}
+
+function UsersTable({ users }: { users: AdminUser[] }) {
+  const { t, i18n } = useTranslation()
+  return (
+    <>
+      <div className="hidden overflow-x-auto md:block">
+        <table className="w-full border-collapse text-left text-sm">
+          <thead>
+            <tr className="border-b border-[var(--color-border)] text-xs uppercase tracking-wide text-[var(--color-muted-foreground)]">
+              <th className="px-5 py-3 font-medium">{t('adminUsers.columns.email')}</th>
+              <th className="px-5 py-3 font-medium">{t('adminUsers.columns.id')}</th>
+              <th className="px-5 py-3 font-medium">{t('adminUsers.columns.role')}</th>
+              <th className="px-5 py-3 font-medium">{t('adminUsers.columns.created')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map((user) => (
+              <tr key={user.id} className="border-b border-[var(--color-border)] last:border-0">
+                <td className="max-w-72 truncate px-5 py-4 font-medium">{user.email}</td>
+                <td className="max-w-72 truncate px-5 py-4 font-mono text-xs text-[var(--color-muted-foreground)]" title={user.id}>{user.id}</td>
+                <td className="px-5 py-4"><RoleBadge role={user.role} /></td>
+                <td className="whitespace-nowrap px-5 py-4 text-[var(--color-muted-foreground)]">
+                  <time dateTime={user.created_at}>{formatCreatedAt(user.created_at, i18n.language)}</time>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <ul className="divide-y divide-[var(--color-border)] md:hidden">
+        {users.map((user) => (
+          <li key={user.id} className="space-y-3 p-4">
+            <div className="flex items-start justify-between gap-3">
+              <p className="min-w-0 break-all font-medium">{user.email}</p>
+              <RoleBadge role={user.role} />
+            </div>
+            <dl className="grid gap-2 text-xs">
+              <div className="grid grid-cols-[5rem_minmax(0,1fr)] gap-2">
+                <dt className="text-[var(--color-muted-foreground)]">{t('adminUsers.columns.id')}</dt>
+                <dd className="break-all font-mono">{user.id}</dd>
+              </div>
+              <div className="grid grid-cols-[5rem_minmax(0,1fr)] gap-2">
+                <dt className="text-[var(--color-muted-foreground)]">{t('adminUsers.columns.created')}</dt>
+                <dd><time dateTime={user.created_at}>{formatCreatedAt(user.created_at, i18n.language)}</time></dd>
+              </div>
+            </dl>
+          </li>
+        ))}
+      </ul>
+    </>
+  )
+}
+
+function AdminUsersPage({ q, onClearSearch }: { q: string; onClearSearch: () => void }) {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const [page, setPage] = useState(0)
+
+  const query = useQuery({
+    queryKey: ['admin-users', page, q] as const,
+    queryFn: ({ signal }) => fetchAdminUsersPage(queryClient, { page, q, signal }),
+    placeholderData: keepPreviousData,
+    staleTime: 30_000,
+  })
+
+  const items = query.data?.items ?? []
+  const total = query.data?.total
+  const firstItem = items.length > 0 ? page * ADMIN_USERS_PAGE_SIZE + 1 : 0
+  const lastItem = page * ADMIN_USERS_PAGE_SIZE + items.length
+  const hasNext = total === undefined ? items.length === ADMIN_USERS_PAGE_SIZE : lastItem < total
+
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader className="gap-2 p-5">
+        <CardTitle>{t('adminUsers.title')}</CardTitle>
+        <CardDescription>{t('adminUsers.description')}</CardDescription>
+      </CardHeader>
+      <CardContent className="p-0">
+        {query.isError ? (
+          <div className="flex flex-col items-center gap-3 border-t border-[var(--color-border)] px-6 py-12 text-center" role="alert">
+            <p className="font-medium">{t('adminUsers.errorTitle')}</p>
+            <p className="text-sm text-[var(--color-muted-foreground)]">{(query.error as Error).message || t('adminUsers.errorBody')}</p>
+            <Button variant="outline" onClick={() => void query.refetch()}>{t('adminUsers.retry')}</Button>
+          </div>
+        ) : query.isPending ? (
+          <p className="border-t border-[var(--color-border)] px-6 py-12 text-center text-sm text-[var(--color-muted-foreground)]" role="status">{t('adminUsers.loading')}</p>
+        ) : items.length === 0 ? (
+          <div className="flex flex-col items-center gap-3 border-t border-[var(--color-border)] px-6 py-12 text-center">
+            <p className="font-medium">{q.trim() ? t('adminUsers.noResultsTitle') : t('adminUsers.emptyTitle')}</p>
+            <p className="text-sm text-[var(--color-muted-foreground)]">{q.trim() ? t('adminUsers.noResultsBody') : t('adminUsers.emptyBody')}</p>
+            {q.trim() ? <Button variant="outline" onClick={onClearSearch}>{t('adminUsers.clearSearch')}</Button> : null}
+          </div>
+        ) : (
+          <UsersTable users={items} />
+        )}
+
+        {!query.isError && !query.isPending && items.length > 0 ? (
+          <div className="flex flex-col gap-3 border-t border-[var(--color-border)] px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-[var(--color-muted-foreground)]" aria-live="polite">
+              {total === undefined
+                ? t('adminUsers.pagination.rangeUnknown', { first: firstItem, last: lastItem })
+                : t('adminUsers.pagination.range', { first: firstItem, last: lastItem, total })}
+            </p>
+            <div className="flex gap-2">
+              <Button variant="outline" disabled={page === 0 || query.isFetching} onClick={() => setPage((value) => Math.max(0, value - 1))}>{t('adminUsers.pagination.previous')}</Button>
+              <Button variant="outline" disabled={!hasNext || query.isFetching} onClick={() => setPage((value) => value + 1)}>{t('adminUsers.pagination.next')}</Button>
+            </div>
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  )
+}
+
+export function AdminUsersView() {
+  const { debouncedQ, setQInput } = useHubSearch()
+  return (
+    <AdminUsersPage
+      key={debouncedQ}
+      q={debouncedQ}
+      onClearSearch={() => setQInput('')}
+    />
+  )
+}

--- a/frontend/app/src/components/hub/HubShell.tsx
+++ b/frontend/app/src/components/hub/HubShell.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { CommandPalette } from '@/components/hub/CommandPalette'
+import { AdminMobileNav } from '@/components/admin/AdminNavigation'
 import { SessionLoadingFallback } from '@/components/SessionLoadingFallback'
 import { SessionUnavailableScreen } from '@/components/SessionUnavailableScreen'
 import { SetlistPaletteRegistrarProvider } from '@/context/SetlistPaletteBridgeContext'
@@ -76,6 +77,8 @@ const hubDetailBackButtonClass =
 
 /** Hub list tab id from pathname; stable when only a sub-segment changes (e.g. `/songs` → `/songs/:id`). */
 function hubSearchSectionKey(pathname: string): string | null {
+  if (pathname === '/admin/users') return 'admin-users'
+  if (pathname === '/admin/metrics') return 'admin-metrics'
   const seg = pathname.split('/').filter(Boolean)[0]
   if (
     seg === 'collections' ||
@@ -135,6 +138,8 @@ function HubLibrarySearchField({
   onSearchBlur,
   onSearchMouseEnter,
   onSearchMouseLeave,
+  placeholder,
+  ariaLabel,
 }: {
   searchAnchorRef: RefObject<HTMLDivElement | null>
   searchInputRef: RefObject<HTMLInputElement | null>
@@ -146,6 +151,8 @@ function HubLibrarySearchField({
   onSearchBlur: () => void
   onSearchMouseEnter: () => void
   onSearchMouseLeave: () => void
+  placeholder?: string
+  ariaLabel?: string
 }) {
   const { t } = useTranslation()
   const { selectedTeamId } = useHubSearch()
@@ -180,8 +187,8 @@ function HubLibrarySearchField({
           onChange={(e) => setQInput(e.target.value)}
           onFocus={onSearchFocus}
           onBlur={onSearchBlur}
-          placeholder={t('hub.searchPlaceholder')}
-          aria-label={t('hub.searchAria')}
+          placeholder={placeholder ?? t('hub.searchPlaceholder')}
+          aria-label={ariaLabel ?? t('hub.searchAria')}
           tabIndex={paletteOpen ? -1 : 0}
           className="h-full min-w-0 flex-1 rounded-full border-0 bg-transparent pl-2 pr-1 shadow-none focus-visible:outline-none"
         />
@@ -366,7 +373,9 @@ function HubChrome({
   const isMediaDetail = /^\/media\/[^/]+$/.test(pathname)
   const mediaEditorId = isMediaDetail ? pathname.slice('/media/'.length) : ''
   const isSettings = pathname === '/settings'
-  const isAdmin = pathname === '/admin'
+  const isAdmin = pathname === '/admin/metrics'
+  const isAdminUsers = pathname === '/admin/users'
+  const isAdminArea = pathname === '/admin' || pathname.startsWith('/admin/')
   const isSessions = pathname === '/sessions'
   const isAbout = pathname === '/about'
   const adminSearch = locationSearch as Record<string, unknown>
@@ -403,7 +412,7 @@ function HubChrome({
   const hideHubPlus =
     pathname === '/sessions' ||
     pathname === '/settings' ||
-    pathname === '/admin' ||
+    isAdminArea ||
     pathname === '/about' ||
     isTeamDetail ||
     isSetlistDetail ||
@@ -418,7 +427,7 @@ function HubChrome({
     !isSongDetail &&
     !isMediaDetail &&
     !isSettings &&
-    !isAdmin &&
+    !isAdminArea &&
     !isSessions &&
     !isAbout
   const reduceMotion = useReducedMotion()
@@ -549,7 +558,7 @@ function HubChrome({
 
   function navigateAdminSearch(nextStart: string, nextEnd: string) {
     void navigate({
-      to: '/admin',
+      to: '/admin/metrics',
       search: {
         start: nextStart,
         end: nextEnd,
@@ -880,18 +889,7 @@ function HubChrome({
             </>
           ) : isAdmin ? (
             <>
-              <Button
-                type="button"
-                size="icon"
-                variant="outline"
-                onClick={() => {
-                  void navigate({ to: '/collections' })
-                }}
-                className={hubDetailBackButtonClass}
-                aria-label={t('adminDashboard.back')}
-              >
-                <ChevronLeftIcon className="text-[var(--color-foreground)]" size={20} />
-              </Button>
+              <AdminMobileNav />
               <AdminDateRangeField
                 searchAnchorRef={searchAnchorRef}
                 paletteOpen={paletteOpen}
@@ -905,6 +903,24 @@ function HubChrome({
                 searchIconActive={searchIconActive}
                 onSearchMouseEnter={() => setSearchFieldHovered(true)}
                 onSearchMouseLeave={() => setSearchFieldHovered(false)}
+              />
+            </>
+          ) : isAdminUsers ? (
+            <>
+              <AdminMobileNav />
+              <HubLibrarySearchField
+                searchAnchorRef={searchAnchorRef}
+                searchInputRef={searchInputRef}
+                paletteOpen={paletteOpen}
+                qInput={qInput}
+                setQInput={setQInput}
+                searchIconActive={searchIconActive}
+                onSearchFocus={() => setSearchFocused(true)}
+                onSearchBlur={() => setSearchFocused(false)}
+                onSearchMouseEnter={() => setSearchFieldHovered(true)}
+                onSearchMouseLeave={() => setSearchFieldHovered(false)}
+                placeholder={t('adminUsers.searchPlaceholder')}
+                ariaLabel={t('adminUsers.searchAria')}
               />
             </>
           ) : isSessions ? (

--- a/frontend/app/src/components/hub/ProfileMenu.tsx
+++ b/frontend/app/src/components/hub/ProfileMenu.tsx
@@ -25,7 +25,6 @@ import { useUserAvatarDisplay } from '@/hooks/useUserAvatarDisplay'
 import { performLogout } from '@/lib/logout-queue'
 import { usePwaInstall } from '@/pwa/pwa-install-context'
 import { Route as RootRoute } from '@/routes/__root'
-import { formatAdminDateInputValue, resolveAdminQuickRange } from '@/lib/admin-dashboard'
 import { cn } from '@/lib/utils'
 
 type ProfileMenuProps = {
@@ -123,14 +122,8 @@ export function ProfileMenu({ user, offline = false }: ProfileMenuProps) {
             onSelect={() => {
               void (async () => {
                 if (!(await leaveSongEditorIfNeeded())) return
-                const range = resolveAdminQuickRange('30d')
                 void navigate({
-                  to: '/admin',
-                  search: {
-                    start: formatAdminDateInputValue(range.start),
-                    end: formatAdminDateInputValue(range.end),
-                  },
-                  replace: true,
+                  to: '/admin/users',
                 })
               })()
             }}

--- a/frontend/app/src/components/ui/sheet.tsx
+++ b/frontend/app/src/components/ui/sheet.tsx
@@ -1,0 +1,39 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+const Sheet = DialogPrimitive.Root
+const SheetTrigger = DialogPrimitive.Trigger
+const SheetClose = DialogPrimitive.Close
+
+const SheetContent = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPrimitive.Portal>
+    <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/40 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed inset-y-0 left-0 z-50 flex w-[min(19rem,85vw)] flex-col border-r border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-foreground)] shadow-[var(--shadow-elevated)]',
+        'data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </DialogPrimitive.Content>
+  </DialogPrimitive.Portal>
+))
+SheetContent.displayName = DialogPrimitive.Content.displayName
+
+const SheetTitle = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title ref={ref} className={cn('text-lg font-semibold', className)} {...props} />
+))
+SheetTitle.displayName = DialogPrimitive.Title.displayName
+
+export { Sheet, SheetClose, SheetContent, SheetTitle, SheetTrigger }

--- a/frontend/app/src/i18n/de.json
+++ b/frontend/app/src/i18n/de.json
@@ -474,6 +474,46 @@
       "prevMonth": "Vormonat"
     }
   },
+  "adminNav": {
+    "kicker": "Verwaltung",
+    "title": "Admin",
+    "aria": "Admin-Navigation",
+    "metrics": "Metriken",
+    "users": "Nutzer",
+    "back": "Zurück zur Bibliothek",
+    "open": "Admin-Navigation öffnen"
+  },
+  "adminUsers": {
+    "title": "Nutzer",
+    "description": "Alle bei Worship Viewer registrierten Nutzerkonten durchsuchen.",
+    "searchPlaceholder": "Nutzer suchen...",
+    "searchAria": "Nutzer nach E-Mail-Adresse oder ID suchen",
+    "columns": {
+      "email": "E-Mail",
+      "id": "Nutzer-ID",
+      "role": "Rolle",
+      "created": "Erstellt"
+    },
+    "roles": {
+      "admin": "Admin",
+      "default": "Nutzer"
+    },
+    "loading": "Nutzer werden geladen...",
+    "errorTitle": "Nutzer konnten nicht geladen werden",
+    "errorBody": "Bitte versuche es in einem Moment erneut.",
+    "retry": "Erneut versuchen",
+    "emptyTitle": "Noch keine Nutzer",
+    "emptyBody": "Nutzerkonten erscheinen hier, nachdem sie sich registriert haben.",
+    "noResultsTitle": "Keine passenden Nutzer",
+    "noResultsBody": "Versuche eine andere E-Mail-Adresse oder Nutzer-ID.",
+    "clearSearch": "Suche löschen",
+    "pagination": {
+      "range": "{{first}}–{{last}} von {{total}} Nutzern",
+      "rangeUnknown": "{{first}}–{{last}} Nutzer",
+      "previous": "Zurück",
+      "next": "Weiter"
+    }
+  },
   "settings": {
     "title": "Einstellungen",
     "description": "Lege fest, wie Worship Viewer auf diesem Gerät funktioniert.",

--- a/frontend/app/src/i18n/en.json
+++ b/frontend/app/src/i18n/en.json
@@ -474,6 +474,46 @@
       "prevMonth": "Previous month"
     }
   },
+  "adminNav": {
+    "kicker": "Administration",
+    "title": "Admin",
+    "aria": "Admin navigation",
+    "metrics": "Metrics",
+    "users": "Users",
+    "back": "Back to library",
+    "open": "Open admin navigation"
+  },
+  "adminUsers": {
+    "title": "Users",
+    "description": "Browse all user accounts registered with Worship Viewer.",
+    "searchPlaceholder": "Search users...",
+    "searchAria": "Search users by email or ID",
+    "columns": {
+      "email": "Email",
+      "id": "User ID",
+      "role": "Role",
+      "created": "Created"
+    },
+    "roles": {
+      "admin": "Admin",
+      "default": "User"
+    },
+    "loading": "Loading users...",
+    "errorTitle": "Could not load users",
+    "errorBody": "Try again in a moment.",
+    "retry": "Try again",
+    "emptyTitle": "No users yet",
+    "emptyBody": "User accounts will appear here after they register.",
+    "noResultsTitle": "No matching users",
+    "noResultsBody": "Try a different email address or user ID.",
+    "clearSearch": "Clear search",
+    "pagination": {
+      "range": "Showing {{first}}–{{last}} of {{total}} users",
+      "rangeUnknown": "Showing {{first}}–{{last}} users",
+      "previous": "Previous",
+      "next": "Next"
+    }
+  },
   "settings": {
     "title": "Settings",
     "description": "Choose how Worship Viewer behaves on this device.",

--- a/frontend/app/src/routeTree.gen.ts
+++ b/frontend/app/src/routeTree.gen.ts
@@ -33,6 +33,7 @@ import { Route as HubCollectionsRouteImport } from './routes/_hub/collections'
 import { Route as HubAdminRouteImport } from './routes/_hub/admin'
 import { Route as HubAboutRouteImport } from './routes/_hub/about'
 import { Route as PlayerRoomsInviteIndexRouteImport } from './routes/player-rooms.invite.index'
+import { Route as HubAdminIndexRouteImport } from './routes/_hub/admin.index'
 import { Route as PlayerRoomRoomIdRouteImport } from './routes/player/room.$roomId'
 import { Route as PlayerMediaMediaIdRouteImport } from './routes/player/media.$mediaId'
 import { Route as PlayerRoomsInviteRoomIdRouteImport } from './routes/player-rooms.invite.$roomId'
@@ -41,6 +42,8 @@ import { Route as HubSongsSongIdRouteImport } from './routes/_hub/songs.$songId'
 import { Route as HubSetlistsSetlistIdRouteImport } from './routes/_hub/setlists.$setlistId'
 import { Route as HubMediaMediaIdRouteImport } from './routes/_hub/media.$mediaId'
 import { Route as HubCollectionsCollectionIdRouteImport } from './routes/_hub/collections.$collectionId'
+import { Route as HubAdminUsersRouteImport } from './routes/_hub/admin.users'
+import { Route as HubAdminMetricsRouteImport } from './routes/_hub/admin.metrics'
 
 const LogoutRoute = LogoutRouteImport.update({
   id: '/logout',
@@ -161,6 +164,11 @@ const PlayerRoomsInviteIndexRoute = PlayerRoomsInviteIndexRouteImport.update({
   path: '/',
   getParentRoute: () => PlayerRoomsInviteRoute,
 } as any)
+const HubAdminIndexRoute = HubAdminIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => HubAdminRoute,
+} as any)
 const PlayerRoomRoomIdRoute = PlayerRoomRoomIdRouteImport.update({
   id: '/room/$roomId',
   path: '/room/$roomId',
@@ -202,6 +210,16 @@ const HubCollectionsCollectionIdRoute =
     path: '/$collectionId',
     getParentRoute: () => HubCollectionsRoute,
   } as any)
+const HubAdminUsersRoute = HubAdminUsersRouteImport.update({
+  id: '/users',
+  path: '/users',
+  getParentRoute: () => HubAdminRoute,
+} as any)
+const HubAdminMetricsRoute = HubAdminMetricsRouteImport.update({
+  id: '/metrics',
+  path: '/metrics',
+  getParentRoute: () => HubAdminRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -211,7 +229,7 @@ export interface FileRoutesByFullPath {
   '/login': typeof LoginRoute
   '/logout': typeof LogoutRoute
   '/about': typeof HubAboutRoute
-  '/admin': typeof HubAdminRoute
+  '/admin': typeof HubAdminRouteWithChildren
   '/collections': typeof HubCollectionsRouteWithChildren
   '/media': typeof HubMediaRouteWithChildren
   '/player-rooms': typeof HubPlayerRoomsRoute
@@ -226,6 +244,8 @@ export interface FileRoutesByFullPath {
   '/player-rooms/invite': typeof PlayerRoomsInviteRouteWithChildren
   '/player/output': typeof PlayerOutputRoute
   '/player/': typeof PlayerIndexRoute
+  '/admin/metrics': typeof HubAdminMetricsRoute
+  '/admin/users': typeof HubAdminUsersRoute
   '/collections/$collectionId': typeof HubCollectionsCollectionIdRoute
   '/media/$mediaId': typeof HubMediaMediaIdRoute
   '/setlists/$setlistId': typeof HubSetlistsSetlistIdRoute
@@ -234,6 +254,7 @@ export interface FileRoutesByFullPath {
   '/player-rooms/invite/$roomId': typeof PlayerRoomsInviteRoomIdRoute
   '/player/media/$mediaId': typeof PlayerMediaMediaIdRoute
   '/player/room/$roomId': typeof PlayerRoomRoomIdRoute
+  '/admin/': typeof HubAdminIndexRoute
   '/player-rooms/invite/': typeof PlayerRoomsInviteIndexRoute
 }
 export interface FileRoutesByTo {
@@ -243,7 +264,6 @@ export interface FileRoutesByTo {
   '/login': typeof LoginRoute
   '/logout': typeof LogoutRoute
   '/about': typeof HubAboutRoute
-  '/admin': typeof HubAdminRoute
   '/collections': typeof HubCollectionsRouteWithChildren
   '/media': typeof HubMediaRouteWithChildren
   '/player-rooms': typeof HubPlayerRoomsRoute
@@ -257,6 +277,8 @@ export interface FileRoutesByTo {
   '/ugc': typeof HubUgcRoute
   '/player/output': typeof PlayerOutputRoute
   '/player': typeof PlayerIndexRoute
+  '/admin/metrics': typeof HubAdminMetricsRoute
+  '/admin/users': typeof HubAdminUsersRoute
   '/collections/$collectionId': typeof HubCollectionsCollectionIdRoute
   '/media/$mediaId': typeof HubMediaMediaIdRoute
   '/setlists/$setlistId': typeof HubSetlistsSetlistIdRoute
@@ -265,6 +287,7 @@ export interface FileRoutesByTo {
   '/player-rooms/invite/$roomId': typeof PlayerRoomsInviteRoomIdRoute
   '/player/media/$mediaId': typeof PlayerMediaMediaIdRoute
   '/player/room/$roomId': typeof PlayerRoomRoomIdRoute
+  '/admin': typeof HubAdminIndexRoute
   '/player-rooms/invite': typeof PlayerRoomsInviteIndexRoute
 }
 export interface FileRoutesById {
@@ -277,7 +300,7 @@ export interface FileRoutesById {
   '/login': typeof LoginRoute
   '/logout': typeof LogoutRoute
   '/_hub/about': typeof HubAboutRoute
-  '/_hub/admin': typeof HubAdminRoute
+  '/_hub/admin': typeof HubAdminRouteWithChildren
   '/_hub/collections': typeof HubCollectionsRouteWithChildren
   '/_hub/media': typeof HubMediaRouteWithChildren
   '/_hub/player-rooms': typeof HubPlayerRoomsRoute
@@ -292,6 +315,8 @@ export interface FileRoutesById {
   '/player-rooms/invite': typeof PlayerRoomsInviteRouteWithChildren
   '/player/output': typeof PlayerOutputRoute
   '/player/': typeof PlayerIndexRoute
+  '/_hub/admin/metrics': typeof HubAdminMetricsRoute
+  '/_hub/admin/users': typeof HubAdminUsersRoute
   '/_hub/collections/$collectionId': typeof HubCollectionsCollectionIdRoute
   '/_hub/media/$mediaId': typeof HubMediaMediaIdRoute
   '/_hub/setlists/$setlistId': typeof HubSetlistsSetlistIdRoute
@@ -300,6 +325,7 @@ export interface FileRoutesById {
   '/player-rooms/invite/$roomId': typeof PlayerRoomsInviteRoomIdRoute
   '/player/media/$mediaId': typeof PlayerMediaMediaIdRoute
   '/player/room/$roomId': typeof PlayerRoomRoomIdRoute
+  '/_hub/admin/': typeof HubAdminIndexRoute
   '/player-rooms/invite/': typeof PlayerRoomsInviteIndexRoute
 }
 export interface FileRouteTypes {
@@ -327,6 +353,8 @@ export interface FileRouteTypes {
     | '/player-rooms/invite'
     | '/player/output'
     | '/player/'
+    | '/admin/metrics'
+    | '/admin/users'
     | '/collections/$collectionId'
     | '/media/$mediaId'
     | '/setlists/$setlistId'
@@ -335,6 +363,7 @@ export interface FileRouteTypes {
     | '/player-rooms/invite/$roomId'
     | '/player/media/$mediaId'
     | '/player/room/$roomId'
+    | '/admin/'
     | '/player-rooms/invite/'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -344,7 +373,6 @@ export interface FileRouteTypes {
     | '/login'
     | '/logout'
     | '/about'
-    | '/admin'
     | '/collections'
     | '/media'
     | '/player-rooms'
@@ -358,6 +386,8 @@ export interface FileRouteTypes {
     | '/ugc'
     | '/player/output'
     | '/player'
+    | '/admin/metrics'
+    | '/admin/users'
     | '/collections/$collectionId'
     | '/media/$mediaId'
     | '/setlists/$setlistId'
@@ -366,6 +396,7 @@ export interface FileRouteTypes {
     | '/player-rooms/invite/$roomId'
     | '/player/media/$mediaId'
     | '/player/room/$roomId'
+    | '/admin'
     | '/player-rooms/invite'
   id:
     | '__root__'
@@ -392,6 +423,8 @@ export interface FileRouteTypes {
     | '/player-rooms/invite'
     | '/player/output'
     | '/player/'
+    | '/_hub/admin/metrics'
+    | '/_hub/admin/users'
     | '/_hub/collections/$collectionId'
     | '/_hub/media/$mediaId'
     | '/_hub/setlists/$setlistId'
@@ -400,6 +433,7 @@ export interface FileRouteTypes {
     | '/player-rooms/invite/$roomId'
     | '/player/media/$mediaId'
     | '/player/room/$roomId'
+    | '/_hub/admin/'
     | '/player-rooms/invite/'
   fileRoutesById: FileRoutesById
 }
@@ -584,6 +618,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PlayerRoomsInviteIndexRouteImport
       parentRoute: typeof PlayerRoomsInviteRoute
     }
+    '/_hub/admin/': {
+      id: '/_hub/admin/'
+      path: '/'
+      fullPath: '/admin/'
+      preLoaderRoute: typeof HubAdminIndexRouteImport
+      parentRoute: typeof HubAdminRoute
+    }
     '/player/room/$roomId': {
       id: '/player/room/$roomId'
       path: '/room/$roomId'
@@ -640,6 +681,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof HubCollectionsCollectionIdRouteImport
       parentRoute: typeof HubCollectionsRoute
     }
+    '/_hub/admin/users': {
+      id: '/_hub/admin/users'
+      path: '/users'
+      fullPath: '/admin/users'
+      preLoaderRoute: typeof HubAdminUsersRouteImport
+      parentRoute: typeof HubAdminRoute
+    }
+    '/_hub/admin/metrics': {
+      id: '/_hub/admin/metrics'
+      path: '/metrics'
+      fullPath: '/admin/metrics'
+      preLoaderRoute: typeof HubAdminMetricsRouteImport
+      parentRoute: typeof HubAdminRoute
+    }
   }
 }
 
@@ -659,6 +714,22 @@ const PlayerRouteRouteChildren: PlayerRouteRouteChildren = {
 
 const PlayerRouteRouteWithChildren = PlayerRouteRoute._addFileChildren(
   PlayerRouteRouteChildren,
+)
+
+interface HubAdminRouteChildren {
+  HubAdminMetricsRoute: typeof HubAdminMetricsRoute
+  HubAdminUsersRoute: typeof HubAdminUsersRoute
+  HubAdminIndexRoute: typeof HubAdminIndexRoute
+}
+
+const HubAdminRouteChildren: HubAdminRouteChildren = {
+  HubAdminMetricsRoute: HubAdminMetricsRoute,
+  HubAdminUsersRoute: HubAdminUsersRoute,
+  HubAdminIndexRoute: HubAdminIndexRoute,
+}
+
+const HubAdminRouteWithChildren = HubAdminRoute._addFileChildren(
+  HubAdminRouteChildren,
 )
 
 interface HubCollectionsRouteChildren {
@@ -723,7 +794,7 @@ const HubTeamsRouteWithChildren = HubTeamsRoute._addFileChildren(
 
 interface HubRouteChildren {
   HubAboutRoute: typeof HubAboutRoute
-  HubAdminRoute: typeof HubAdminRoute
+  HubAdminRoute: typeof HubAdminRouteWithChildren
   HubCollectionsRoute: typeof HubCollectionsRouteWithChildren
   HubMediaRoute: typeof HubMediaRouteWithChildren
   HubPlayerRoomsRoute: typeof HubPlayerRoomsRoute
@@ -739,7 +810,7 @@ interface HubRouteChildren {
 
 const HubRouteChildren: HubRouteChildren = {
   HubAboutRoute: HubAboutRoute,
-  HubAdminRoute: HubAdminRoute,
+  HubAdminRoute: HubAdminRouteWithChildren,
   HubCollectionsRoute: HubCollectionsRouteWithChildren,
   HubMediaRoute: HubMediaRouteWithChildren,
   HubPlayerRoomsRoute: HubPlayerRoomsRoute,

--- a/frontend/app/src/routes/_hub/admin.index.tsx
+++ b/frontend/app/src/routes/_hub/admin.index.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_hub/admin/')({
+  beforeLoad: () => {
+    throw redirect({ to: '/admin/users', replace: true })
+  },
+})

--- a/frontend/app/src/routes/_hub/admin.metrics.tsx
+++ b/frontend/app/src/routes/_hub/admin.metrics.tsx
@@ -1,0 +1,57 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+import { AdminDashboardView } from '@/components/admin/AdminDashboardView'
+import {
+  formatAdminDateInputValue,
+  resolveAdminDateRangeFromStrings,
+  resolveAdminQuickRange,
+} from '@/lib/admin-dashboard'
+
+function defaultAdminRange(): { start: string; end: string } {
+  const range = resolveAdminQuickRange('30d')
+  return {
+    start: formatAdminDateInputValue(range.start),
+    end: formatAdminDateInputValue(range.end),
+  }
+}
+
+function normalizeDateSearch(start: string, end: string): { start: string; end: string } | null {
+  const parsed = resolveAdminDateRangeFromStrings(start, end)
+  if (!parsed) return null
+  const ordered =
+    parsed.start.getTime() <= parsed.end.getTime()
+      ? parsed
+      : { start: parsed.end, end: parsed.start }
+  return {
+    start: formatAdminDateInputValue(ordered.start),
+    end: formatAdminDateInputValue(ordered.end),
+  }
+}
+
+export const Route = createFileRoute('/_hub/admin/metrics')({
+  beforeLoad: ({ search }) => {
+    if (typeof search.start !== 'string' || typeof search.end !== 'string') {
+      throw redirect({ to: '/admin/metrics', search: defaultAdminRange(), replace: true })
+    }
+
+    const normalized = normalizeDateSearch(search.start, search.end)
+    if (!normalized) {
+      throw redirect({ to: '/admin/metrics', search: defaultAdminRange(), replace: true })
+    }
+
+    if (normalized.start !== search.start || normalized.end !== search.end) {
+      throw redirect({ to: '/admin/metrics', search: normalized, replace: true })
+    }
+  },
+  validateSearch: (search: Record<string, unknown>) => ({
+    start: typeof search.start === 'string' ? search.start : undefined,
+    end: typeof search.end === 'string' ? search.end : undefined,
+  }),
+  component: AdminMetricsRoute,
+})
+
+function AdminMetricsRoute() {
+  const { start, end } = Route.useSearch()
+  if (!start || !end) return null
+  return <AdminDashboardView startDate={start} endDate={end} />
+}

--- a/frontend/app/src/routes/_hub/admin.tsx
+++ b/frontend/app/src/routes/_hub/admin.tsx
@@ -1,74 +1,19 @@
-import { createFileRoute, redirect } from '@tanstack/react-router'
+import { Outlet, createFileRoute } from '@tanstack/react-router'
 
-import { AdminDashboardView } from '@/components/admin/AdminDashboardView'
+import { AdminLayout } from '@/components/admin/AdminNavigation'
 import { requireAdminSession } from '@/lib/auth-guard'
-import {
-  formatAdminDateInputValue,
-  resolveAdminDateRangeFromStrings,
-  resolveAdminQuickRange,
-} from '@/lib/admin-dashboard'
-
-function defaultAdminRange(): { start: string; end: string } {
-  const range = resolveAdminQuickRange('30d')
-  return {
-    start: formatAdminDateInputValue(range.start),
-    end: formatAdminDateInputValue(range.end),
-  }
-}
-
-function normalizeDateSearch(start: string, end: string): { start: string; end: string } | null {
-  const parsed = resolveAdminDateRangeFromStrings(start, end)
-  if (!parsed) return null
-  const ordered =
-    parsed.start.getTime() <= parsed.end.getTime()
-      ? parsed
-      : { start: parsed.end, end: parsed.start }
-  return {
-    start: formatAdminDateInputValue(ordered.start),
-    end: formatAdminDateInputValue(ordered.end),
-  }
-}
 
 export const Route = createFileRoute('/_hub/admin')({
-  beforeLoad: async ({ context, search }) => {
+  beforeLoad: async ({ context }) => {
     await requireAdminSession(context)
-
-    if (typeof search.start !== 'string' || typeof search.end !== 'string') {
-      throw redirect({
-        to: '/admin',
-        search: defaultAdminRange(),
-        replace: true,
-      })
-    }
-
-    const normalized = normalizeDateSearch(search.start, search.end)
-    if (!normalized) {
-      throw redirect({
-        to: '/admin',
-        search: defaultAdminRange(),
-        replace: true,
-      })
-    }
-
-    if (normalized.start !== search.start || normalized.end !== search.end) {
-      throw redirect({
-        to: '/admin',
-        search: normalized,
-        replace: true,
-      })
-    }
   },
-  validateSearch: (search: Record<string, unknown>) => ({
-    start: typeof search.start === 'string' ? search.start : undefined,
-    end: typeof search.end === 'string' ? search.end : undefined,
-  }),
-  component: AdminRoute,
+  component: AdminLayoutRoute,
 })
 
-function AdminRoute() {
-  const { start, end } = Route.useSearch()
-
-  if (!start || !end) return null
-
-  return <AdminDashboardView startDate={start} endDate={end} />
+function AdminLayoutRoute() {
+  return (
+    <AdminLayout>
+      <Outlet />
+    </AdminLayout>
+  )
 }

--- a/frontend/app/src/routes/_hub/admin.users.tsx
+++ b/frontend/app/src/routes/_hub/admin.users.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { AdminUsersView } from '@/components/admin/AdminUsersView'
+
+export const Route = createFileRoute('/_hub/admin/users')({
+  component: AdminUsersView,
+})


### PR DESCRIPTION
## Summary
- add a responsive admin sidebar with mobile drawer navigation
- make Users the default admin page and move metrics to `/admin/metrics`
- add a searchable, paginated, read-only user directory with English and German translations

## Validation
- ESLint
- TypeScript typecheck
- flow coverage (56 flows)
- Vitest (810 passed, 9 skipped)
- production build