### PR TITLE
fix(frontend): preserve song key change mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Worship Viewer are documented here. The format follows [K
 
 ### Fixed
 
+- Song editor key changes now preserve the selected transpose-or-keep chord behavior when autosaving.
 - Dark and light AV lyrics remain visible over checkerboard slide-selector previews.
 - Unliked songs disappear immediately from the sheet player's Liked table of contents and show inverse heart feedback.
 

--- a/frontend/app/src/components/songs/SongEditorScreen.test.tsx
+++ b/frontend/app/src/components/songs/SongEditorScreen.test.tsx
@@ -1,0 +1,183 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ComponentProps, ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { PatchSongData } from '@/lib/song-editor-state'
+import type { ChordEngine, ChordSongData } from '@/ports/chord-engine'
+
+let autosaveDraft: PatchSongData | null = null
+
+const songInC: ChordSongData = {
+  titles: ['Test song'],
+  artists: [''],
+  languages: [''],
+  key: { level: 3 },
+  sections: [
+    {
+      lines: [
+        {
+          parts: [
+            {
+              chord: { main: { level: 7 }, base: { level: 10 } },
+              languages: ['Line'],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+const engine = {
+  parseChordPro: (source: string) => JSON.parse(source) as ChordSongData,
+  formatChordPro: (song: ChordSongData) => JSON.stringify(song),
+} as ChordEngine
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}))
+
+vi.mock('@/hooks/useSongDetailQuery', () => ({
+  useSongDetailQuery: () => ({
+    data: {
+      id: 'song-1',
+      owner: 'user:test',
+      not_a_song: false,
+      data: songInC,
+    },
+    isPending: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}))
+
+vi.mock('@/hooks/useCanEditSong', () => ({ useCanEditSong: () => ({ canEdit: true }) }))
+vi.mock('@/hooks/useChordFormatPreference', () => ({ useChordFormatPreference: () => 'letters' }))
+vi.mock('@/hooks/use-online', () => ({ useOnline: () => true }))
+vi.mock('@/lib/chord-engine', () => ({ getChordEngine: async () => engine }))
+vi.mock('@/context/SongEditorNavigationBridgeContext', () => ({
+  useRegisterSongEditorNavigationBridge: vi.fn(),
+}))
+
+const autosaveResult = {
+  markDraftDirty: vi.fn(),
+  flushNow: vi.fn(async () => true),
+  patchInFlight: false,
+  saveIcon: 'idle' as const,
+  saveFailure: null,
+  saveRevision: 0,
+  retrySave: vi.fn(),
+  discardFailedSave: vi.fn(),
+}
+
+vi.mock('@/hooks/useSongAutosave', () => ({
+  useSongAutosave: ({ draft }: { draft: PatchSongData | null }) => {
+    autosaveDraft = draft
+    return autosaveResult
+  },
+}))
+
+vi.mock('@/lib/song-editor-compose', () => ({
+  composeSectionsFromSongData: () => [],
+  mergeSongDataWithComposeSections: (song: ChordSongData) => song,
+}))
+
+vi.mock('@/components/songs/SongEditorCompose', () => ({
+  SongEditorCompose: () => <div />,
+}))
+
+vi.mock('@/components/songs/SongEditorSource', () => ({
+  SongEditorSource: () => <textarea />,
+}))
+
+vi.mock('@/components/ui/select', () => ({
+  Select: ({
+    children,
+    value,
+    onValueChange,
+    disabled,
+  }: {
+    children: ReactNode
+    value: string
+    onValueChange: (value: string) => void
+    disabled?: boolean
+  }) => (
+    <select
+      value={value}
+      disabled={disabled}
+      onChange={(event) => onValueChange(event.target.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectContent: ({ children }: { children: ReactNode }) => children,
+  SelectItem: ({ children, value }: { children: ReactNode; value: string }) => (
+    <option value={value}>{children}</option>
+  ),
+  SelectTrigger: ({ children }: { children: ReactNode }) => children,
+  SelectValue: () => null,
+}))
+
+vi.mock('@/components/ui/alert-dialog', () => ({
+  AlertDialog: ({ children, open }: { children: ReactNode; open: boolean }) =>
+    open ? <div>{children}</div> : null,
+  AlertDialogCancel: (props: ComponentProps<'button'>) => <button {...props} />,
+  AlertDialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  AlertDialogDescription: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  AlertDialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  AlertDialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+import { SongEditorScreen } from '@/components/songs/SongEditorScreen'
+
+function savedChordLevel(): number | undefined {
+  const sections = autosaveDraft?.sections as
+    | Array<{ lines?: Array<{ parts?: Array<{ chord?: { main?: { level?: number } } }> }> }>
+    | undefined
+  return sections?.[0]?.lines?.[0]?.parts?.[0]?.chord?.main?.level
+}
+
+function savedBassLevel(): number | undefined {
+  const sections = autosaveDraft?.sections as
+    | Array<{
+        lines?: Array<{
+          parts?: Array<{ chord?: { base?: { level?: number } } }>
+        }>
+      }>
+    | undefined
+  return sections?.[0]?.lines?.[0]?.parts?.[0]?.chord?.base?.level
+}
+
+describe('SongEditorScreen key changes', () => {
+  beforeEach(() => {
+    autosaveDraft = null
+    vi.clearAllMocks()
+  })
+
+  it.each([
+    ['songs.editor.keyChangeTranspose', 7, 10],
+    ['songs.editor.keyChangeKeep', 5, 8],
+  ])(
+    'keeps the %s result in the autosave draft',
+    async (buttonName, expectedLevel, expectedBassLevel) => {
+      const user = userEvent.setup()
+      render(<SongEditorScreen songId="song-1" />)
+
+      const keySelect = await screen.findByLabelText('songs.editor.keyLabel')
+      await user.selectOptions(keySelect, 'D')
+      await user.click(screen.getByRole('button', { name: buttonName }))
+
+      await waitFor(() => {
+        expect(autosaveDraft?.key).toEqual({ level: 5 })
+        expect(savedChordLevel()).toBe(expectedLevel)
+        expect(savedBassLevel()).toBe(expectedBassLevel)
+      })
+    },
+  )
+})

--- a/frontend/app/src/components/songs/SongEditorScreen.tsx
+++ b/frontend/app/src/components/songs/SongEditorScreen.tsx
@@ -34,7 +34,7 @@ import { getChordEngine } from '@/lib/chord-engine'
 import { MUSICAL_KEYS } from '@/lib/setlist-editor-constants'
 import { songDetailQueryKey } from '@/lib/setlist-detail-key'
 import {
-  applyKeyChangeToSource,
+  applyKeyChangeToSongData,
   applyMetadataStripToSource,
   formatSourceFromSongData,
   createSongLanguageEntry,
@@ -439,20 +439,21 @@ export function SongEditorScreen({ songId }: { songId: string }) {
       if (!engine || sourceBlocked) return
       const base = composeSongDataRef.current ?? (parseResult?.ok ? parseResult.data : null)
       if (!base) return
-      const nextSource = applyKeyChangeToSource(
-        engine,
+      const changed = applyKeyChangeToSongData(
         base,
         strip,
         mode,
         previousKey,
-        chordFormat,
       )
-      setSourceText(nextSource)
-      const reparsed = parseSourceWithEngine(engine, nextSource)
-      if (reparsed.ok) {
-        setMetadataStrip(metadataStripFromSongData(reparsed.data))
-        setParseError(null)
-      }
+      composeSongDataRef.current = changed
+      skipComposeResyncRef.current = true
+      setComposeSections(
+        composeSectionsFromSongData(changed, engine, strip.key || null, chordFormat),
+      )
+      setComposeDraftRevision((revision) => revision + 1)
+      setSourceText(formatSourceFromSongData(engine, changed, chordFormat))
+      setMetadataStrip(metadataStripFromSongData(changed))
+      setParseError(null)
     },
     [chordFormat, engine, parseResult, sourceBlocked],
   )

--- a/frontend/app/src/lib/song-editor-state.test.ts
+++ b/frontend/app/src/lib/song-editor-state.test.ts
@@ -13,6 +13,7 @@ import { ChordEngineError } from '@/ports/chord-engine'
 
 import {
   applyKeyChangeToSource,
+  applyKeyChangeToSongData,
   beatsPerMeasureFromTimeSignature,
   createSongLanguageEntry,
   metadataStripFromSongData,
@@ -393,6 +394,20 @@ describe('applyKeyChangeToSource', () => {
 
     applyKeyChangeToSource(engine, songInC, stripD, 'keep', 'C')
     expect(formatted?.sections?.[0]?.lines?.[0]?.parts?.[0]?.chord?.main?.level).toBe(5)
+  })
+
+  it.each([
+    ['transpose', 7],
+    ['keep', 5],
+  ] as const)('returns canonical %s data for autosave', (mode, expectedLevel) => {
+    const changed = applyKeyChangeToSongData(songInC, stripD, mode, 'C') as SongWire
+
+    expect(changed.key).toEqual({ level: 5 })
+    expect(changed.sections?.[0]?.lines?.[0]?.parts?.[0]?.chord?.main?.level).toBe(
+      expectedLevel,
+    )
+    expect(patchSongDataFromParsed(changed, metadataStripFromSongData(changed)).sections)
+      .toEqual(changed.sections)
   })
 })
 

--- a/frontend/app/src/lib/song-editor-state.ts
+++ b/frontend/app/src/lib/song-editor-state.ts
@@ -412,6 +412,17 @@ export function applyKeyChangeToSource(
   previousKey: string,
   chordFormat: ChordFormatPreference = 'letters',
 ): string {
+  const changed = applyKeyChangeToSongData(parsed, strip, mode, previousKey)
+  return engine.formatChordPro(changed, songEditorFormatOptions(chordFormat, changed))
+}
+
+/** Apply a key change to canonical song data so the chosen chord behavior survives saving. */
+export function applyKeyChangeToSongData(
+  parsed: ChordSongData,
+  strip: SongMetadataStrip,
+  mode: KeyChangeChordMode,
+  previousKey: string,
+): ChordSongData {
   let merged = mergeSongDataWithMetadataStrip(parsed, strip)
 
   if (
@@ -422,7 +433,7 @@ export function applyKeyChangeToSource(
     merged = remapSongChordLevelsForAbsolutePitch(merged, previousKey.trim(), strip.key.trim())
   }
 
-  return engine.formatChordPro(merged, songEditorFormatOptions(chordFormat, merged))
+  return merged
 }
 
 export function applyMetadataStripToSource(


### PR DESCRIPTION
## Summary
- keep the selected key-change transformation as the canonical song editor snapshot
- synchronize compose sections, source text, metadata, and autosave revision from that snapshot
- add editor-level regression coverage for root and slash-bass levels in both key-change modes

## Root cause
Autosave preferred the compose snapshot, but key changes only updated formatted source and metadata. The stale pre-change snapshot therefore discarded the Keep chord symbols remap.

## Verification
- frontend ESLint
- TypeScript typecheck
- full frontend suite: 819 passed, 9 skipped
- production build
- focused key-change tests: 32 passed