### PR TITLE
fix(frontend): reconcile player likes immediately

### DIFF
--- a/.agents/skills/create-bug/SKILL.md
+++ b/.agents/skills/create-bug/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: create-bug
+description: Create and index assessed Worship Viewer bug documents from rough reports. Use when capturing or promoting a bug under docs/issues; do not use for feature ideas.
+---
+
+# Create Bug
+
+Turn the user's report into one concise, assessed bug document and add it to the
+repository's bug index.
+
+## Workflow
+
+1. Read `docs/issues/templates/bug-template.md` and the `## Bugs` table in
+   `docs/issues/Readme.md`.
+2. If no bug report was provided, ask for it and stop.
+3. Derive a concise title that describes the incorrect behavior and a lowercase
+   kebab-case slug. Create `docs/issues/bugs/<slug>.md`. Never overwrite an
+   existing document; make the slug more specific when it already exists.
+4. Follow the template structure. Replace every placeholder, give every
+   assessment a 1-5 score and concise reason, and preserve the score scales.
+   Keep `[← Back to issues README](../Readme.md)` as the first visible content
+   after the YAML front matter. Populate the visible `## Assessment` table with
+   each score as `<score> / 5` and the same reason used in metadata. Set `status`
+   to `reported`, `last_reviewed` to today's date, and `owner` to `null` unless
+   the user identifies one.
+5. Identify affected personas and environment details from the report. Use
+   `null` for unknown environment metadata. Do not invent reproduction steps,
+   evidence, affected versions, causes, or workarounds; label unknowns clearly.
+6. Assess severity by consequence, frequency by occurrence, reproducibility by
+   how deterministically it can be triggered, and evidence by the strongest
+   artifact actually available. Estimate total fix effort including regression
+   tests, documentation, migrations, and rollout. Keep severity separate from
+   effort and fix risk.
+7. Use repository evidence when it materially improves the report. Keep the
+   observed and expected behavior distinct, and put unresolved diagnostic
+   details in open questions.
+8. Append one row to the Bugs table with a relative document link and the area,
+   primary persona, severity, frequency, reproducibility, effort, and status.
+   Preserve existing rows. Escape pipe characters that would break the Markdown
+   table. Preserve the `## Rough Ideas` section unless the user explicitly asks
+   to promote or remove a matching rough report.
+9. Validate the YAML front matter and confirm the visible assessment table and
+   index row match its metadata. Report links to the created document and
+   updated index. Do not create a git commit unless the user explicitly requests
+   one.

--- a/.agents/skills/create-bug/agents/openai.yaml
+++ b/.agents/skills/create-bug/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Create Bug"
+  short_description: "Create and index an assessed bug document"
+  default_prompt: "Use $create-bug to turn this report into an assessed bug document and index it."

--- a/.agents/skills/create-idea/SKILL.md
+++ b/.agents/skills/create-idea/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: create-idea
+description: Create and index scored Worship Viewer idea documents from rough idea text. Use when capturing or promoting an idea under docs/issues.
+---
+
+# Create Idea
+
+Turn the user's input into one concise, assessed idea document and add it to the
+repository's idea index.
+
+## Workflow
+
+1. Read `docs/issues/templates/idea-template.md` and the `## Ideas` table in
+   `docs/issues/Readme.md`.
+2. If no idea text was provided, ask for it and stop.
+3. Derive a concise, outcome-oriented title and a lowercase kebab-case slug.
+   Create `docs/issues/ideas/<slug>.md`. Never overwrite an existing document;
+   make the slug more specific when it already exists.
+4. Follow the template structure. Replace every placeholder, give every
+   assessment a 1-5 score and concise reason, and preserve the score scales.
+   Keep `[← Back to issues README](../Readme.md)` as the first visible content
+   after the YAML front matter.
+   Populate the visible `## Assessment` table with each score as `<score> / 5`
+   and the same reason used in metadata. Set `status` to `rough`,
+   `last_reviewed` to today's date, and `owner` to `null` unless the user
+   identifies one.
+5. Classify the impact audience as `user`, `maintainer`, or `both`; classify the
+   change as `new capability or area` or `improvement to an existing capability`;
+   identify the benefiting personas; and estimate total effort including tests,
+   documentation, migrations, and rollout.
+6. Keep the body minimal and concrete. Use repository evidence when it changes
+   the assessment. Record unresolved details as open questions instead of
+   inventing facts.
+7. Append one row to the Ideas table with a relative document link and the area,
+   primary persona, impact audience, change type, clarity, impact, effort, and
+   status. Preserve existing rows and the `## Rough Ideas` section unless the
+   user explicitly asks to promote or remove a matching rough idea. Escape pipe
+   characters that would break the Markdown table.
+8. Validate the YAML front matter and confirm the visible assessment table and
+   index row match its metadata. Report links to the created document and updated
+   index. Do not create a git commit unless the user explicitly requests one.

--- a/.agents/skills/create-idea/agents/openai.yaml
+++ b/.agents/skills/create-idea/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Create Idea"
+  short_description: "Create and index a scored idea document"
+  default_prompt: "Use $create-idea to turn this text into a scored idea document and index it."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to Worship Viewer are documented here. The format follows [K
 ### Fixed
 
 - Dark and light AV lyrics remain visible over checkerboard slide-selector previews.
+- Unliked songs disappear immediately from the sheet player's Liked table of contents and show inverse heart feedback.
 
 ## Release process
 

--- a/frontend/app/src/api/songs-like.test.ts
+++ b/frontend/app/src/api/songs-like.test.ts
@@ -1,0 +1,90 @@
+import { QueryClient } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { components } from '@/api/schema'
+import { setSongLikeStatus } from '@/api/songs-like'
+import { playerQueryKey, playerResourceTitleKey, songDetailQueryKey } from '@/lib/setlist-detail-key'
+
+const mocks = vi.hoisted(() => ({
+  deleteLike: vi.fn(),
+  putLike: vi.fn(),
+}))
+
+vi.mock('@/api/client', () => ({
+  api: {
+    DELETE: mocks.deleteLike,
+    PUT: mocks.putLike,
+  },
+}))
+
+vi.mock('@/lib/api-unauthorized', () => ({
+  redirectToLoginAfterUnauthorized: vi.fn(),
+}))
+
+type Player = components['schemas']['Player']
+type Song = components['schemas']['Song']
+
+function song(id: string, liked: boolean): Song {
+  return {
+    id,
+    blobs: [],
+    not_a_song: false,
+    owner: 'team-1',
+    user_specific_addons: { liked },
+    data: { titles: [id], sections: [] },
+  } as Song
+}
+
+function player(): Player {
+  return {
+    index: 0,
+    between_items: false,
+    orientation: 'portrait',
+    scroll_type: 'book',
+    scroll_type_cache_other_orientation: 'book',
+    toc: [
+      { idx: 0, nr: '1', title: 'First', id: 'song-1', liked: true },
+      { idx: 1, nr: '2', title: 'Duplicate', id: 'song-1', liked: true },
+    ],
+    items: [
+      { type: 'chords', song: song('song-1', true), language: null, flow: null },
+      { type: 'chords', song: song('song-1', true), language: null, flow: null },
+    ],
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.deleteLike.mockResolvedValue({
+    response: { ok: true, status: 204 },
+    error: undefined,
+  })
+})
+
+describe('setSongLikeStatus', () => {
+  it('reconciles every cached player occurrence and the song detail after an unlike', async () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(playerQueryKey('setlist', 'setlist-1', 'book'), {
+      status: 'ready',
+      source: 'network',
+      player: player(),
+    })
+    queryClient.setQueryData(songDetailQueryKey('song-1'), song('song-1', true))
+    queryClient.setQueryData(playerResourceTitleKey('setlist', 'setlist-1'), 'Sunday')
+
+    await setSongLikeStatus(queryClient, { id: 'song-1', liked: false })
+
+    const cached = queryClient.getQueryData<{
+      status: 'ready'
+      player: Player
+    }>(playerQueryKey('setlist', 'setlist-1', 'book'))
+    expect(cached?.player.toc.every((row) => !row.liked)).toBe(true)
+    expect(
+      cached?.player.items.every(
+        (item) => item.type !== 'chords' || !item.song.user_specific_addons.liked,
+      ),
+    ).toBe(true)
+    expect(queryClient.getQueryData<Song>(songDetailQueryKey('song-1'))?.user_specific_addons.liked).toBe(false)
+    expect(queryClient.getQueryData(playerResourceTitleKey('setlist', 'setlist-1'))).toBe('Sunday')
+  })
+})

--- a/frontend/app/src/api/songs-like.ts
+++ b/frontend/app/src/api/songs-like.ts
@@ -1,8 +1,56 @@
 import type { QueryClient } from '@tanstack/react-query'
+import type { components } from '@/api/schema'
 
 import { api } from '@/api/client'
 
 import { redirectToLoginAfterUnauthorized } from '@/lib/api-unauthorized'
+import type { ResolvedPlayerState } from '@/lib/offline/resolve-player'
+import { playerQueriesRootKey, songDetailQueryKey } from '@/lib/setlist-detail-key'
+
+type Player = components['schemas']['Player']
+type Song = components['schemas']['Song']
+
+function updatePlayerLike(player: Player, songId: string, liked: boolean): Player {
+  return {
+    ...player,
+    toc: player.toc.map((row) => (row.id === songId ? { ...row, liked } : row)),
+    items: player.items.map((item) =>
+      item.type === 'chords' && item.song.id === songId
+        ? {
+            ...item,
+            song: {
+              ...item.song,
+              user_specific_addons: { ...item.song.user_specific_addons, liked },
+            },
+          }
+        : item,
+    ),
+  }
+}
+
+function updateResolvedPlayerLike(
+  state: ResolvedPlayerState | undefined,
+  songId: string,
+  liked: boolean,
+): ResolvedPlayerState | undefined {
+  if (state?.status !== 'ready') return state
+  return { ...state, player: updatePlayerLike(state.player, songId, liked) }
+}
+
+function reconcileCachedLike(queryClient: QueryClient, songId: string, liked: boolean): void {
+  queryClient.setQueriesData<ResolvedPlayerState>(
+    { queryKey: playerQueriesRootKey() },
+    (state) => updateResolvedPlayerLike(state, songId, liked),
+  )
+  queryClient.setQueryData<Song>(songDetailQueryKey(songId), (song) =>
+    song
+      ? {
+          ...song,
+          user_specific_addons: { ...song.user_specific_addons, liked },
+        }
+      : song,
+  )
+}
 
 function problemTitle(status: number, body: unknown): string {
   if (body && typeof body === 'object' && 'title' in body) {
@@ -32,4 +80,5 @@ export async function setSongLikeStatus(
   if (!response.ok) {
     throw new Error(problemTitle(response.status, error))
   }
+  reconcileCachedLike(queryClient, id, liked)
 }

--- a/frontend/app/src/components/player/PlayerBook.likes.test.tsx
+++ b/frontend/app/src/components/player/PlayerBook.likes.test.tsx
@@ -1,0 +1,240 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { components } from '@/api/schema'
+import { PlayerBook } from '@/components/player/PlayerBook'
+
+const mocks = vi.hoisted(() => ({
+  setSongLikeStatus: vi.fn(),
+  toastError: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children }: { children: React.ReactNode }) => <a href="/">{children}</a>,
+  useNavigate: () => vi.fn(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: mocks.toastError, info: vi.fn() },
+}))
+
+vi.mock('@/api/songs-like', () => ({
+  setSongLikeStatus: mocks.setSongLikeStatus,
+}))
+
+vi.mock('@/components/player/BlobSlide', () => ({ BlobSlide: () => null }))
+vi.mock('@/components/player/ChordsSlide', () => ({ ChordsSlide: () => <div>song</div> }))
+vi.mock('@/components/player/ChordsThreeColumnSlide', () => ({
+  ChordsThreeColumnSlide: () => <div>song</div>,
+}))
+vi.mock('@/components/player/PlayerBookSpread', () => ({
+  PlayerBookSpread: ({ left }: { left: React.ReactNode }) => <>{left}</>,
+}))
+vi.mock('@/components/player/PlayerEditMenu', () => ({ PlayerEditMenu: () => null }))
+vi.mock('@/components/player/PlayerLikeHeartBurst', () => ({
+  PlayerLikeHeartBurst: ({ liked }: { liked: boolean }) => (
+    <div data-testid="like-feedback" data-liked={liked} />
+  ),
+}))
+vi.mock('@/components/player-room/StartPlayerRoomButton', () => ({
+  StartPlayerRoomButton: () => null,
+}))
+vi.mock('@/components/player/PlayerTocSidebar', () => ({
+  PlayerTocSidebar: ({ toc }: { toc: components['schemas']['TocItem'][] }) => (
+    <div data-testid="liked-toc">
+      {toc
+        .filter((row) => row.liked)
+        .map((row) => <div key={`${row.idx}:${row.title}`}>{row.title}</div>)}
+    </div>
+  ),
+}))
+
+vi.mock('@/hooks/useChordFormatPreference', () => ({
+  useChordFormatPreference: () => 'letters',
+}))
+vi.mock('@/hooks/useMediaQuery', () => ({
+  useIsPhoneWidth: () => false,
+  useMediaQuery: () => false,
+}))
+vi.mock('@/hooks/use-online', () => ({ useOnline: () => true }))
+vi.mock('@/hooks/usePlayerIndexSearchSync', () => ({
+  usePlayerIndexSearchSync: () => undefined,
+}))
+vi.mock('@/hooks/usePlayerScrollPreference', () => ({
+  usePlayerLayoutPreference: () => ({
+    linkedOrientations: true,
+    portrait: {
+      mode: 'page',
+      pageCount: 1,
+      columnCount: 1,
+      nextSongPreview: false,
+      overflowStyle: 'scroll',
+      expandSections: false,
+    },
+    landscape: {
+      mode: 'page',
+      pageCount: 1,
+      columnCount: 1,
+      nextSongPreview: false,
+      overflowStyle: 'scroll',
+      expandSections: false,
+    },
+  }),
+}))
+vi.mock('@/hooks/useSetlistEvictionWatch', () => ({
+  useSetlistEvictionWatch: () => false,
+}))
+vi.mock('@/hooks/useTocMultilingualPreference', () => ({
+  useTocMultilingualPreference: () => false,
+}))
+vi.mock('@/lib/chord-engine', () => ({
+  getChordEngine: async () => ({ renderA4Html: vi.fn(), renderA4SectionHtmls: vi.fn() }),
+}))
+vi.mock('@/lib/player/apply-song-flow', () => ({
+  useResolvedSongWithFlow: (song: components['schemas']['Song']) => song,
+}))
+
+type Player = components['schemas']['Player']
+type Song = components['schemas']['Song']
+
+function song(id: string, liked: boolean): Song {
+  return {
+    id,
+    blobs: [],
+    not_a_song: false,
+    owner: 'team-1',
+    user_specific_addons: { liked },
+    data: { titles: [id], sections: [] },
+  } as Song
+}
+
+function player(): Player {
+  return {
+    index: 0,
+    between_items: false,
+    orientation: 'portrait',
+    scroll_type: 'one_page',
+    scroll_type_cache_other_orientation: 'book',
+    toc: [
+      { idx: 0, nr: '1', title: 'Current', id: 'song-1', liked: true },
+      { idx: 1, nr: '2', title: 'Current duplicate', id: 'song-1', liked: true },
+      { idx: 2, nr: '3', title: 'Other', id: 'song-2', liked: true },
+    ],
+    items: [
+      { type: 'chords', song: song('song-1', false), language: null, flow: null },
+      { type: 'chords', song: song('song-1', false), language: null, flow: null },
+      { type: 'chords', song: song('song-2', false), language: null, flow: null },
+    ],
+  }
+}
+
+function renderPlayer(value: Player) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <PlayerBook
+        type="setlist"
+        id="setlist-1"
+        player={value}
+        allowNetworkFetch
+        roomSidebar={<div>room</div>}
+      />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('PlayerBook likes', () => {
+  it('unlikes exactly once for a native mouse double-click', async () => {
+    mocks.setSongLikeStatus.mockImplementation(() => new Promise<void>(() => undefined))
+    renderPlayer(player())
+    const main = screen.getByRole('main')
+    vi.spyOn(main, 'getBoundingClientRect').mockReturnValue(
+      DOMRect.fromRect({ x: -50, width: 100, height: 100 }),
+    )
+
+    await userEvent.dblClick(main)
+
+    expect(mocks.setSongLikeStatus).toHaveBeenCalledTimes(1)
+    expect(mocks.setSongLikeStatus).toHaveBeenCalledWith(expect.anything(), {
+      id: 'song-1',
+      liked: false,
+    })
+    expect(screen.getByTestId('like-feedback')).toHaveAttribute('data-liked', 'false')
+  })
+
+  it('ignores both delayed synthetic clicks after a touch double-tap unlike', () => {
+    mocks.setSongLikeStatus.mockImplementation(() => new Promise<void>(() => undefined))
+    renderPlayer(player())
+    const main = screen.getByRole('main')
+    const touch = { clientX: 50, clientY: 50 }
+
+    fireEvent.touchStart(main, { touches: [touch] })
+    fireEvent.touchEnd(main, { changedTouches: [touch] })
+    fireEvent.touchStart(main, { touches: [touch] })
+    fireEvent.touchEnd(main, { changedTouches: [touch] })
+    fireEvent.click(main, { clientX: 50, clientY: 50 })
+    fireEvent.click(main, { clientX: 50, clientY: 50 })
+
+    expect(mocks.setSongLikeStatus).toHaveBeenCalledTimes(1)
+    expect(mocks.setSongLikeStatus).toHaveBeenCalledWith(expect.anything(), {
+      id: 'song-1',
+      liked: false,
+    })
+  })
+
+  it('keeps every duplicate row removed across a fresh player object while unlike is pending', async () => {
+    mocks.setSongLikeStatus.mockImplementation(() => new Promise<void>(() => undefined))
+    const original = player()
+    const view = renderPlayer(original)
+
+    fireEvent.keyDown(window, { key: 'l' })
+
+    const likedToc = within(screen.getByTestId('liked-toc'))
+    expect(likedToc.queryByText('Current')).not.toBeInTheDocument()
+    expect(likedToc.queryByText('Current duplicate')).not.toBeInTheDocument()
+    expect(likedToc.getByText('Other')).toBeInTheDocument()
+
+    view.rerender(
+      <QueryClientProvider client={new QueryClient()}>
+        <PlayerBook
+          type="setlist"
+          id="setlist-1"
+          player={structuredClone(original)}
+          allowNetworkFetch
+          roomSidebar={<div>room</div>}
+        />
+      </QueryClientProvider>,
+    )
+
+    expect(likedToc.queryByText('Current')).not.toBeInTheDocument()
+    expect(likedToc.queryByText('Current duplicate')).not.toBeInTheDocument()
+    await waitFor(() =>
+      expect(mocks.setSongLikeStatus).toHaveBeenCalledWith(expect.anything(), {
+        id: 'song-1',
+        liked: false,
+      }),
+    )
+  })
+
+  it('restores every duplicate row when the unlike request fails', async () => {
+    mocks.setSongLikeStatus.mockRejectedValue(new Error('failed'))
+    renderPlayer(player())
+
+    fireEvent.keyDown(window, { key: 'l' })
+
+    const likedToc = within(screen.getByTestId('liked-toc'))
+    await waitFor(() => expect(likedToc.getByText('Current')).toBeInTheDocument())
+    expect(likedToc.getByText('Current duplicate')).toBeInTheDocument()
+    expect(mocks.toastError).toHaveBeenCalledWith('player.loadFailed')
+  })
+})

--- a/frontend/app/src/components/player/PlayerBook.tsx
+++ b/frontend/app/src/components/player/PlayerBook.tsx
@@ -99,13 +99,16 @@ type TocItem = Player['toc'][number]
 
 function initialLikedBySongId(player: Player): Record<string, boolean> {
   const liked: Record<string, boolean> = {}
-  for (const row of player.toc) {
-    if (row.id) liked[row.id] = row.liked
-  }
   for (const item of player.items) {
     if (item.type === 'chords') {
       liked[item.song.id] = item.song.user_specific_addons.liked
     }
+  }
+  // The TOC is assembled with the current user's like set. Some player item
+  // payloads still carry a stale/default user-specific addon, so TOC values
+  // must win when both representations contain the same song.
+  for (const row of player.toc) {
+    if (row.id) liked[row.id] = row.liked
   }
   return liked
 }
@@ -225,6 +228,7 @@ const PLAYER_CHROME_EASE = [0.25, 0.1, 0.25, 1] as const
 const VIEWPORT_DOUBLE_TAP_MS = 300
 const VIEWPORT_TAP_MOVE_SLOP_PX = 10
 const VIEWPORT_SWIPE_MIN_PX = 48
+const TOUCH_CLICK_SUPPRESSION_MS = 750
 
 const playerChromeHeaderClass =
   'pointer-events-auto flex shrink-0 items-center gap-2 overflow-hidden border-b border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-2 sm:px-3 sm:py-3'
@@ -281,29 +285,30 @@ export function PlayerBook({
 
   const touchStartRef = useRef<{ x: number; y: number } | null>(null)
   const touchMovedRef = useRef(false)
-  const suppressClickRef = useRef(false)
-  const chromeToggleHandledRef = useRef(false)
+  const suppressClicksUntilRef = useRef(0)
   const lastMiddleViewportTapTimeRef = useRef<number | null>(null)
   const pendingChromeOpenRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [likeBurstKey, setLikeBurstKey] = useState(0)
   const [likeBurstActive, setLikeBurstActive] = useState(false)
+  const [likeBurstLiked, setLikeBurstLiked] = useState(true)
   const tocMultilingualEnabled = useTocMultilingualPreference()
 
   const [viewState, setViewState] = useState<PlayerViewState>(() => readPlayerViewState(type, id))
   const serverLikes = useMemo(() => initialLikedBySongId(player), [player])
+  const likeScope = `${type}:${id}`
   const [likeState, setLikeState] = useState<{
-    player: Player
+    scope: string
     delta: Record<string, boolean>
   }>(() => ({
-    player,
+    scope: likeScope,
     delta: {},
   }))
   const likedBySongId = useMemo(
     () => ({
       ...serverLikes,
-      ...(likeState.player === player ? likeState.delta : {}),
+      ...(likeState.scope === likeScope ? likeState.delta : {}),
     }),
-    [likeState, player, serverLikes],
+    [likeScope, likeState, serverLikes],
   )
 
   useEffect(() => {
@@ -393,8 +398,9 @@ export function PlayerBook({
 
   usePlayerIndexSearchSync(type, id, nav.index, mode)
 
-  const triggerLikeBurst = useCallback(() => {
+  const triggerLikeBurst = useCallback((liked: boolean) => {
     setLikeBurstKey((key) => key + 1)
+    setLikeBurstLiked(liked)
     setLikeBurstActive(true)
   }, [])
 
@@ -404,24 +410,33 @@ export function PlayerBook({
     const previousLiked = likedBySongId[songId] ?? currentItem.song.user_specific_addons.liked
     const nextLiked = !previousLiked
     setLikeState((state) => ({
-      player,
+      scope: likeScope,
       delta: {
-        ...(state.player === player ? state.delta : {}),
+        ...(state.scope === likeScope ? state.delta : {}),
         [songId]: nextLiked,
       },
     }))
-    if (nextLiked) triggerLikeBurst()
-    void setSongLikeStatus(queryClient, { id: songId, liked: nextLiked }).catch(() => {
-      setLikeState((state) => ({
-        player,
-        delta: {
-          ...(state.player === player ? state.delta : {}),
-          [songId]: previousLiked,
-        },
-      }))
-      toast.error(t('player.loadFailed'))
-    })
-  }, [allowLibraryActions, allowNetworkFetch, currentItem, likedBySongId, online, player, queryClient, t, triggerLikeBurst])
+    triggerLikeBurst(nextLiked)
+    void setSongLikeStatus(queryClient, { id: songId, liked: nextLiked })
+      .then(() => {
+        setLikeState((state) => {
+          if (state.scope !== likeScope || state.delta[songId] !== nextLiked) return state
+          const delta = { ...state.delta }
+          delete delta[songId]
+          return { ...state, delta }
+        })
+      })
+      .catch(() => {
+        setLikeState((state) => {
+          if (state.scope !== likeScope || state.delta[songId] !== nextLiked) return state
+          return {
+            ...state,
+            delta: { ...state.delta, [songId]: previousLiked },
+          }
+        })
+        toast.error(t('player.loadFailed'))
+      })
+  }, [allowLibraryActions, allowNetworkFetch, currentItem, likedBySongId, likeScope, online, queryClient, t, triggerLikeBurst])
 
   const cancelPendingChromeOpen = useCallback(() => {
     if (pendingChromeOpenRef.current != null) {
@@ -926,7 +941,7 @@ export function PlayerBook({
 
     if (isSwipe) {
       touchMovedRef.current = false
-      suppressClickRef.current = true
+      suppressClicksUntilRef.current = performance.now() + TOUCH_CLICK_SUPPRESSION_MS
       if (navBlocked || chromeVisible) return
       if (dx > 0) dispatch({ type: 'prev' })
       else dispatch({ type: 'next' })
@@ -935,29 +950,35 @@ export function PlayerBook({
 
     if (touchMovedRef.current) {
       touchMovedRef.current = false
-      suppressClickRef.current = true
+      suppressClicksUntilRef.current = performance.now() + TOUCH_CLICK_SUPPRESSION_MS
       return
     }
 
     const rect = e.currentTarget.getBoundingClientRect()
     if (handleViewportPointer(touch.clientX, e.target, rect)) {
-      chromeToggleHandledRef.current = true
+      suppressClicksUntilRef.current = performance.now() + TOUCH_CLICK_SUPPRESSION_MS
     }
   }
 
   function onMainClick(e: React.MouseEvent<HTMLElement>) {
-    if (suppressClickRef.current) {
-      suppressClickRef.current = false
+    if (performance.now() < suppressClicksUntilRef.current) {
       return
     }
-
-    if (chromeToggleHandledRef.current) {
-      chromeToggleHandledRef.current = false
-      return
-    }
+    suppressClicksUntilRef.current = 0
+    if (e.detail > 1) return
 
     const rect = e.currentTarget.getBoundingClientRect()
     handleViewportPointer(e.clientX, e.target, rect)
+  }
+
+  function onMainDoubleClick(e: React.MouseEvent<HTMLElement>) {
+    if (isInteractiveTarget(e.target)) return
+    const rect = e.currentTarget.getBoundingClientRect()
+    if (viewportPointerZone(e.clientX, rect) !== 'middle') return
+    e.preventDefault()
+    cancelPendingChromeOpen()
+    lastMiddleViewportTapTimeRef.current = performance.now()
+    toggleCurrentSongLike()
   }
 
   if (itemsLen === 0 || !currentItem) {
@@ -1160,6 +1181,7 @@ export function PlayerBook({
             }}
             transition={chromeTransition}
             onClick={onMainClick}
+            onDoubleClick={onMainDoubleClick}
             onTouchStart={onTouchStart}
             onTouchMove={onTouchMove}
             onTouchEnd={onTouchEnd}
@@ -1168,6 +1190,7 @@ export function PlayerBook({
             {likeBurstActive ? (
               <PlayerLikeHeartBurst
                 key={likeBurstKey}
+                liked={likeBurstLiked}
                 onFinished={() => setLikeBurstActive(false)}
               />
             ) : null}

--- a/frontend/app/src/components/player/PlayerLikeHeartBurst.tsx
+++ b/frontend/app/src/components/player/PlayerLikeHeartBurst.tsx
@@ -4,10 +4,11 @@ import { useEffect } from 'react'
 const INSTAGRAM_HEART = '#ed4956'
 
 type PlayerLikeHeartBurstProps = {
+  liked: boolean
   onFinished?: () => void
 }
 
-export function PlayerLikeHeartBurst({ onFinished }: PlayerLikeHeartBurstProps) {
+export function PlayerLikeHeartBurst({ liked, onFinished }: PlayerLikeHeartBurstProps) {
   const reduceMotion = useReducedMotion()
 
   useEffect(() => {
@@ -19,6 +20,7 @@ export function PlayerLikeHeartBurst({ onFinished }: PlayerLikeHeartBurstProps) 
   return (
     <div
       className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center"
+      data-like-feedback={liked ? 'like' : 'unlike'}
       aria-hidden
     >
       <motion.svg
@@ -26,12 +28,19 @@ export function PlayerLikeHeartBurst({ onFinished }: PlayerLikeHeartBurstProps) 
         height={96}
         viewBox="0 0 24 24"
         className="drop-shadow-[0_4px_24px_rgba(0,0,0,0.35)]"
-        initial={{ scale: 0, opacity: 0 }}
-        animate={{ scale: [0, 1.28, 1], opacity: [0, 1, 0] }}
+        initial={liked ? { scale: 0, opacity: 0 } : { scale: 1, opacity: 1 }}
+        animate={
+          liked
+            ? {
+                scale: [0, 0.58, 1.38, 1.2, 1.2],
+                opacity: [0, 0.7, 1, 1, 0],
+              }
+            : { scale: [1, 0.72, 0], opacity: [1, 0.7, 0] }
+        }
         transition={{
-          duration: 0.9,
-          times: [0, 0.22, 1],
-          ease: [0.175, 0.885, 0.32, 1.275],
+          duration: liked ? 1 : 0.75,
+          times: liked ? [0, 0.1, 0.32, 0.48, 1] : [0, 0.35, 1],
+          ease: liked ? [0.175, 0.885, 0.32, 1.275] : [0.4, 0, 1, 1],
         }}
         onAnimationComplete={onFinished}
       >


### PR DESCRIPTION
## Summary

- make TOC likes authoritative over stale embedded player-item values
- preserve optimistic likes across refreshed player payloads and reconcile player/song query caches
- handle duplicate rows, rollback, native double-click, and delayed touch-generated clicks safely
- add distinct like pop and inverse unlike collapse feedback
- add repository-local skills for capturing assessed bugs and ideas

## Verification

- pnpm -C frontend lint
- pnpm -C frontend typecheck
- pnpm -C frontend test (815 passed, 9 skipped)
- pnpm -C frontend build
- verified like/unlike, native double-tap, immediate Liked-list removal, animation feedback, and persistence after reload in the running local player

The local docs/issues updates are intentionally excluded from this PR.