### PR TITLE
feat(frontend): link tutorials from profile menu

### DIFF
--- a/frontend/app/src/components/hub/ProfileMenu.test.tsx
+++ b/frontend/app/src/components/hub/ProfileMenu.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import i18next from 'i18next'
+import { I18nextProvider, initReactI18next } from 'react-i18next'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { User } from '@/api/session'
+import { ProfileMenu } from '@/components/hub/ProfileMenu'
+import { SongEditorNavigationBridgeProvider } from '@/context/SongEditorNavigationBridgeContext'
+import de from '@/i18n/de.json'
+import en from '@/i18n/en.json'
+import { PwaInstallContext } from '@/pwa/pwa-install-context'
+
+vi.mock('@tanstack/react-router', () => ({ useNavigate: () => vi.fn() }))
+vi.mock('@/routes/__root', () => ({
+  Route: { useRouteContext: () => ({ queryClient: {} }) },
+}))
+
+const userByRole = (role: User['role']): User => ({
+  id: `${role}-user`,
+  email: `${role}@example.com`,
+  role,
+  created_at: '2026-08-31T00:00:00Z',
+})
+
+async function renderMenu({
+  language = 'en',
+  role = 'default',
+  offline = false,
+  canShowInstall = true,
+  flushBeforeLeave = vi.fn(async () => true),
+}: {
+  language?: 'en' | 'de'
+  role?: User['role']
+  offline?: boolean
+  canShowInstall?: boolean
+  flushBeforeLeave?: () => Promise<boolean>
+} = {}) {
+  const i18n = i18next.createInstance()
+  await i18n.use(initReactI18next).init({
+    resources: { en: { translation: en }, de: { translation: de } },
+    lng: language,
+    fallbackLng: 'en',
+    interpolation: { escapeValue: false },
+  })
+
+  const setBridge = vi.fn()
+  render(
+    <I18nextProvider i18n={i18n}>
+      <PwaInstallContext.Provider value={{ canShowInstall, openInstall: vi.fn() }}>
+        <SongEditorNavigationBridgeProvider
+          bridge={{ flushBeforeLeave }}
+          setBridge={setBridge}
+        >
+          <ProfileMenu user={userByRole(role)} offline={offline} />
+        </SongEditorNavigationBridgeProvider>
+      </PwaInstallContext.Provider>
+    </I18nextProvider>,
+  )
+
+  const interaction = userEvent.setup()
+  await interaction.click(
+    screen.getByRole('button', {
+      name: offline ? /profile menu \(offline\)|profilmenü öffnen \(offline\)/i : /profile menu|profilmenü/i,
+    }),
+  )
+  return { interaction, flushBeforeLeave }
+}
+
+describe('ProfileMenu tutorials link', () => {
+  it.each(['default', 'admin'] as const)(
+    'places Tutorials after About and before Install app for the %s role',
+    async (role) => {
+      await renderMenu({ role })
+
+      const menu = screen.getByRole('menu')
+      const itemLabels = within(menu)
+        .getAllByRole('menuitem')
+        .map((item) => item.textContent?.trim())
+      const aboutIndex = itemLabels.indexOf('About')
+      const tutorialsIndex = itemLabels.indexOf('Tutorials')
+      const installIndex = itemLabels.indexOf('Install app')
+
+      expect(tutorialsIndex).toBe(aboutIndex + 1)
+      expect(installIndex).toBe(tutorialsIndex + 1)
+    },
+  )
+
+  it.each([
+    ['en' as const, 'Tutorials'],
+    ['de' as const, 'Tutorials'],
+  ])('uses the localized label in %s', async (language, label) => {
+    await renderMenu({ language, canShowInstall: false })
+    expect(screen.getByRole('menuitem', { name: label })).toBeEnabled()
+  })
+
+  it('remains enabled offline and keeps secure external-link attributes', async () => {
+    await renderMenu({ offline: true })
+    const tutorials = screen.getByRole('menuitem', { name: 'Tutorials' })
+
+    expect(tutorials).toBeEnabled()
+    expect(tutorials).toHaveAttribute('href', 'https://www.worshipviewer.com/tutorials')
+    expect(tutorials).toHaveAttribute('target', '_blank')
+    expect(tutorials).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('activates from the keyboard without invoking the leave-editor flow', async () => {
+    const flushBeforeLeave = vi.fn(async () => true)
+    const { interaction } = await renderMenu({ flushBeforeLeave })
+    const tutorials = screen.getByRole('menuitem', { name: 'Tutorials' })
+
+    tutorials.focus()
+    await interaction.keyboard('{Enter}')
+
+    expect(flushBeforeLeave).not.toHaveBeenCalled()
+    expect(tutorials).toHaveAttribute('href', 'https://www.worshipviewer.com/tutorials')
+  })
+
+  it('activates with a pointer without invoking the leave-editor flow', async () => {
+    const flushBeforeLeave = vi.fn(async () => true)
+    const { interaction } = await renderMenu({ flushBeforeLeave })
+    const tutorials = screen.getByRole('menuitem', { name: 'Tutorials' })
+
+    await interaction.click(tutorials)
+
+    expect(flushBeforeLeave).not.toHaveBeenCalled()
+    expect(tutorials).toHaveAttribute('target', '_blank')
+  })
+})

--- a/frontend/app/src/components/hub/ProfileMenu.tsx
+++ b/frontend/app/src/components/hub/ProfileMenu.tsx
@@ -9,6 +9,7 @@ import {
   IconInstall,
   IconLogout,
   IconSettings,
+  IconTutorials,
   IconUsers,
 } from '@/components/icons/profile-menu-icons'
 import { Button } from '@/components/ui/button'
@@ -27,6 +28,8 @@ import { usePwaInstall } from '@/pwa/pwa-install-context'
 import { Route as RootRoute } from '@/routes/__root'
 import { cn } from '@/lib/utils'
 
+const TUTORIALS_URL = 'https://www.worshipviewer.com/tutorials'
+
 type ProfileMenuProps = {
   user: User
   /** When true, show a red ring on the avatar and an Offline line at the top of the menu. */
@@ -41,7 +44,7 @@ export function ProfileMenu({ user, offline = false }: ProfileMenuProps) {
   const songEditorNavigationBridge = useSongEditorNavigationBridge()
   const { imageSrc, onImageError, initials } = useUserAvatarDisplay(user)
   const [hoveredRow, setHoveredRow] = useState<
-    'rooms' | 'settings' | 'admin' | 'about' | 'install' | 'logout' | null
+    'rooms' | 'settings' | 'admin' | 'about' | 'tutorials' | 'install' | 'logout' | null
   >(null)
 
   async function leaveSongEditorIfNeeded(): Promise<boolean> {
@@ -146,6 +149,16 @@ export function ProfileMenu({ user, offline = false }: ProfileMenuProps) {
         >
           <IconAbout isHovered={hoveredRow === 'about'} />
           {t('hub.profile.about')}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          asChild
+          onMouseEnter={() => setHoveredRow('tutorials')}
+          onMouseLeave={() => setHoveredRow(null)}
+        >
+          <a href={TUTORIALS_URL} target="_blank" rel="noopener noreferrer">
+            <IconTutorials isHovered={hoveredRow === 'tutorials'} />
+            {t('hub.profile.tutorials')}
+          </a>
         </DropdownMenuItem>
         {canShowInstall ? (
           <DropdownMenuItem

--- a/frontend/app/src/components/icons/profile-menu-icons.tsx
+++ b/frontend/app/src/components/icons/profile-menu-icons.tsx
@@ -62,6 +62,28 @@ export function IconAbout({ className, isHovered, ...rest }: ProfileMenuIconProp
   )
 }
 
+export function IconTutorials({ className, isHovered, ...rest }: ProfileMenuIconProps) {
+  return (
+    <div className={cn(iconClass, className)} data-hovered={isHovered ? 'true' : undefined} {...rest}>
+      <svg
+        aria-hidden
+        fill="none"
+        height={PROFILE_MENU_ICON_PX}
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+        viewBox="0 0 24 24"
+        width={PROFILE_MENU_ICON_PX}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+        <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2Z" />
+      </svg>
+    </div>
+  )
+}
+
 export function IconAdminDashboard({ className, isHovered, ...rest }: ProfileMenuIconProps) {
   return (
     <div className={cn(iconClass, className)} data-hovered={isHovered ? 'true' : undefined} {...rest}>

--- a/frontend/app/src/i18n/de.json
+++ b/frontend/app/src/i18n/de.json
@@ -102,6 +102,7 @@
       "sessions": "Sitzungen",
       "admin": "Admin-Dashboard",
       "about": "Über",
+      "tutorials": "Tutorials",
       "install": "App installieren",
       "logout": "Abmelden"
     },

--- a/frontend/app/src/i18n/en.json
+++ b/frontend/app/src/i18n/en.json
@@ -102,6 +102,7 @@
       "sessions": "Sessions",
       "admin": "Admin dashboard",
       "about": "About",
+      "tutorials": "Tutorials",
       "install": "Install app",
       "logout": "Log out"
     },


### PR DESCRIPTION
## Summary
- add a localized Tutorials entry after About in the signed-in profile menu
- open the tutorials site in a secure new tab without triggering editor leave handling
- cover role-independent placement, localization, offline availability, and pointer/keyboard activation

## Verification
- pnpm --filter app exec eslint . --fix
- pnpm -C frontend lint
- pnpm -C frontend typecheck
- node frontend/app/scripts/lint-flow-coverage.mjs
- pnpm -C frontend test
- pnpm -C frontend build