### PR TITLE
feat(frontend): scale chord-song player text

### DIFF
--- a/frontend/app/src/components/player/ChordsSlide.tsx
+++ b/frontend/app/src/components/player/ChordsSlide.tsx
@@ -7,10 +7,15 @@ import { useHideChordsPreference } from '@/hooks/useHideChordsPreference'
 import { observeElementResize } from '@/lib/browser-apis'
 import { scopeChordlibPageCss } from '@/lib/chord-page-css'
 import { getChordEngine } from '@/lib/chord-engine'
-import { cssScaleToFitViewport } from '@/lib/chord-a4-scale'
+import {
+  A4_REFERENCE_HEIGHT_PX,
+  cssScaleToFitViewport,
+  scaledPlayerPageTypography,
+} from '@/lib/chord-a4-scale'
 import { chordFormatToRepresentation, type ChordFormatPreference } from '@/lib/chord-format'
 import { stripChordsFromChordlibHtml } from '@/lib/strip-chords-from-html'
 import type { ChordSongData } from '@/ports/chord-engine'
+import type { PlayerOverflowStyle } from '@/lib/player/effective-scroll-type'
 import { cn } from '@/lib/utils'
 
 import './player-chords.css'
@@ -31,6 +36,8 @@ type ChordsSlideProps = {
   orientation: Orientation
   /** Fill a fixed-size book spread slot instead of growing with content. */
   fillParent?: boolean
+  fontScale?: number
+  overflowStyle?: PlayerOverflowStyle
 }
 
 export function ChordsSlide({
@@ -40,6 +47,8 @@ export function ChordsSlide({
   chordFormat,
   orientation,
   fillParent = false,
+  fontScale = 1,
+  overflowStyle = 'scroll',
 }: ChordsSlideProps) {
   const { t } = useTranslation()
   const hideChords = useHideChordsPreference()
@@ -76,10 +85,37 @@ export function ChordsSlide({
         viewportSize.width,
         viewportSize.height,
         contentSize.width,
-        contentSize.height,
+        Math.min(contentSize.height, A4_REFERENCE_HEIGHT_PX),
       ),
     [contentSize.height, contentSize.width, viewportSize.height, viewportSize.width],
   )
+
+  const fontScaleCss = useMemo(() => {
+    const titleFontSize = scaledPlayerPageTypography(26, fontScale)
+    const bodyFontSize = scaledPlayerPageTypography(13, fontScale)
+    const bodyLineHeight = scaledPlayerPageTypography(17, fontScale)
+    return `
+.player-chords-page .title { font-size: ${titleFontSize}px; }
+.player-chords-page .subtitle,
+.player-chords-page .meta,
+.player-chords-page .copyright { font-size: ${bodyFontSize}px; }
+.player-chords-page .columns {
+  font-size: ${bodyFontSize}px;
+  line-height: ${bodyLineHeight}px;
+}
+${
+  overflowStyle === 'scroll' && fontScale > 1
+    ? `.player-chords-page .page {
+  height: auto;
+  min-height: ${A4_REFERENCE_HEIGHT_PX}px;
+  overflow: visible;
+}
+.player-chords-page .columns {
+  height: auto;
+}`
+    : ''
+}`
+  }, [fontScale, overflowStyle])
 
   useEffect(() => {
     const el = viewportRef.current
@@ -127,8 +163,13 @@ export function ChordsSlide({
     if (!el) return
 
     const measure = () => {
-      const width = el.scrollWidth
-      const height = el.scrollHeight
+      const page = el.firstElementChild as HTMLElement | null
+      const width = page?.offsetWidth ?? el.scrollWidth
+      const height = page
+        ? overflowStyle === 'scroll'
+          ? page.scrollHeight
+          : page.offsetHeight
+        : el.scrollHeight
       if (width > 0 && height > 0) {
         setContentSizeCache({ key: renderKey, size: { width, height } })
       }
@@ -136,7 +177,7 @@ export function ChordsSlide({
 
     measure()
     return observeElementResize(el, measure)
-  }, [renderKey, renderState])
+  }, [fontScale, overflowStyle, renderKey, renderState])
 
   const scaledReady = renderState.status === 'ready' && cssScale != null
   const measuring = renderState.status === 'ready' && cssScale == null
@@ -148,9 +189,11 @@ export function ChordsSlide({
   return (
     <div
       ref={viewportRef}
+      data-player-chord-surface
       className={cn(
-        'player-chords-viewport flex min-h-0 flex-1 flex-col',
-        fillParent ? 'h-full w-full overflow-hidden' : 'overflow-auto',
+        'player-chord-song-surface player-chords-viewport flex min-h-0 flex-1 flex-col',
+        fillParent && 'h-full w-full',
+        overflowStyle === 'scroll' ? 'overflow-auto' : 'overflow-hidden',
         scaledReady && 'player-chords-viewport--ready',
         orientation === 'landscape' && 'player-chords-viewport--landscape',
       )}
@@ -173,7 +216,11 @@ export function ChordsSlide({
 
       {renderState.status === 'ready' ? (
         <>
-          <style dangerouslySetInnerHTML={{ __html: scopeChordlibPageCss(renderState.css) }} />
+          <style
+            dangerouslySetInnerHTML={{
+              __html: `${scopeChordlibPageCss(renderState.css)}\n${fontScaleCss}`,
+            }}
+          />
           <div
             className={cn(
               'mx-auto shrink-0 overflow-hidden',

--- a/frontend/app/src/components/player/ChordsThreeColumnSlide.tsx
+++ b/frontend/app/src/components/player/ChordsThreeColumnSlide.tsx
@@ -1,5 +1,5 @@
 import type { components } from '@/api/schema'
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
@@ -60,6 +60,7 @@ type ChordsThreeColumnSlideProps = {
   overflowStyle?: PlayerOverflowStyle
   expandSections?: boolean
   fillParent?: boolean
+  fontScale?: number
 }
 
 const COLUMN_GAP_PX = 24 // 1.5rem — keep in sync with player-chords-three-column.css
@@ -299,6 +300,7 @@ export function ChordsThreeColumnSlide({
   overflowStyle = 'scroll',
   expandSections = false,
   fillParent = false,
+  fontScale = 1,
 }: ChordsThreeColumnSlideProps) {
   const { t } = useTranslation()
   const hideChords = useHideChordsPreference()
@@ -383,7 +385,7 @@ export function ChordsThreeColumnSlide({
 
   const layoutKey =
     renderState.status === 'ready' && renderState.sections.length > 0
-      ? `${columnCount}:${renderState.sections.length}`
+      ? `${columnCount}:${renderState.sections.length}:${fontScale}`
       : null
   const columnLayout =
     layoutKey && columnLayoutCache?.key === layoutKey ? columnLayoutCache.layout : null
@@ -423,7 +425,7 @@ export function ChordsThreeColumnSlide({
       const scale = fontScaleForMultiColumnPlayer(columnWidth)
       if (scale == null) return
 
-      const typography = scaledColumnTypography(scale)
+      const typography = scaledColumnTypography(scale, fontScale)
       setColumnLayoutCache((prev) => {
         if (
           prev?.key === layoutKey &&
@@ -449,7 +451,7 @@ export function ChordsThreeColumnSlide({
     const cleanups = [observeElementResize(columnAreaEl, updateLayout)]
     if (viewportRef.current) cleanups.push(observeElementResize(viewportRef.current, updateLayout))
     return () => cleanups.forEach((cleanup) => cleanup())
-  }, [layoutKey, columnCount, renderState.status, columnSections?.length, overflowStyle])
+  }, [layoutKey, columnCount, renderState.status, columnSections?.length, overflowStyle, fontScale])
 
   useLayoutEffect(() => {
     if (!packingContextKey || !columnLayout || !columnSections) return
@@ -554,13 +556,15 @@ export function ChordsThreeColumnSlide({
 
   return (
     <div
+      data-player-chord-surface
       className={cn(
-        'player-chords-three-column',
+        'player-chord-song-surface player-chords-three-column',
         overflowStyle === 'scroll' && 'player-chords-three-column--scroll',
         overflowStyle === 'scroll' && layoutReady && !needsVerticalScroll && 'player-chords-three-column--fits',
         'h-full min-h-0 w-full',
         fillParent && 'flex-1',
       )}
+      style={{ '--player-chord-song-font-scale': fontScale } as CSSProperties}
     >
       {renderState.status === 'loading' ? (
         <p className="py-12 text-center text-sm text-[var(--color-muted-foreground)]">{t('common.load')}</p>

--- a/frontend/app/src/components/player/PlayerBook.likes.test.tsx
+++ b/frontend/app/src/components/player/PlayerBook.likes.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { components } from '@/api/schema'
 import { PlayerBook } from '@/components/player/PlayerBook'
@@ -10,6 +10,13 @@ const mocks = vi.hoisted(() => ({
   setSongLikeStatus: vi.fn(),
   toastError: vi.fn(),
 }))
+const localStorageState = new Map<string, string>()
+const localStorageMock = {
+  getItem: (key: string) => localStorageState.get(key) ?? null,
+  setItem: (key: string, value: string) => localStorageState.set(key, value),
+  removeItem: (key: string) => localStorageState.delete(key),
+  clear: () => localStorageState.clear(),
+}
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({ children }: { children: React.ReactNode }) => <a href="/">{children}</a>,
@@ -29,9 +36,15 @@ vi.mock('@/api/songs-like', () => ({
 }))
 
 vi.mock('@/components/player/BlobSlide', () => ({ BlobSlide: () => null }))
-vi.mock('@/components/player/ChordsSlide', () => ({ ChordsSlide: () => <div>song</div> }))
+vi.mock('@/components/player/ChordsSlide', () => ({
+  ChordsSlide: ({ song }: { song: components['schemas']['Song'] }) => (
+    <div data-player-chord-surface>{song.id}</div>
+  ),
+}))
 vi.mock('@/components/player/ChordsThreeColumnSlide', () => ({
-  ChordsThreeColumnSlide: () => <div>song</div>,
+  ChordsThreeColumnSlide: ({ song }: { song: components['schemas']['Song'] }) => (
+    <div data-player-chord-surface>{song.id}</div>
+  ),
 }))
 vi.mock('@/components/player/PlayerBookSpread', () => ({
   PlayerBookSpread: ({ left }: { left: React.ReactNode }) => <>{left}</>,
@@ -134,7 +147,7 @@ function player(): Player {
   }
 }
 
-function renderPlayer(value: Player) {
+function renderPlayer(value: Player, roomSidebar: React.ReactNode = <div>room</div>) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <QueryClientProvider client={queryClient}>
@@ -143,7 +156,7 @@ function renderPlayer(value: Player) {
         id="setlist-1"
         player={value}
         allowNetworkFetch
-        roomSidebar={<div>room</div>}
+        roomSidebar={roomSidebar}
       />
     </QueryClientProvider>,
   )
@@ -151,9 +164,57 @@ function renderPlayer(value: Player) {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  localStorageState.clear()
+  vi.stubGlobal('localStorage', localStorageMock)
 })
 
+afterEach(() => vi.unstubAllGlobals())
+
 describe('PlayerBook likes', () => {
+  it('pinches only the chord surface without navigating', () => {
+    renderPlayer(player(), null)
+    const main = screen.getByRole('main')
+    const chordSurface = screen.getByText('song-1')
+    const first = { clientX: 0, clientY: 0 }
+    const second = { clientX: 100, clientY: 0 }
+    const expandedSecond = { clientX: 200, clientY: 0 }
+
+    fireEvent.touchStart(chordSurface, { touches: [first, second] })
+    fireEvent.touchMove(chordSurface, { touches: [first, expandedSecond] })
+    fireEvent.touchEnd(chordSurface, { touches: [], changedTouches: [first, expandedSecond] })
+
+    expect(window.localStorage.getItem('wv_chord_song_font_scale')).toBe('2')
+    expect(within(main).getByText('song-1')).toBeInTheDocument()
+  })
+
+  it('ignores two-finger gestures outside the chord surface', () => {
+    renderPlayer(player(), null)
+    const main = screen.getByRole('main')
+    const first = { clientX: 0, clientY: 0 }
+    const second = { clientX: 100, clientY: 0 }
+
+    fireEvent.touchStart(main, { touches: [first, second] })
+    fireEvent.touchMove(main, { touches: [first, { clientX: 200, clientY: 0 }] })
+    fireEvent.touchEnd(main, { touches: [], changedTouches: [first, second] })
+
+    expect(window.localStorage.getItem('wv_chord_song_font_scale')).toBeNull()
+  })
+
+  it('keeps one-finger swipe navigation working', () => {
+    renderPlayer(player(), null)
+    const main = screen.getByRole('main')
+    const start = { clientX: 100, clientY: 50 }
+    const end = { clientX: 0, clientY: 50 }
+
+    fireEvent.touchStart(main, { touches: [start] })
+    fireEvent.touchEnd(main, { changedTouches: [end] })
+    fireEvent.touchStart(main, { touches: [start] })
+    fireEvent.touchEnd(main, { changedTouches: [end] })
+
+    expect(within(main).getByText('song-2')).toBeInTheDocument()
+    expect(window.localStorage.getItem('wv_chord_song_font_scale')).toBeNull()
+  })
+
   it('unlikes exactly once for a native mouse double-click', async () => {
     mocks.setSongLikeStatus.mockImplementation(() => new Promise<void>(() => undefined))
     renderPlayer(player())

--- a/frontend/app/src/components/player/PlayerBook.tsx
+++ b/frontend/app/src/components/player/PlayerBook.tsx
@@ -20,6 +20,7 @@ import { SettingsIcon } from '@/components/icons/lucide-animated/settings-icon'
 import { Button } from '@/components/ui/button'
 import { PopoverContent, PopoverRoot, PopoverTrigger } from '@/components/ui/popover'
 import { useChordFormatPreference } from '@/hooks/useChordFormatPreference'
+import { useChordSongFontScale } from '@/hooks/useChordSongFontScale'
 import { useIsPhoneWidth, useMediaQuery } from '@/hooks/useMediaQuery'
 import { usePlayerLayoutPreference } from '@/hooks/usePlayerScrollPreference'
 import { useOnline } from '@/hooks/use-online'
@@ -84,6 +85,7 @@ import type { PlayerEntityType } from '@/lib/player-route'
 import { buildSongEditorReturnSearch } from '@/lib/player/player-editor-return'
 import { resolveSongLanguageIndex, songLanguageOptions } from '@/lib/player/song-language'
 import { buildSettingsSearch } from '@/lib/settings-route'
+import { writeChordSongFontScale } from '@/lib/player/chord-song-font-scale-preference'
 import { MUSICAL_KEYS } from '@/lib/setlist-editor-constants'
 import { languageIndexForSongLink, resolveSongDataKey } from '@/lib/setlist-song-links'
 import { cn } from '@/lib/utils'
@@ -158,6 +160,17 @@ function isInteractiveTarget(target: EventTarget | null): boolean {
   )
 }
 
+function isChordSurfaceTarget(target: EventTarget | null): boolean {
+  return Boolean(target instanceof Element && target.closest('[data-player-chord-surface]'))
+}
+
+function touchDistance(touches: React.TouchList): number | null {
+  const first = touches[0]
+  const second = touches[1]
+  if (!first || !second) return null
+  return Math.hypot(second.clientX - first.clientX, second.clientY - first.clientY)
+}
+
 type ResolvedBookChordsProps = {
   song: Song
   flow: SongFlowItem[] | null | undefined
@@ -173,6 +186,7 @@ type ResolvedBookChordsProps = {
   freeColumnCount: 1 | 2 | 3 | null
   overflowStyle?: PlayerOverflowStyle
   expandSections?: boolean
+  fontScale?: number
 }
 
 export function ResolvedBookChords({
@@ -190,6 +204,7 @@ export function ResolvedBookChords({
   freeColumnCount,
   overflowStyle,
   expandSections,
+  fontScale = 1,
 }: ResolvedBookChordsProps) {
   const resolvedSong = useResolvedSongWithFlow(song, flow)
   const resolvedNextSong = useResolvedSongWithFlow(nextSong ?? song, nextFlow)
@@ -208,6 +223,7 @@ export function ResolvedBookChords({
         overflowStyle={overflowStyle}
         expandSections={expandSections}
         fillParent={fillParent}
+        fontScale={fontScale}
       />
     )
   }
@@ -220,6 +236,8 @@ export function ResolvedBookChords({
       chordFormat={chordFormat}
       orientation={sheetOrientation}
       fillParent={fillParent}
+      fontScale={fontScale}
+      overflowStyle={overflowStyle}
     />
   )
 }
@@ -271,6 +289,7 @@ export function PlayerBook({
   const queryClient = useQueryClient()
   const online = useOnline()
   const chordFormat = useChordFormatPreference()
+  const chordSongFontScale = useChordSongFontScale()
   const layoutPreferences = usePlayerLayoutPreference()
   const isPhoneViewport = useIsPhoneWidth()
   const isLandscapeViewport = useMediaQuery('(orientation: landscape)')
@@ -284,6 +303,7 @@ export function PlayerBook({
   const [chromeVisible, setChromeVisible] = useState(() => roomSidebar != null)
 
   const touchStartRef = useRef<{ x: number; y: number } | null>(null)
+  const pinchStartRef = useRef<{ distance: number; fontScale: number } | null>(null)
   const touchMovedRef = useRef(false)
   const suppressClicksUntilRef = useRef(0)
   const lastMiddleViewportTapTimeRef = useRef<number | null>(null)
@@ -835,11 +855,27 @@ export function PlayerBook({
         freeColumnCount={freeColumnCount}
         overflowStyle={layoutPreference.overflowStyle}
         expandSections={layoutPreference.expandSections}
+        fontScale={chordSongFontScale}
       />
     )
   }
 
   function onTouchStart(e: React.TouchEvent) {
+    if (e.touches.length >= 2) {
+      touchStartRef.current = null
+      touchMovedRef.current = true
+      cancelPendingChromeOpen()
+      if (!isChordSurfaceTarget(e.target)) {
+        pinchStartRef.current = null
+        return
+      }
+      const distance = touchDistance(e.touches)
+      if (distance == null || distance <= 0) return
+      e.preventDefault()
+      pinchStartRef.current = { distance, fontScale: chordSongFontScale }
+      return
+    }
+
     const touch = e.touches[0]
     if (!touch) return
     touchStartRef.current = { x: touch.clientX, y: touch.clientY }
@@ -847,6 +883,15 @@ export function PlayerBook({
   }
 
   function onTouchMove(e: React.TouchEvent) {
+    const pinchStart = pinchStartRef.current
+    if (pinchStart) {
+      const distance = touchDistance(e.touches)
+      if (distance == null) return
+      e.preventDefault()
+      writeChordSongFontScale(pinchStart.fontScale * (distance / pinchStart.distance))
+      return
+    }
+
     const start = touchStartRef.current
     const touch = e.touches[0]
     if (!start || !touch || touchMovedRef.current) return
@@ -863,6 +908,7 @@ export function PlayerBook({
 
   function onTouchCancel() {
     touchStartRef.current = null
+    pinchStartRef.current = null
     touchMovedRef.current = false
   }
 
@@ -929,6 +975,15 @@ export function PlayerBook({
   )
 
   function onTouchEnd(e: React.TouchEvent) {
+    if (pinchStartRef.current) {
+      pinchStartRef.current = null
+      touchStartRef.current = null
+      touchMovedRef.current = false
+      suppressClicksUntilRef.current = performance.now() + TOUCH_CLICK_SUPPRESSION_MS
+      e.preventDefault()
+      return
+    }
+
     const start = touchStartRef.current
     touchStartRef.current = null
     const touch = e.changedTouches[0]

--- a/frontend/app/src/components/player/player-chords-three-column.css
+++ b/frontend/app/src/components/player/player-chords-three-column.css
@@ -19,14 +19,14 @@
 
 .player-chords-three-column__title {
   margin: 0;
-  font-size: 1.25rem;
+  font-size: calc(1.25rem * var(--player-chord-song-font-scale, 1));
   font-weight: 600;
   line-height: 1.3;
 }
 
 .player-chords-three-column__subtitle {
   margin: 0.125rem 0 0;
-  font-size: 0.8125rem;
+  font-size: calc(0.8125rem * var(--player-chord-song-font-scale, 1));
   color: var(--color-muted-foreground);
 }
 
@@ -38,7 +38,7 @@
   align-items: flex-end;
   gap: 0.125rem;
   text-align: right;
-  font-size: 0.8125rem;
+  font-size: calc(0.8125rem * var(--player-chord-song-font-scale, 1));
   color: var(--color-muted-foreground);
 }
 

--- a/frontend/app/src/components/player/player-chords.css
+++ b/frontend/app/src/components/player/player-chords.css
@@ -1,3 +1,7 @@
+.player-chord-song-surface {
+  touch-action: pan-x pan-y;
+}
+
 .player-chords-viewport--ready {
   align-items: center;
   justify-content: center;

--- a/frontend/app/src/components/settings/SettingsView.tsx
+++ b/frontend/app/src/components/settings/SettingsView.tsx
@@ -55,6 +55,12 @@ import {
   type AvVerticalAlign,
 } from '@/lib/player/av-preferences'
 import { readPlayerDefaultMode, writePlayerDefaultMode } from '@/lib/player/player-mode-preference'
+import {
+  CHORD_SONG_FONT_SCALE_MAX,
+  CHORD_SONG_FONT_SCALE_MIN,
+  readChordSongFontScale,
+  writeChordSongFontScale,
+} from '@/lib/player/chord-song-font-scale-preference'
 import type { PlayerMode } from '@/lib/player/player-mode'
 import {
   readSheetBackgroundPreference,
@@ -383,6 +389,7 @@ export function SettingsView({
   const [appearancePreference, setAppearancePreference] = useState(readAppearancePreference)
   const [chordFormatPreference, setChordFormatPreference] = useState(readChordFormatPreference)
   const [hideChords, setHideChordsState] = useState(readHideChordsPreference)
+  const [chordSongFontScale, setChordSongFontScaleState] = useState(readChordSongFontScale)
   const [tocMultilingual, setTocMultilingualState] = useState(readTocMultilingualPreference)
   const [avBilingual, setAvBilingualState] = useState(readAvBilingualPreference)
   const [sheetBackgroundPreference, setSheetBackgroundPreference] = useState(readSheetBackgroundPreference)
@@ -626,6 +633,10 @@ export function SettingsView({
   function setHideChords(enabled: boolean) {
     setHideChordsState(enabled)
     writeHideChordsPreference(enabled)
+  }
+
+  function setChordSongFontScale(value: number) {
+    setChordSongFontScaleState(writeChordSongFontScale(value))
   }
 
   function setTocMultilingual(enabled: boolean) {
@@ -921,6 +932,42 @@ export function SettingsView({
             value={chordFormatPreference}
             onChange={setChordFormat}
           />
+
+          <Card>
+            <CardHeader className="p-4 pb-3">
+              <CardTitle className="text-base">
+                {t('settings.chordSongFontScale.title')}
+              </CardTitle>
+              <CardDescription>{t('settings.chordSongFontScale.description')}</CardDescription>
+            </CardHeader>
+            <CardContent className="p-4 pt-0">
+              <label className="flex flex-col gap-2 text-sm">
+                <span className="flex items-center justify-between gap-3">
+                  <span>{t('settings.chordSongFontScale.label')}</span>
+                  <output className="tabular-nums text-[var(--color-muted-foreground)]">
+                    {chordSongFontScale}×
+                  </output>
+                </span>
+                <input
+                  type="range"
+                  min={CHORD_SONG_FONT_SCALE_MIN}
+                  max={CHORD_SONG_FONT_SCALE_MAX}
+                  step={0.05}
+                  value={chordSongFontScale}
+                  aria-label={t('settings.chordSongFontScale.label')}
+                  onChange={(event) => setChordSongFontScale(Number(event.target.value))}
+                  className="w-full accent-[var(--color-primary)]"
+                />
+                <span
+                  className="flex justify-between text-xs text-[var(--color-muted-foreground)]"
+                  aria-hidden
+                >
+                  <span>{CHORD_SONG_FONT_SCALE_MIN}×</span>
+                  <span>{CHORD_SONG_FONT_SCALE_MAX}×</span>
+                </span>
+              </label>
+            </CardContent>
+          </Card>
 
           <Card>
             <CardContent className="p-4">

--- a/frontend/app/src/components/settings/settings-view.test.tsx
+++ b/frontend/app/src/components/settings/settings-view.test.tsx
@@ -85,6 +85,23 @@ afterEach(() => {
 })
 
 describe('SettingsView', () => {
+  it('defaults, stores, and restores the chord-song font scale in the Player tab', () => {
+    const first = render(<SettingsView activeTab="player" />)
+    const slider = screen.getByRole('slider', {
+      name: 'settings.chordSongFontScale.label',
+    })
+
+    expect(slider).toHaveValue('1')
+    fireEvent.change(slider, { target: { value: '2' } })
+    expect(window.localStorage.getItem('wv_chord_song_font_scale')).toBe('2')
+
+    first.unmount()
+    render(<SettingsView activeTab="player" />)
+    expect(
+      screen.getByRole('slider', { name: 'settings.chordSongFontScale.label' }),
+    ).toHaveValue('2')
+  })
+
   it('renders the TOC multilingual control in the Player tab and restores it from storage', async () => {
     const user = userEvent.setup()
 

--- a/frontend/app/src/hooks/useChordSongFontScale.ts
+++ b/frontend/app/src/hooks/useChordSongFontScale.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react'
+
+import {
+  CHORD_SONG_FONT_SCALE_CHANGE_EVENT,
+  readChordSongFontScale,
+} from '@/lib/player/chord-song-font-scale-preference'
+
+export function useChordSongFontScale(): number {
+  const [fontScale, setFontScale] = useState(readChordSongFontScale)
+
+  useEffect(() => {
+    const onChange = (event: Event) => {
+      const detail = (event as CustomEvent<number>).detail
+      setFontScale(detail ?? readChordSongFontScale())
+    }
+
+    globalThis.window.addEventListener(CHORD_SONG_FONT_SCALE_CHANGE_EVENT, onChange)
+    return () => globalThis.window.removeEventListener(CHORD_SONG_FONT_SCALE_CHANGE_EVENT, onChange)
+  }, [])
+
+  return fontScale
+}

--- a/frontend/app/src/i18n/de.json
+++ b/frontend/app/src/i18n/de.json
@@ -577,6 +577,11 @@
       "nashville": "Nashville",
       "nashvilleDescription": "Zeigt Nashville-Ziffern wie 1, 4 und 6m."
     },
+    "chordSongFontScale": {
+      "title": "Schriftgröße für Akkordlieder",
+      "description": "Skaliert die Schrift von Akkordliedern im normalen Player auf diesem Gerät.",
+      "label": "Schriftskalierung"
+    },
     "tocMultilingual": {
       "label": "Mehrsprachige Liedtitel im Inhaltsverzeichnis erweitern",
       "description": "Zeigt im Inhaltsverzeichnis bei aktivem Sprachfilter den passenden übersetzten Titel. Die Erweiterung für A–Z und Favoriten folgt später."

--- a/frontend/app/src/i18n/en.json
+++ b/frontend/app/src/i18n/en.json
@@ -577,6 +577,11 @@
       "nashville": "Nashville",
       "nashvilleDescription": "Show Nashville numbers such as 1, 4, and 6m."
     },
+    "chordSongFontScale": {
+      "title": "Chord-song font size",
+      "description": "Scale chord-song type in the normal player on this device.",
+      "label": "Font scale"
+    },
     "tocMultilingual": {
       "label": "Expand multilingual song titles in the TOC",
       "description": "Use the matching translated title in the table of contents when a language filter is active. Alphabetical and liked expansion will come later."

--- a/frontend/app/src/lib/chord-a4-scale.test.ts
+++ b/frontend/app/src/lib/chord-a4-scale.test.ts
@@ -15,6 +15,7 @@ import {
   fontScaleForMultiColumnPlayer,
   MULTI_COLUMN_PLAYER_FONT_SCALE_FACTOR,
   scaledColumnTypography,
+  scaledPlayerPageTypography,
   viewportScaleForA4,
 } from '@/lib/chord-a4-scale'
 
@@ -121,5 +122,16 @@ describe('column typography scaling', () => {
       fontSizePx: A4_COLUMN_FONT_SIZE_PX * MULTI_COLUMN_PLAYER_FONT_SCALE_FACTOR,
       lineHeightPx: A4_COLUMN_LINE_HEIGHT_PX * MULTI_COLUMN_PLAYER_FONT_SCALE_FACTOR,
     })
+  })
+
+  it('multiplies free-layout typography by the device font scale', () => {
+    expect(scaledColumnTypography(0.5, 2)).toEqual({
+      fontSizePx: A4_COLUMN_FONT_SIZE_PX,
+      lineHeightPx: A4_COLUMN_LINE_HEIGHT_PX,
+    })
+  })
+
+  it('multiplies page typography independently of viewport fit', () => {
+    expect(scaledPlayerPageTypography(A4_COLUMN_FONT_SIZE_PX, 2)).toBe(26)
   })
 })

--- a/frontend/app/src/lib/chord-a4-scale.ts
+++ b/frontend/app/src/lib/chord-a4-scale.ts
@@ -59,14 +59,19 @@ export function cappedColumnFontScale(
   return Math.min(widthScale, a4Cap)
 }
 
-export function scaledColumnTypography(scale: number): {
+export function scaledColumnTypography(scale: number, userFontScale = 1): {
   fontSizePx: number
   lineHeightPx: number
 } {
   return {
-    fontSizePx: A4_COLUMN_FONT_SIZE_PX * scale,
-    lineHeightPx: A4_COLUMN_LINE_HEIGHT_PX * scale,
+    fontSizePx: A4_COLUMN_FONT_SIZE_PX * scale * userFontScale,
+    lineHeightPx: A4_COLUMN_LINE_HEIGHT_PX * scale * userFontScale,
   }
+}
+
+/** Multiply a page-layout font size without changing the A4 viewport-fit transform. */
+export function scaledPlayerPageTypography(fontSizePx: number, userFontScale: number): number {
+  return fontSizePx * userFontScale
 }
 
 /** Scale chordlib A4 HTML to fit a viewport; uses the tighter of height and width when both are known. */

--- a/frontend/app/src/lib/player/chord-song-font-scale-preference.test.ts
+++ b/frontend/app/src/lib/player/chord-song-font-scale-preference.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  CHORD_SONG_FONT_SCALE_CHANGE_EVENT,
+  CHORD_SONG_FONT_SCALE_STORAGE_KEY,
+  clampChordSongFontScale,
+  readChordSongFontScale,
+  writeChordSongFontScale,
+} from '@/lib/player/chord-song-font-scale-preference'
+
+describe('chord song font scale preference', () => {
+  it('defaults to 1 and rejects malformed stored values', () => {
+    expect(readChordSongFontScale({ getItem: () => null })).toBe(1)
+    expect(readChordSongFontScale({ getItem: () => 'not-a-number' })).toBe(1)
+  })
+
+  it('clamps values to 0.5–2', () => {
+    expect(clampChordSongFontScale(0.1)).toBe(0.5)
+    expect(clampChordSongFontScale(2.5)).toBe(2)
+    expect(readChordSongFontScale({ getItem: () => '3' })).toBe(2)
+  })
+
+  it('persists and broadcasts the normalized value', () => {
+    const storage = { setItem: vi.fn() }
+    const dispatchEvent = vi.fn()
+    vi.stubGlobal('window', { dispatchEvent })
+
+    expect(writeChordSongFontScale(1.234, storage)).toBe(1.23)
+    expect(storage.setItem).toHaveBeenCalledWith(CHORD_SONG_FONT_SCALE_STORAGE_KEY, '1.23')
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: CHORD_SONG_FONT_SCALE_CHANGE_EVENT, detail: 1.23 }),
+    )
+
+    vi.unstubAllGlobals()
+  })
+})

--- a/frontend/app/src/lib/player/chord-song-font-scale-preference.ts
+++ b/frontend/app/src/lib/player/chord-song-font-scale-preference.ts
@@ -1,0 +1,40 @@
+import { getLocalStorage, safeGetItem, safeSetItem } from '@/lib/browser-storage'
+
+export const CHORD_SONG_FONT_SCALE_MIN = 0.5
+export const CHORD_SONG_FONT_SCALE_MAX = 2
+export const DEFAULT_CHORD_SONG_FONT_SCALE = 1
+export const CHORD_SONG_FONT_SCALE_STORAGE_KEY = 'wv_chord_song_font_scale'
+export const CHORD_SONG_FONT_SCALE_CHANGE_EVENT = 'wv-chord-song-font-scale-change'
+
+export function clampChordSongFontScale(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_CHORD_SONG_FONT_SCALE
+  const clamped = Math.min(CHORD_SONG_FONT_SCALE_MAX, Math.max(CHORD_SONG_FONT_SCALE_MIN, value))
+  return Math.round(clamped * 100) / 100
+}
+
+export function readChordSongFontScale(
+  storage: Pick<Storage, 'getItem'> | null = getLocalStorage(),
+): number {
+  const raw = safeGetItem(CHORD_SONG_FONT_SCALE_STORAGE_KEY, storage)
+  if (raw == null || raw.trim() === '') return DEFAULT_CHORD_SONG_FONT_SCALE
+  const parsed = Number(raw)
+  return Number.isFinite(parsed)
+    ? clampChordSongFontScale(parsed)
+    : DEFAULT_CHORD_SONG_FONT_SCALE
+}
+
+export function writeChordSongFontScale(
+  value: number,
+  storage: Pick<Storage, 'setItem'> | null = getLocalStorage(),
+): number {
+  const normalized = clampChordSongFontScale(value)
+  safeSetItem(CHORD_SONG_FONT_SCALE_STORAGE_KEY, String(normalized), storage)
+
+  if (typeof globalThis.window !== 'undefined') {
+    globalThis.window.dispatchEvent(
+      new CustomEvent(CHORD_SONG_FONT_SCALE_CHANGE_EVENT, { detail: normalized }),
+    )
+  }
+
+  return normalized
+}


### PR DESCRIPTION
## Summary

- add a persistent 0.5×–2× chord-song font scale to Player settings
- support chord-surface pinch scaling without interfering with one-finger navigation
- multiply page and free-layout typography while preserving cut/scroll overflow behavior
- add English/German labels and automated preference, layout, settings, and gesture coverage

## Validation

- ESLint
- TypeScript typecheck
- frontend tests: 835 passed, 9 skipped
- production frontend/WASM build